### PR TITLE
Add missing dependencies for Cava2SystemVerilog

### DIFF
--- a/cava/cava/Cava2HDL.cabal
+++ b/cava/cava/Cava2HDL.cabal
@@ -89,6 +89,8 @@ library
                      ByteVector
                      Compare_dec
                      Decimal
+                     Hexadecimal
+                     Numeral
                      Functor
                      Specif
                      MonadExc


### PR DESCRIPTION
Building on my laptop fails without the missing dependecies.