### PR TITLE
Consolidate combinational semantics

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -32,6 +32,9 @@ Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.UnsignedAdders.
 
+Existing Instance CombinationalSemantics.
+Existing Instance CavaCombinationalNet.
+
 (******************************************************************************)
 (* A generic description of all adder trees made from a syntheszable adder    *)
 (* by using the tree combinator.                                              *)
@@ -75,17 +78,17 @@ Local Open Scope string_scope.
 Local Open Scope vector_scope.
 
 Definition v0_v1 := [v0; v1].
-Definition v0_plus_v1 : Bvector 8 := combinational (adderTree 0 v0_v1).
+Definition v0_plus_v1 : list (Bvector 8) := combinational (adderTree 0 [v0_v1]%list).
 
-Example sum_vo_v1 : combinational (adderTree2 v0_v1) = N2Bv_sized 8 21.
+Example sum_vo_v1 : combinational (adderTree2 [v0_v1]%list) = [N2Bv_sized 8 21]%list.
 Proof. reflexivity. Qed.
 
 
 
 Definition v0_3 := [v0; v1; v2; v3].
-Definition sum_v0_3 : Bvector 8 := combinational (adderTree4 v0_3).
+Definition sum_v0_3 : list (Bvector 8) := combinational (adderTree4 [v0_3]%list).
 
-Example sum_v0_v1_v2_v3 : combinational (adderTree4 v0_3) = N2Bv_sized 8 30.
+Example sum_v0_v1_v2_v3 : combinational (adderTree4 [v0_3]%list) = [N2Bv_sized 8 30]%list.
 Proof. reflexivity. Qed.
 
 Definition adder_tree_Interface name nrInputs bitSize
@@ -109,7 +112,8 @@ Definition adder_tree4_8_tb_inputs
      ].
 
 Definition adder_tree4_8_tb_expected_outputs
-  := map (fun i => combinational (adderTree4 i)) adder_tree4_8_tb_inputs.
+  := map (fun i => List.hd (Vector.const false _) (combinational (adderTree4 [i]%list)))
+         adder_tree4_8_tb_inputs.
 
 Definition adder_tree4_8_tb :=
   testBench "adder_tree4_8_tb" adder_tree4_8Interface
@@ -137,7 +141,8 @@ Definition adder_tree64_8_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_8_tb_expected_outputs
-  := map (fun i => combinational (adderTree 5 i)) adder_tree64_8_tb_inputs.
+  := map (fun i => List.hd (Vector.const false _)
+                        (combinational (adderTree 5 [i]%list))) adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "adder_tree64_8_tb" adder_tree64_8Interface
@@ -156,7 +161,8 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := map (fun i => combinational (adderTree 5 i)) adder_tree64_128_tb_inputs.
+  := map (fun i => List.hd (Vector.const false _)
+                        (combinational (adderTree 5 [i]%list))) adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "adder_tree64_128_tb" adder_tree64_128Interface

--- a/acorn-examples/Examples.v
+++ b/acorn-examples/Examples.v
@@ -16,18 +16,20 @@
 
 (* Experiments with the primitives that form the core of Cava. *)
 
+Require Import Coq.Lists.List.
 Require Import Cava.Acorn.Acorn.
+Import ListNotations.
 
 (* Experiments with the primitive Cava gates. *)
 
-Example inv_false : combinational (inv false) = true.
+Example inv_false : combinational (inv [false]) = [true].
 Proof. reflexivity. Qed.
 
-Example inv_true  : combinational (inv true) = false.
+Example inv_true  : combinational (inv [true]) = [false].
 Proof. reflexivity. Qed.
 
-Example and_00 : combinational (and2 (false, false)) = false.
+Example and_00 : combinational (and2 ([false], [false])) = [false].
 Proof. reflexivity. Qed.
 
-Example and_11 : combinational (and2 (true, true)) = true.
+Example and_11 : combinational (and2 ([true], [true])) = [true].
 Proof. reflexivity. Qed.

--- a/acorn-examples/FullAdderExample.v
+++ b/acorn-examples/FullAdderExample.v
@@ -46,7 +46,7 @@ Definition halfAdderNetlist := makeNetlist halfAdderInterface halfAdder.
 
 (* A proof that the half-adder is correct. *)
 Lemma halfAdder_behaviour : forall (a : bool) (b : bool),
-                            combinational (halfAdder (a, b)) = (xorb a b, a && b).
+                            combinational (halfAdder ([a], [b])) = ([xorb a b], [a && b]).
 
 Proof.
   auto.
@@ -72,7 +72,10 @@ Definition fullAdder_tb_inputs :=
 ].
 
 Definition fullAdder_tb_expected_outputs
-   := map (fun i => combinational (fullAdderTop i)) fullAdder_tb_inputs.
+  := map (fun '(i0,i1,i2) =>
+            let '(r1, r2) := combinational (fullAdderTop ([i0],[i1],[i2])%list) in
+            (List.hd (defaultCombValue _) r1, List.hd (defaultCombValue _) r2))
+         fullAdder_tb_inputs.
 
 Definition fullAdder_tb
   := testBench "fullAdder_tb" fullAdderInterface
@@ -80,9 +83,9 @@ Definition fullAdder_tb
 
 (* A proof that the the full-adder is correct. *)
 Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
-                            combinational (fullAdderTop (cin, a, b))
-                              = (xorb cin (xorb a b),
-                                 (a && b) || (b && cin) || (a && cin)).
+                            combinational (fullAdderTop ([cin], [a], [b]))
+                              = ([xorb cin (xorb a b)],
+                                 [(a && b) || (b && cin) || (a && cin)]).
 Proof.
   intros.
   unfold combinational.
@@ -94,8 +97,8 @@ Qed.
 
 (* Prove the generic full adder is equivalent to Xilinx fast adder. *)
 Lemma generic_vs_xilinx_adder : forall (a : bool) (b : bool) (cin : bool),
-                                combinational (fullAdderTop (cin, a, b)) =
-                                combinational (xilinxFullAdder (cin, (a, b))).
+                                combinational (fullAdderTop ([cin], [a], [b])) =
+                                combinational (xilinxFullAdder ([cin], ([a], [b]))).
 Proof.
   intros.
   unfold combinational. simpl.

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -14,19 +14,22 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.
 Require Import Coq.NArith.NArith.
 Require Import Coq.Vectors.Vector.
 Require Import coqutil.Tactics.Tactics.
 Require Import ExtLib.Structures.Monad.
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Acorn.Identity.
 Require Import Cava.BitArithmetic.
 Require Import Cava.NatUtils.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
-Import VectorNotations MonadNotation.
+Import VectorNotations ListNotations MonadNotation.
 Open Scope monad_scope.
+Open Scope list_scope.
 
 Section WithCava.
   Context `{semantics: Cava} {monad : Monad cava}.
@@ -101,19 +104,19 @@ End WithCava.
 Section Proofs.
   Existing Instance CombinationalSemantics.
 
-  Lemma half_adder_correct (input : combType Bit * combType Bit) :
-    combinational (half_adder input)
-    = (xorb (fst input) (snd input), andb (fst input) (snd input)).
+  Lemma half_adder_correct (x y : combType Bit) :
+    combinational (half_adder ([x],[y]))
+    = ([xorb x y], [andb x y]).
   Proof.
-    cbv [half_adder combinational and2 xor2 CombinationalSemantics
-                    xorBool andBool].
+    cbv [half_adder combinational and2 xor2 CombinationalSemantics].
+    cbv [lift2]. rewrite pad_combine_eq by reflexivity.
     repeat destruct_pair_let. simpl_ident.
     reflexivity.
   Qed.
   Hint Rewrite half_adder_correct using solve [eauto] : simpl_ident.
 
   Lemma incr4_correct (input : combType (Vec Bit 4)) :
-    combinational (incr4 input) = N2Bv_sized 4 (Bv2N input + 1).
+    combinational (incr4 [input]) = [N2Bv_sized 4 (Bv2N input + 1)].
   Proof.
     cbv [incr4 combinational]. simpl_ident. boolsimpl.
     cbn [unpeel indexConst CombinationalSemantics].
@@ -121,20 +124,20 @@ Section Proofs.
     all:reflexivity.
   Qed.
 
-  Lemma half_subtractor_correct (input : combType Bit * combType Bit) :
-    combinational (half_subtractor input)
-    = (xorb (fst input) (snd input), andb (negb (fst input)) (snd input)).
+  Lemma half_subtractor_correct (x y : combType Bit) :
+    combinational (half_subtractor ([x],[y]))
+    = ([xorb x y], [andb (negb x) y]).
   Proof.
-    cbv [half_subtractor combinational and2 xor2 inv
-                         CombinationalSemantics xorBool andBool].
+    cbv [half_subtractor combinational and2 xor2 CombinationalSemantics].
+    cbv [lift2]. rewrite pad_combine_eq by reflexivity.
     repeat destruct_pair_let. simpl_ident.
     reflexivity.
   Qed.
   Hint Rewrite half_subtractor_correct using solve [eauto] : simpl_ident.
 
   Lemma decr4_correct (input : combType (Vec Bit 4)) :
-    combinational (decr4 input) = N2Bv_sized 4 (if (Bv2N input =? 0)%N then 15
-                                                else Bv2N input - 1).
+    combinational (decr4 [input]) = [N2Bv_sized 4 (if (Bv2N input =? 0)%N then 15
+                                                   else Bv2N input - 1)].
   Proof.
     cbv [decr4 combinational]. simpl_ident. boolsimpl.
     cbn [unpeel indexConst CombinationalSemantics].
@@ -143,19 +146,34 @@ Section Proofs.
   Qed.
 
   Lemma incr'_correct {sz} carry (input : combType (Vec Bit sz)) :
-    combinational (incr' carry input)
-    = N2Bv_sized _ (Bv2N input + if carry then 1 else 0)%N.
+    combinational (incr' [carry] [input])
+    = [N2Bv_sized _ (Bv2N input + if carry then 1 else 0)%N].
   Proof.
     cbv [combinational].
-    revert carry input; induction sz; intros; [ solve [apply nil_eq] | ].
+    revert carry input; induction sz; intros; [ cbn; f_equal; solve [apply nil_eq] | ].
     cbn [incr']. simpl_ident. cbn [unpeel peel CombinationalSemantics].
-    rewrite (eta input). autorewrite with vsimpl.
+    rewrite (eta input). autorewrite with vsimpl. repeat destruct_pair_let.
+    cbn [unIdent combType]. rewrite (peelVecList_cons_cons (A:=Bit)).
+    autorewrite with vsimpl. rewrite half_adder_correct. cbn [fst snd].
+    (* Prove sz=0 case immediately to get sz <> 0 precondition *)
+    destruct (PeanoNat.Nat.eq_dec sz 0);
+      [ subst; eapply case0 with (v:=Vector.tl input);
+        cbn; repeat destruct_one_match; reflexivity | ].
+    rewrite unpeel_peel by auto.
     rewrite IHsz; clear IHsz.
+    erewrite (unpeelVecList_cons_singleton (A:=Bit))
+      by lazymatch goal with
+         | |- unpeelVecList (peelVecList _) = _ => rewrite unpeel_peel by auto; reflexivity
+         | |- forall l, InV l (peelVecList _) -> length l = _ =>
+           intros * Hin; apply peelVecList_length in Hin;
+             cbn [length] in *; solve [auto]
+         | _ => solve [auto]
+         end.
     destruct carry, (Vector.hd input);
       boolsimpl; rewrite ?N.add_0_r, ?N2Bv_sized_Bv2N;
         try reflexivity; [ | ].
     (* TODO(jadep) : improve this proof *)
-    { apply Bv2N_inj; autorewrite with push_Bv2N.
+    { f_equal. apply Bv2N_inj; autorewrite with push_Bv2N.
       compute_expr (N.of_nat 1). rewrite !Bv2N_N2Bv_sized_modulo.
       rewrite !N.double_spec, !N.succ_double_spec.
       rewrite Nat2N.inj_succ. rewrite N.pow_succ_r by lia.
@@ -166,7 +184,7 @@ Section Proofs.
       end.
       rewrite N.div_mul, N.mod_mul by lia.
       lia. }
-    { autorewrite with push_Bv2N.
+    { f_equal. autorewrite with push_Bv2N.
       rewrite N.double_succ_double.
       autorewrite with push_N2Bv_sized.
       rewrite N2Bv_sized_Bv2N.
@@ -174,22 +192,38 @@ Section Proofs.
   Qed.
 
   Lemma incr_correct {sz} (input : combType (Vec Bit sz)) :
-    combinational (incr input) = N2Bv_sized _ (Bv2N input + 1).
+    combinational (incr [input]) = [N2Bv_sized _ (Bv2N input + 1)].
   Proof. cbv [incr]. simpl_ident. apply incr'_correct. Qed.
 
   Lemma decr'_correct {sz} borrow (input : combType (Vec Bit sz)) :
-    combinational (decr' borrow input)
-    = N2Bv_sized _ (if borrow
-                    then if (Bv2N input =? 0)%N
-                         then N.ones (N.of_nat sz)
-                         else N.pred (Bv2N input)
-                    else Bv2N input).
+    combinational (decr' [borrow] [input])
+    = [N2Bv_sized _ (if borrow
+                     then if (Bv2N input =? 0)%N
+                          then N.ones (N.of_nat sz)
+                          else N.pred (Bv2N input)
+                     else Bv2N input)].
   Proof.
     cbv [combinational].
-    revert borrow input; induction sz; intros; [ solve [apply nil_eq] | ].
+    revert borrow input; induction sz; intros; [ cbn; f_equal; solve [apply nil_eq] | ].
     cbn [decr']. simpl_ident. cbn [unpeel peel CombinationalSemantics].
-    rewrite (eta input). autorewrite with vsimpl.
+    rewrite (eta input). autorewrite with vsimpl. repeat destruct_pair_let.
+    cbn [unIdent combType]. rewrite (peelVecList_cons_cons (A:=Bit)).
+    autorewrite with vsimpl. rewrite half_subtractor_correct. cbn [fst snd].
+    (* Prove sz=0 case immediately to get sz <> 0 precondition *)
+    destruct (PeanoNat.Nat.eq_dec sz 0);
+      [ subst; eapply case0 with (v:=Vector.tl input);
+        cbn; repeat destruct_one_match; repeat destruct_one_match_hyp;
+        try reflexivity; congruence | ].
+    rewrite unpeel_peel by auto.
     rewrite IHsz; clear IHsz. autorewrite with push_Bv2N.
+    erewrite (unpeelVecList_cons_singleton (A:=Bit))
+      by lazymatch goal with
+         | |- unpeelVecList (peelVecList _) = _ => rewrite unpeel_peel by auto; reflexivity
+         | |- forall l, InV l (peelVecList _) -> length l = _ =>
+           intros * Hin; apply peelVecList_length in Hin;
+             cbn [length] in *; solve [auto]
+         | _ => solve [auto]
+         end.
     destruct borrow, (Vector.hd input); boolsimpl;
       autorewrite with push_Bv2N push_N2Bv_sized;
       rewrite ?N.sub_0_r, ?N2Bv_sized_Bv2N;
@@ -210,16 +244,16 @@ Section Proofs.
                            | reflexivity ]
                end.
     (* should only have one case left *)
-    {  rewrite <-N2Bv_sized_succ_double.
+    {  f_equal; rewrite <-N2Bv_sized_succ_double.
        rewrite !N.double_spec, !N.succ_double_spec, !N.pred_sub.
        f_equal; lia. }
   Qed.
 
   Lemma decr_correct {sz} (input : combType (Vec Bit sz)) :
-    combinational (decr input)
-    = N2Bv_sized _ ( if (Bv2N input =? 0)%N
-                     then 2 ^ (N.of_nat sz) - 1
-                     else Bv2N input - 1)%N.
+    combinational (decr [input])
+    = [N2Bv_sized _ ( if (Bv2N input =? 0)%N
+                      then 2 ^ (N.of_nat sz) - 1
+                      else Bv2N input - 1)%N].
   Proof.
     cbv [decr]. simpl_ident. rewrite decr'_correct.
     rewrite N.ones_equiv, !N.pred_sub. reflexivity.

--- a/acorn-examples/Multiplexers.v
+++ b/acorn-examples/Multiplexers.v
@@ -53,16 +53,16 @@ Local Close Scope vector_scope.
 (* mux2_1                                                                     *)
 (******************************************************************************)
 
-Example m1: combinational (mux2_1 (false, false, true)) = false.
+Example m1: combinational (mux2_1 ([false], [false], [true])) = [false].
 Proof. reflexivity. Qed.
 
-Example m2: combinational (mux2_1 (false, true, false)) = true.
+Example m2: combinational (mux2_1 ([false], [true], [false])) = [true].
 Proof. reflexivity. Qed.
 
-Example m3: combinational (mux2_1 (true, false, true)) = true.
+Example m3: combinational (mux2_1 ([true], [false], [true])) = [true].
 Proof. reflexivity. Qed.
 
-Example m4: combinational (mux2_1 (true, true, false)) = false.
+Example m4: combinational (mux2_1 ([true], [true], [false])) = [false].
 Proof. reflexivity. Qed.
 
 Definition mux2_1_Interface
@@ -80,7 +80,9 @@ Definition mux2_1_tb_inputs :=
    (true,  true,  false)].
 
 Definition mux2_1_tb_expected_outputs
-  := map (fun i => combinational (mux2_1 i)) mux2_1_tb_inputs.
+  := map (fun '(i0,i1,i2) =>
+            List.hd false (combinational (mux2_1 ([i0],[i1],[i2])%list)))
+         mux2_1_tb_inputs.
 
 Definition mux2_1_tb
   := testBench "mux2_1_tb" mux2_1_Interface
@@ -97,16 +99,16 @@ Definition v2 := N2Bv_sized 8 255.
 Definition v3 := N2Bv_sized 8  63.
 Definition v0to3 : Vector.t (Bvector 8) 4 := [v0; v1; v2; v3].
 
-Example m5: combinational (muxBus (v0to3, [false; false])) = v0.
+Example m5: combinational (muxBus ([v0to3]%list, [[false; false]%vector]%list)) = [v0]%list.
 Proof. reflexivity. Qed.
 
-Example m6: combinational (muxBus (v0to3, [true; false])) = v1.
+Example m6: combinational (muxBus ([v0to3]%list, [[true; false]%vector]%list)) = [v1]%list.
 Proof. reflexivity. Qed.
 
-Example m7: combinational (muxBus (v0to3, [false; true])) = v2.
+Example m7: combinational (muxBus ([v0to3]%list, [[false; true]%vector]%list)) = [v2]%list.
 Proof. reflexivity. Qed.
 
-Example m8: combinational (muxBus (v0to3, [true; true])) = v3.
+Example m8: combinational (muxBus ([v0to3]%list, [[true; true]%vector]%list)) = [v3]%list.
 Proof. reflexivity. Qed.
 
 Local Close Scope vector_scope.
@@ -127,7 +129,9 @@ Definition muxBus4_8_tb_inputs : list (Vector.t (Bvector 8) 4 * Vector.t bool 2)
   ].
 
 Definition muxBus4_8_tb_expected_outputs : list (Bvector 8)
-  := map (fun i => combinational (muxBus i)) muxBus4_8_tb_inputs.
+  := map (fun '(i0,i1) => List.hd (defaultCombValue _)
+                               (combinational (muxBus ([i0],[i1])%list)))
+         muxBus4_8_tb_inputs.
 
 Definition muxBus4_8_tb
   := testBench "muxBus4_8_tb" muxBus4_8Interface

--- a/acorn-examples/NandGate.v
+++ b/acorn-examples/NandGate.v
@@ -56,22 +56,22 @@ Definition nand2Netlist := makeNetlist nand2Interface nand2_gate.
 
 (* A proof that the NAND gate implementation is correct. *)
 Lemma nand2_behaviour : forall (a : bool) (b : bool),
-                        combinational (nand2_gate (a, b)) = negb (a && b).
+                        combinational (nand2_gate ([a], [b])) = [negb (a && b)].
 Proof.
   auto.
 Qed.
 
 (* An exhuastive proof by analyzing all four cases. *)
-Example nand_00 : combinational (nand2_gate (false, false)) = true.
+Example nand_00 : combinational (nand2_gate ([false], [false])) = [true].
 Proof. reflexivity. Qed.
 
-Example nand_01 : combinational (nand2_gate (false, true)) = true.
+Example nand_01 : combinational (nand2_gate ([false], [true])) = [true].
 Proof. reflexivity. Qed.
 
-Example nand_10 : combinational (nand2_gate (true, false)) = true.
+Example nand_10 : combinational (nand2_gate ([true], [false])) = [true].
 Proof. reflexivity. Qed.
 
-Example nand_11 : combinational (nand2_gate (true, true)) = false.
+Example nand_11 : combinational (nand2_gate ([true], [true])) = [false].
 Proof. reflexivity. Qed.
 
 (* Test bench tables for generated SystemVerilog simulation test bench *)
@@ -80,7 +80,7 @@ Definition nand_tb_inputs : list (bool * bool) :=
 
 (* Compute expected outputs. *)
 Definition nand_tb_expected_outputs : list bool :=
-  map (fun i => combinational (nand2_gate i)) nand_tb_inputs.
+  map (fun '(i0,i1) => List.hd false (combinational (nand2_gate ([i0], [i1])%list))) nand_tb_inputs.
 
 Definition nand2_tb :=
   testBench "nand2_tb" nand2Interface nand_tb_inputs nand_tb_expected_outputs.

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -74,7 +74,8 @@ Definition two_sorter_tb_inputs : list (Vector.t (Bvector 8) _) :=
   ].
 
 Definition adder_tree4_8_tb_expected_outputs : list (Vector.t (Bvector 8) _) :=
-  map (fun i => combinational (twoSorter i)) two_sorter_tb_inputs.
+  map (fun i => List.hd (defaultCombValue _) (combinational (twoSorter [i]%list)))
+      two_sorter_tb_inputs.
 
 Definition two_sorter_tb :=
   testBench "two_sorter_tb" (two_sorter_Interface 8)

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -46,11 +46,11 @@ Definition bv5_30 := N2Bv_sized 5 30.
 (******************************************************************************)
 
 (* Check 0 + 0 = 0 *)
-Example add0_0 : combinational (addN (bv4_0, bv4_0)) = bv4_0.
+Example add0_0 : combinational (addN ([bv4_0], [bv4_0])) = [bv4_0].
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 0 *)
-Example add15_1 : combinational (addN (bv4_15, bv4_1)) = bv4_0.
+Example add15_1 : combinational (addN ([bv4_15], [bv4_1])) = [bv4_0].
 Proof. reflexivity. Qed.
 
 Section WithCava.
@@ -76,19 +76,19 @@ Section WithCava.
 End WithCava.
 
 (* Check 0 + 0 = 0 *)
-Example add5_0_0 : combinational (adderGrowth (bv4_0, bv4_0)) = bv5_0.
+Example add5_0_0 : combinational (adderGrowth ([bv4_0], [bv4_0])) = [bv5_0].
 Proof. reflexivity. Qed.
 
 (* Check 1 + 2 = 3 *)
-Example add5_1_2 : combinational (adderGrowth (bv4_1, bv4_2)) = bv5_3.
+Example add5_1_2 : combinational (adderGrowth ([bv4_1], [bv4_2])) = [bv5_3].
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 16 *)
-Example add5_15_1 : combinational (adderGrowth (bv4_15, bv4_1)) = bv5_16.
+Example add5_15_1 : combinational (adderGrowth ([bv4_15], [bv4_1])) = [bv5_16].
 Proof. reflexivity. Qed.
 
 (* Check 15 + 15 = 30 *)
-Example add5_15_15 : combinational (adderGrowth (bv4_15, bv4_15)) = bv5_30.
+Example add5_15_15 : combinational (adderGrowth ([bv4_15], [bv4_15])) = [bv5_30].
 Proof. reflexivity. Qed.
 
 (******************************************************************************)
@@ -110,7 +110,9 @@ Definition adder4_tb_inputs
   := [(bv4_0, bv4_0); (bv4_1, bv4_2); (bv4_15, bv4_1); (bv4_15, bv4_15)].
 
 Definition adder4_tb_expected_outputs
-  := map (fun '(a, b) => combinational (unsignedAdd a b)) adder4_tb_inputs.
+  := map (fun '(a, b) =>
+            List.hd (defaultCombValue _)
+                    (combinational (unsignedAdd [a] [b]))) adder4_tb_inputs.
 
 Definition adder4_tb
   := testBench "adder4_tb" adder4Interface
@@ -136,7 +138,9 @@ Definition adder8_3input_tb_inputs :=
   [(17, 23, 95); (4, 200, 30); (255, 255, 200)].
 
 Definition adder8_3input_tb_expected_outputs :=
-  map (fun i => combinational (add3InputTuple 8 8 8 i)) adder8_3input_tb_inputs.
+  map (fun '(i0,i1,i2) => List.hd (defaultCombValue _)
+                               (combinational (add3InputTuple 8 8 8 ([i0],[i1],[i2])%list)))
+      adder8_3input_tb_inputs.
 
 Definition adder8_3input_tb :=
   testBench "adder8_3input_tb" adder8_3inputInterface

--- a/acorn-examples/xilinx/NandLUT.v
+++ b/acorn-examples/xilinx/NandLUT.v
@@ -41,7 +41,10 @@ Definition lutNANDNetlist := makeNetlist lutNANDInterface lutNAND.
  [(false, false); (false, true); (true, false); (true, true)].
 
  Definition lutNAND_tb_expected_outputs : list bool :=
-  map (fun i => combinational (lutNAND i)) lutNAND_tb_inputs.
+   map (fun '(i0,i1) =>
+          List.hd (defaultCombValue _)
+                  (combinational (lutNAND ([i0],[i1])%list)))
+       lutNAND_tb_inputs.
 
 Definition lutNAND_tb :=
   testBench "lutNAND_tb" lutNANDInterface

--- a/acorn-examples/xilinx/XilinxAdderExamples.v
+++ b/acorn-examples/xilinx/XilinxAdderExamples.v
@@ -42,24 +42,24 @@ Definition v44  := N2Bv_sized 8 44.
 
 (* Perform a few basic checks to make sure the adder works. *)
 
-Example xadd_17_52_0 : combinational (xilinxAdderWithCarry (false, (v17, v52))) =
-                                     (v69, false).
+Example xadd_17_52_0 : combinational (xilinxAdderWithCarry ([false], ([v17], [v52]))) =
+                                     ([v69], [false]).
 Proof. reflexivity. Qed.
 
-Example xadd_17_52_1 : combinational (xilinxAdderWithCarry (true, (v17, v52))) =
-                                     (v70, false).
+Example xadd_17_52_1 : combinational (xilinxAdderWithCarry ([true], ([v17], [v52]))) =
+                                     ([v70], [false]).
 Proof. reflexivity. Qed.
 
-Example xadd_1_255_1 : combinational (xilinxAdderWithCarry (false, (v1, v255))) =
-                                     (v0, true).
+Example xadd_1_255_1 : combinational (xilinxAdderWithCarry ([false], ([v1], [v255]))) =
+                                     ([v0], [true]).
 Proof. reflexivity. Qed.
 
-Example xadd_0_255_1 : combinational (xilinxAdderWithCarry (true, (v0, v255))) =
-                                     (v0, true).
+Example xadd_0_255_1 : combinational (xilinxAdderWithCarry ([true], ([v0], [v255]))) =
+                                     ([v0], [true]).
 Proof. reflexivity. Qed.
 
-Example xadd_200_100_0 : combinational (xilinxAdderWithCarry (false, (v200, v100))) =
-                                       (v44, true).
+Example xadd_200_100_0 : combinational (xilinxAdderWithCarry ([false], ([v200], [v100]))) =
+                                       ([v44], [true]).
 Proof. reflexivity. Qed.
 
 (****************************************************************************)
@@ -95,7 +95,10 @@ Definition adder8_tb_inputs :=
    (1, (255, 255))].
 
 Definition adder8_tb_expected_outputs :=
-  map (fun i => combinational (xilinxAdderWithCarryFlat i)) adder8_tb_inputs.
+  map (fun '(i0,i1,i2) =>
+         let '(r1,r2) := combinational (xilinxAdderWithCarryFlat ([i0],[i1],[i2])%list) in
+         (List.hd (defaultCombValue _) r1, List.hd (defaultCombValue _) r2))
+      adder8_tb_inputs.
 
 Definition adder8_tb :=
   testBench "adder8_tb" adder8Interface

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -74,15 +74,16 @@ Local Open Scope nat_scope.
 Local Open Scope vector_scope.
 
 Definition v0_v1 : Vector.t (Bvector 8) 2 := [v0; v1].
-Definition v0_plus_v1 : Bvector 8 := combinational (adderTree2 v0_v1).
-Example sum_vo_v1 : v0_plus_v1 = N2Bv_sized 8 21.
+Definition v0_plus_v1 : list (Bvector 8) := combinational (adderTree2 [v0_v1]%list).
+Example sum_vo_v1 : v0_plus_v1 = [N2Bv_sized 8 21]%list.
 Proof. reflexivity. Qed.
 
 Local Open Scope N_scope.
 
 Definition v0_v1_v2_v3 := [v0; v1; v2; v3].
-Definition adderTree4_v0_v1_v2_v3 := combinational (adderTree4 v0_v1_v2_v3).
-Example sum_v0_v1_v2_v3 : Bv2N (combinational (adderTree4 v0_v1_v2_v3)) = 30.
+Definition adderTree4_v0_v1_v2_v3 := combinational (adderTree4 [v0_v1_v2_v3]%list).
+Example sum_v0_v1_v2_v3 :
+  List.map Bv2N (combinational (adderTree4 [v0_v1_v2_v3]%list)) = [30]%list.
 Proof. reflexivity. Qed.
 
 Local Open Scope nat_scope.
@@ -109,7 +110,9 @@ Definition adder_tree4_8_tb_inputs
       [9; 56; 2; 87];   [14; 72; 90; 11]; [64; 12; 92; 13];    [88; 24; 107; 200]]).
 
 Definition adder_tree4_8_tb_expected_outputs
-  := map (fun i => combinational (adderTree4 i)) adder_tree4_8_tb_inputs.
+  := map (fun i => List.hd (defaultCombValue _)
+                        (combinational (adderTree4 [i]%list)))
+         adder_tree4_8_tb_inputs.
 
 Definition adder_tree4_8_tb :=
   testBench "xadder_tree4_8_tb" adder_tree4_8Interface
@@ -143,7 +146,8 @@ Definition adder_tree64_8_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64].
 
 Definition adder_tree64_8_tb_expected_outputs
-  := map (fun i => combinational (adderTree 5 i)) adder_tree64_8_tb_inputs.
+  := map (fun i => List.hd (defaultCombValue _) (combinational (adderTree 5 [i]%list)))
+         adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "xadder_tree64_8_tb" adder_tree64_8Interface
@@ -164,7 +168,9 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := map (fun i => combinational (adderTree 5 i)) adder_tree64_128_tb_inputs.
+  := map (fun i => List.hd (defaultCombValue _)
+                        (combinational (adderTree 5 [i]%list)))
+         adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "xadder_tree64_128_tb" adder_tree64_128Interface
@@ -186,7 +192,8 @@ Definition adder_tree128_256_tb_inputs : list (Vector.t (Bvector 256) 128)
 
 Definition adder_tree128_256_tb_expected_outputs
            : list (Bvector 256)
-  := map (fun i => combinational (adderTree 6 i)) adder_tree128_256_tb_inputs.
+  := map (fun i => List.hd (defaultCombValue _)
+                        (combinational (adderTree 6 [i]%list))) adder_tree128_256_tb_inputs.
 
 Definition adder_tree128_256_tb :=
   testBench "xadder_tree128_256_tb" adder_tree128_256Interface

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -15,6 +15,7 @@
 (****************************************************************************)
 
 Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.
 Require Import Coq.NArith.NArith.
 Require Import Coq.Vectors.Vector.
@@ -24,91 +25,271 @@ Require Import Cava.Acorn.Combinators.
 Require Import Cava.Acorn.CombinationalMonad.
 Require Import Cava.Acorn.Identity.
 Require Import Cava.BitArithmetic.
+Require Import Cava.ListUtils.
 Require Import Cava.NatUtils.
 Require Import Cava.Signal.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
-Import VectorNotations.
+Import ListNotations VectorNotations.
+Local Open Scope list_scope.
 
 Existing Instance CombinationalSemantics.
 
-Lemma all_fold_left {n} v :
-  unIdent (all (n:=n) v) = Vector.fold_left andb true v.
+Section PadCombine.
+  Lemma pad_combine_eq {A B} a b :
+    length a = length b -> @pad_combine A B a b = combine a b.
+  Proof.
+    cbv [pad_combine]; intros.
+    rewrite !extend_le by lia.
+    reflexivity.
+  Qed.
+End PadCombine.
+
+Section Pairs.
+  Lemma unpair_skipn {A B} n (l : seqType (Pair A B)) :
+    unpair (skipn n l) = (skipn n (fst (unpair l)), skipn n (snd (unpair l))).
+  Proof. apply split_skipn. Qed.
+  Lemma unpair_mkpair {A B} (a : seqType A) (b : seqType B) :
+    length a = length b ->
+    unpair (mkpair a b) = (a, b).
+  Proof.
+    cbv [mkpair unpair CombinationalSemantics]; intros.
+    rewrite pad_combine_eq by lia.
+    apply combine_split; lia.
+  Qed.
+End Pairs.
+
+Section Peel.
+  Lemma fold_left_map2_peel A B n (f : combType B -> combType A -> combType B)
+        (v : combType (Vec A n)) (start : combType B) :
+    fold_left (map2 f) [start] (peel [v]) = [fold_left f start v].
+  Proof.
+    cbn [peel CombinationalSemantics].
+    revert v start; induction n; [ intros; eapply case0 with (v:=v); reflexivity | ].
+    intros v start; rewrite (eta v). fold combType. cbn [combType].
+    rewrite peelVecList_cons_cons.
+    autorewrite with push_vector_fold push_vector_map vsimpl.
+    cbn [map2]. rewrite IHn. reflexivity.
+  Qed.
+
+  Lemma peel_length_InV {A} n (vs : seqType (Vec A n)) l :
+    InV l (peel vs) -> length l = length vs.
+  Proof. apply peelVecList_length. Qed.
+
+  Lemma peel_length_ForallV {A} n (vs : seqType (Vec A n)) :
+    ForallV (fun l => length l = length vs) (peel vs).
+  Proof.
+    cbv [peel peelVecList indexConstBoolList CombinationalSemantics].
+    apply ForallV_forall. intros *.
+    rewrite InV_map_iff; intros [? [? ?]]. subst.
+    length_hammer.
+  Qed.
+
+  Lemma map_nth_default_vseq' {A} d n m (v : Vector.t A (n + m)) :
+    Vector.map (fun i => nth_default d i v) (vseq 0 n) = fst (splitat _ v).
+  Proof.
+    apply to_list_inj. autorewrite with push_to_list.
+    revert v; induction n; intros; [ reflexivity | ].
+    autorewrite with pull_snoc natsimpl.
+    rewrite firstn_succ_snoc with (d0:=d) by length_hammer.
+    change (S n + m) with (S (n + m)) in *.
+    rewrite (eta_snoc v).
+    autorewrite with push_to_list push_firstn push_length natsimpl listsimpl vsimpl.
+    rewrite <-IHn; f_equal; [ | ].
+    { apply List.map_ext_in. intros *; rewrite in_seq; intros.
+      apply nth_default_snoc; lia. }
+    { rewrite nth_default_to_list.
+      autorewrite with push_to_list. reflexivity. }
+  Qed.
+
+  Lemma map_nth_default_vseq {A} d n (v : Vector.t A n) :
+    Vector.map (fun i => nth_default d i v) (vseq 0 n) = v.
+  Proof.
+    replace v with (resize_default d n (resize_default d (n + 0) v))
+      by (rewrite resize_default_resize_default, resize_default_id by lia;
+          reflexivity).
+    erewrite map_ext by (intros;rewrite nth_default_resize_default by lia;
+                         instantiate_app_by_reflexivity).
+    rewrite map_nth_default_vseq'.
+    rewrite resize_default_resize_default, resize_default_id by lia.
+    apply to_list_inj. autorewrite with push_to_list.
+    rewrite firstn_all2 by length_hammer. reflexivity.
+  Qed.
+
+  Lemma map_nth_default_seq' {A} d n (l : list A) :
+    n <= length l -> List.map (fun i => List.nth i l d) (seq 0 n) = firstn n l.
+  Proof.
+    revert l; induction n; [ destruct l; reflexivity | ].
+    intros. autorewrite with pull_snoc natsimpl.
+    rewrite firstn_succ_snoc with (d0:=d) by lia.
+    rewrite IHn by lia; reflexivity.
+  Qed.
+
+  Lemma map_nth_default_seq {A} d n (l : list A) :
+    length l = n -> List.map (fun i => List.nth i l d) (seq 0 n) = l.
+  Proof.
+    intros; rewrite map_nth_default_seq' by lia.
+    rewrite firstn_all2 by lia; reflexivity.
+  Qed.
+
+  Lemma unpeel_peel A n (v : seqType (Vec A n)) :
+    n <> 0 -> unpeel (peel v) = v.
+  Proof.
+    cbv [unpeel peel unpeelVecList peelVecList CombinationalSemantics].
+    cbv [indexConstBoolList]. intros.
+    erewrite max_length_same_length with (len:=length v); [ | | lia .. ];
+      [ | intros *; rewrite InV_map_iff; intros [? [? ?]]; subst;
+          solve [length_hammer] ].
+    erewrite List.map_ext_in.
+    2:{ intros *. rewrite in_seq; intros.
+        rewrite map_map.
+        erewrite Vector.map_ext_in.
+        2:{
+          intros.
+          rewrite map_nth_inbounds with (d2:=Vector.const (defaultCombValue _) _)
+            by (cbn [combType] in *; lia).
+          instantiate_app_by_reflexivity. }
+        rewrite map_nth_default_vseq.
+        instantiate_app_by_reflexivity. }
+    rewrite map_nth_default_seq; reflexivity.
+  Qed.
+End Peel.
+
+Section DecidableEquality.
+  Fixpoint combType_eqb {t} : combType t -> combType t -> bool :=
+    match t as t0 return combType t0 -> combType t0 -> bool with
+    | Void => fun _ _ => true
+    | Bit => fun x y => Bool.eqb x y
+    | Vec A n => fun x y => Vector.eqb _ combType_eqb x y
+    | Pair A B => fun x y =>
+                   (combType_eqb (fst x) (fst y) &&
+                    combType_eqb (snd x) (snd y))%bool
+    | ExternalType s => fun x y => true
+    end.
+
+  Lemma combType_eqb_true_iff {t} (x y : combType t) :
+    combType_eqb x y = true <-> x = y.
+  Proof.
+    revert x y; induction t; intros;
+      repeat match goal with
+             | _ => progress cbn [combType_eqb combType Bool.eqb fst snd] in *
+             | x : unit |- _ => destruct x
+             | x : bool |- _ => destruct x
+             | x : _ * _ |- _ => destruct x
+             | _ => tauto
+             | _ => solve [eauto using VectorEq.eqb_eq]
+             | |- _ <-> _ => split; congruence
+             end; [ ].
+    (* only the pair case should be remaining *)
+    rewrite Bool.andb_true_iff, IHt1, IHt2.
+    split; [ destruct 1 | inversion 1; split ];
+      intros; subst; eauto.
+  Qed.
+End DecidableEquality.
+
+Lemma all_correct {n} v :
+  unIdent (all (n:=n) [v]) = [Vector.fold_left andb true v].
 Proof.
   destruct n; [ eapply Vector.case0 with (v:=v); reflexivity | ].
   cbv [all]. cbn [one CombinationalSemantics].
   rewrite MonadLaws.bind_of_return by apply MonadLaws_ident.
-  erewrite tree_all_sizes_equiv with (op:=andb) (id:=true);
-    auto using Bool.andb_true_r, Bool.andb_true_l, Bool.andb_assoc.
+  erewrite tree_all_sizes_equiv' with (op:=map2 andb) (id:=[true]) (valid:=fun a => length a = 1);
+    intros; destruct_lists_by_length;
+      cbn [map2 length unIdent Monad.bind Monad.ret Monad_ident]; boolsimpl;
+        try reflexivity; try lia.
+  { apply fold_left_map2_peel with (A:=Bit) (B:=Bit). }
+  { f_equal; apply Bool.andb_assoc. }
+  { apply ForallV_forall; intros.
+    lazymatch goal with H : InV _ _ |- _ =>
+                        eapply (peel_length_InV (A:=Bit)) in H end.
+    length_hammer. }
 Qed.
 
-Lemma eqb_eq {t} (x y : combType t) :
-  unIdent (eqb x y) = true <-> x = y.
+Lemma eqb_correct {t} (x y : combType t) :
+  unIdent (eqb [x] [y]) = [combType_eqb x y].
 Proof.
   revert x y.
   induction t;
-    cbn [eqb combType and2 andBool xnor2 xnorBool one unpair
-             CombinationalSemantics] in *;
+    cbn [eqb combType and2 xnor2 one unpair
+             CombinationalSemantics] in *; cbv [lift2];
     intros; simpl_ident; repeat destruct_pair_let;
     (* handle easy cases first *)
     repeat lazymatch goal with
            | x : unit |- _ => destruct x
-           | x : bool |- _ => destruct x; cbn [xorb negb]
+           | x : bool |- _ => destruct x
            | |- (?x = ?x <-> ?y = ?y) => split; reflexivity
-           end;
-    try (split; congruence); [ | ].
+           | _ => first [ progress cbn [List.map combine fst snd xnorb xorb negb]
+                       | rewrite pad_combine_eq by length_hammer
+                       | split; (congruence || reflexivity) ]
+           end.
   { (* Vector case *)
-    match goal with
-    | |- context [(@unIdent (Vector.t bool ?n) (zipWith _ _ _))] =>
-      change (Vector.t bool n) with (combType (Vec Bit n));
-        rewrite zipWith_unIdent
-    end.
-    rewrite <-fold_andb_eq_iff by apply IHt.
-    rewrite all_fold_left. reflexivity. }
+    destruct (Nat.eq_dec n 0); subst;
+      [ repeat match goal with
+               | x : Vector.t _ 0 |- _ => eapply case0 with (v:=x); clear x
+               end; split; reflexivity | ].
+    erewrite (zipWith_unIdent (A:=t) (B:=t) (C:=Bit)) by eauto.
+    rewrite (all_correct (n:=n)). cbn [combType_eqb].
+    rewrite eqb_fold. reflexivity. }
   { (* Pair case *)
-    simpl_ident. rewrite pair_equal_spec, <-IHt1, <-IHt2.
-    rewrite Bool.andb_true_iff. reflexivity. }
+    simpl_ident. cbn [split]. repeat destruct_pair_let.
+    cbn [fst snd]. rewrite IHt1, IHt2.
+    rewrite pad_combine_eq by length_hammer.
+    cbn [combine List.map fst snd combType_eqb].
+    reflexivity. }
 Qed.
 
-Lemma eqb_refl {t} (x : combType t) : unIdent (eqb x x) = true.
+Lemma eqb_eq {t} (x y : combType t) :
+  unIdent (eqb [x] [y]) = [true] <-> x = y.
+Proof.
+  rewrite eqb_correct. split.
+  { inversion 1. apply combType_eqb_true_iff. auto. }
+  { intros; subst. f_equal.
+    apply combType_eqb_true_iff. reflexivity. }
+Qed.
+
+Lemma eqb_refl {t} (x : combType t) : unIdent (eqb [x] [x]) = [true].
 Proof. apply eqb_eq. reflexivity. Qed.
 
-Lemma eqb_neq {t} (x y : combType t) : x <> y ->  unIdent (eqb x y) = false.
-Proof. rewrite <-Bool.not_true_iff_false, eqb_eq. tauto. Qed.
+Lemma eqb_neq {t} (x y : combType t) : x <> y ->  unIdent (eqb [x] [y]) = [false].
+Proof.
+  rewrite eqb_correct; intros. f_equal.
+  apply Bool.not_true_is_false.
+  rewrite combType_eqb_true_iff. auto.
+Qed.
 
 Lemma eqb_nat_to_bitvec_sized sz n m :
   n < 2 ^ sz -> m < 2 ^ sz ->
-  unIdent (eqb (t:=Vec Bit sz) (nat_to_bitvec_sized sz n)
-               (nat_to_bitvec_sized sz m))
-  = if Nat.eqb n m then true else false.
+  unIdent (eqb (t:=Vec Bit sz) [nat_to_bitvec_sized sz n]
+               [nat_to_bitvec_sized sz m])
+  = [if Nat.eqb n m then true else false].
 Proof.
-  intros; destruct_one_match; subst; [ solve [apply eqb_refl] | ].
-  apply eqb_neq. cbv [nat_to_bitvec_sized].
+  intros; destruct_one_match; subst; [ solve [apply (eqb_refl (t:=Vec Bit sz))] | ].
+  apply (eqb_neq (t:=Vec Bit sz)). cbv [nat_to_bitvec_sized].
   rewrite N2Bv_sized_eq_iff with (n:=sz) by auto using N.size_nat_le_nat.
   lia.
 Qed.
 
 Lemma pairSel_mkpair {t} (x y : combType t) (sel : bool) :
-  pairSel sel (mkpair x y) = if sel then y else x.
-Proof. reflexivity. Qed.
+  pairSel [sel] (mkpair [x] [y]) = [if sel then y else x].
+Proof. cbn - [pairSel]. reflexivity. Qed.
 
 Lemma pairAssoc_mkpair {A B C} a b c :
-  @pairAssoc _ _ A B C (mkpair (mkpair a b) c) = mkpair a (mkpair b c).
+  @pairAssoc _ _ A B C (mkpair (mkpair [a] [b]) [c]) = mkpair [a] (mkpair [b] [c]).
 Proof. reflexivity. Qed.
 
-Lemma mux4_mkpair {t} (i0 i1 i2 i3 : combType t) sel :
-  mux4 (mkpair (mkpair (mkpair i0 i1) i2) i3) sel =
-  if Vector.hd (Vector.tl sel)
-  then if Vector.hd sel then i3 else i2
-  else if Vector.hd sel then i1 else i0.
+Lemma mux4_mkpair {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
+  mux4 (mkpair (mkpair (mkpair [i0] [i1]) [i2]) [i3]) [sel] =
+  [if Vector.hd (Vector.tl sel)
+   then if Vector.hd sel then i3 else i2
+   else if Vector.hd sel then i1 else i0].
 Proof.
   cbv in sel. constant_vector_simpl sel.
   cbv [mux4 indexConst CombinationalSemantics].
   autorewrite with vsimpl.
   repeat
     match goal with
-    | |- context [(@indexConstBool ?t ?sz ?v ?n)] =>
-      let x := constr:(@indexConstBool t sz v n) in
+    | |- context [(@indexConstBoolList ?t ?sz ?v ?n)] =>
+      let x := constr:(@indexConstBoolList t sz v n) in
       let y := (eval cbn in x) in
       progress change x with y
     | _ => rewrite pairAssoc_mkpair
@@ -118,10 +299,10 @@ Proof.
     end.
 Qed.
 
-Lemma one_correct : @unIdent (combType Bit) one = true.
+Lemma one_correct : @unIdent (seqType Bit) one = [true].
 Proof. reflexivity. Qed.
 Hint Rewrite one_correct using solve [eauto] : simpl_ident.
 
-Lemma zero_correct : @unIdent (combType Bit) zero = false.
+Lemma zero_correct : @unIdent (seqType Bit) zero = [false].
 Proof. reflexivity. Qed.
 Hint Rewrite zero_correct using solve [eauto] : simpl_ident.

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -14,46 +14,151 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Lists.List.
 Require Import Coq.Vectors.Vector.
+Require Import Coq.micromega.Lia.
+Require Import coqutil.Tactics.Tactics.
 Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.MonadLaws.
 Require Import Cava.Signal.
 Require Import Cava.Tactics.
+Require Import Cava.ListUtils.
 Require Import Cava.VectorUtils.
 Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.CombinationalMonad.
 Require Import Cava.Acorn.Combinators.
+Import VectorNotations ListNotations.
+Open Scope list_scope.
 
 Existing Instance CombinationalSemantics.
 
+
+Section MapT.
+  Lemma mapT_vector_ident {A B n} (f : A -> ident B) (v : Vector.t A n) :
+    unIdent (mapT_vector f v) = map (fun a => unIdent (f a)) v.
+  Proof.
+    induction v; intros; [ reflexivity | ].
+    cbn. rewrite IHv. reflexivity.
+  Qed.
+End MapT.
+Hint Rewrite @mapT_vector_ident using solve [eauto] : simpl_ident.
+
+Section PeelUnpeel.
+  Lemma peelVecList_cons_cons {A n} (a : combType A) (v : combType (Vec A n)) :
+    peelVecList [(a :: v)%vector] = ([a]%list :: peelVecList [v])%vector.
+  Proof.
+    cbv [peelVecList indexConstBoolList]. cbn [List.map Vector.map].
+    apply to_list_inj. autorewrite with push_to_list.
+    rewrite <-cons_seq, <-seq_shift. cbn [List.map]. rewrite List.map_map.
+    cbn. autorewrite with natsimpl.
+    reflexivity.
+  Qed.
+
+  (* Useful for unpeel *)
+  Lemma max_length_same_length {A n} (v : Vector.t (list A) n) m len:
+    (forall l, InV l v -> length l = len) -> n <> 0 -> m <= len ->
+    fold_left PeanoNat.Nat.max m (map (@length _) v) = len.
+  Proof.
+    revert m; induction n; intros; [ congruence | ].
+    rewrite (eta v) in *. cbn [Vector.map InV] in *.
+    autorewrite with vsimpl in *.
+    destruct (PeanoNat.Nat.eq_dec n 0);
+      subst; autorewrite with push_vector_fold vsimpl;
+        repeat match goal with
+               | Hin : forall l, _ -> length l = _ |- _ =>
+                 rewrite Hin by (tauto || lia)
+               | _ => rewrite IHn; [ | intros; try lia .. ]
+               | _ => reflexivity
+               | _ => lia
+               end.
+  Qed.
+
+  Lemma peelVecList_length {A n} (v : seqType (Vec A n)) l :
+    InV l (peelVecList v) -> length l = length v.
+  Proof.
+    cbv [peelVecList indexConstBoolList].
+    rewrite InV_map_iff. destruct 1 as [? [? ?]].
+    subst. autorewrite with push_length. reflexivity.
+  Qed.
+
+  Lemma unpeelVecList_cons_singleton {A n} (a : combType A) (v : Vector.t (seqType A) n) x :
+    (forall l, InV l v -> length l = 1) -> n <> 0 -> unpeelVecList v = [x]%list ->
+    unpeelVecList ([a]%list :: v)%vector = [(a :: x)%vector].
+  Proof.
+    cbv [unpeelVecList]; intros Hin ? Heq.
+    rewrite max_length_same_length with (len:=1) in Heq by (lia || eauto).
+    rewrite max_length_same_length with (len:=1)
+      by (try lia; eauto; intros *; rewrite InV_cons_iff;
+          destruct 1; subst; intros; eauto).
+    cbn [List.map List.seq Vector.map List.nth] in *.
+    inversion Heq; reflexivity.
+  Qed.
+End PeelUnpeel.
+
 (* Lemmas about combinators specialized to the identity monad *)
 Section Combinators.
-  Lemma zipWith_unIdent {A B C : SignalType} n f va vb :
-    unIdent (@zipWith _ _ Monad_ident A B C n f va vb)
-    = map2 (fun a b => unIdent (f (a,b))) va vb.
+  Lemma zipWith_unIdent {A B C : SignalType} n
+        (f : seqType A * seqType B -> cava (seqType C))
+        (spec : combType A -> combType B -> combType C)
+        (va : combType (Vec A n)) (vb : combType (Vec B n)) :
+    n <> 0 ->
+    (forall a b, unIdent (f ([a], [b])) = [spec a b]) ->
+    unIdent (@zipWith _ _ Monad_ident A B C n f [va] [vb])
+    = [Vector.map2 spec va vb].
   Proof.
     cbv [zipWith Traversable.mapT Traversable_vector].
     cbn [peel unpeel CombinationalSemantics].
-    revert va vb; induction n; intros; [ apply nil_eq | ].
-    cbn [vcombine]. rewrite (eta va), (eta vb).
-    autorewrite with push_vector_map vsimpl.
-    rewrite <-IHn. reflexivity.
+    cbn [bind ret Monad_ident unIdent] in *.
+    rewrite mapT_vector_ident.
+    revert va vb; induction n; intros; [ lia | ].
+    { rewrite (eta va), (eta vb).
+      autorewrite with push_vcombine push_vector_map vsimpl.
+      cbn [combType]  in *. rewrite !peelVecList_cons_cons.
+      autorewrite with push_vcombine push_vector_map vsimpl.
+      lazymatch goal with
+      | Hspec : context [unIdent (f _)] |- _ =>
+        rewrite Hspec
+      end.
+      fold combType.
+      destruct (PeanoNat.Nat.eq_dec n 0).
+      { subst n. eapply case0 with (v:=Vector.tl va).
+        eapply case0 with (v:=Vector.tl vb).
+        reflexivity. }
+      cbv [seqType].
+      erewrite unpeelVecList_cons_singleton; eauto; [ ].
+      intros *. rewrite InV_map_iff.
+      destruct 1 as [? [? ?]].
+      subst.
+      cbv [vcombine] in *.
+      repeat match goal with
+             | H : _ |- _ =>
+               apply InV_map2_impl in H; destruct H as [? [? [? [? ?]]]]; subst
+             | H : InV _ _ |- _ => apply peelVecList_length in H
+             end.
+      match goal with
+      | |- context [f (?l1, ?l2)] =>
+        destruct l1 as [| ? [|? ?] ];
+          destruct l2 as [| ? [|? ?] ];
+          cbn [length] in *; try lia
+      end.
+      lazymatch goal with
+      | Hspec : context [unIdent (f _)] |- _ =>
+        rewrite Hspec
+      end.
+      reflexivity. }
   Qed.
 End Combinators.
 
 
 Section Vectors.
-  Lemma xorV_unIdent n ab :
-    unIdent (@xorV _ _ Monad_ident n ab) = map2 xorb (fst ab) (snd ab).
+  Lemma xorV_unIdent n a b :
+    n <> 0 ->
+    unIdent (@xorV _ _ Monad_ident n ([a],[b])) = [Vector.map2 xorb a b].
   Proof.
-    cbv [xorV Traversable.mapT Traversable_vector].
-    cbn [peel unpeel CombinationalSemantics]. destruct ab as [a b].
-    revert a b; induction n; intros; [ apply nil_eq | ].
-    cbn [vcombine]. rewrite (eta a), (eta b).
-    autorewrite with push_vector_map vsimpl.
-    cbn [fst snd] in *.
-    rewrite <-IHn. reflexivity.
+    intros. cbv [xorV]. cbn [fst snd].
+    erewrite zipWith_unIdent; [ reflexivity | lia | ].
+    intros; reflexivity.
   Qed.
 End Vectors.
 

--- a/cava/Cava/Acorn/Sequential.v
+++ b/cava/Cava/Acorn/Sequential.v
@@ -94,147 +94,6 @@ Definition loopSeqS {A B : SignalType}
                     (a : seqType A) : ident (seqType B) :=
   snd (fold_left (loopSeqS' f) a (0, ret [])).
 
-(******************************************************************************)
-(* A boolean sequential logic interpretation for the Cava class               *)
-(******************************************************************************)
-
-Definition notBoolList (i : list bool) : ident (list bool) :=
-  mapT notBool i.
-
-Definition andBoolList (i : (list bool) * (list bool)) : ident (list bool) :=
-  mapT andBool (combine (fst i) (snd i)).
-
-Definition nandBoolList (i : (list bool) * (list bool)) : ident (list bool) :=
-  mapT nandBool (combine (fst i) (snd i)).
-
-Definition orBoolList (i : (list bool) * (list bool)) : ident (list bool) :=
-  mapT orBool (combine (fst i) (snd i)).
-
-Definition norBoolList (i : (list bool) * (list bool)) : ident (list bool) :=
-  mapT norBool (combine (fst i) (snd i)).
-
-Definition xorBoolList (i : (list bool) * (list bool)) : ident (list bool) :=
-  mapT xorBool (combine (fst i) (snd i)).
-
-Definition xnorBoolList (i : (list bool) * (list bool)) : ident (list bool) :=
-  mapT xnorBool (combine (fst i) (snd i)).
-
-Definition lut1BoolList (f: bool -> bool) (i : list bool) : ident (list bool) :=
-  ret (map f i).
-
-Definition lut2BoolList (f: bool -> bool -> bool)
-                        (i : (list bool) * (list bool)) : ident (list bool) :=
-  ret (map (fun (i : bool * bool) => let (a, b) := i in f a b)
-           (combine (fst i) (snd i))).
-
-Definition lut3BoolList (f: bool -> bool -> bool -> bool)
-                        (i : (list bool) * (list bool) * (list bool)) : ident (list bool) :=
-  let '(aL, bL, cL) := i in
-  ret (map (fun (i : bool * bool * bool) => let '(a, b, c) := i in f a b c)
-           (combine (combine aL bL) cL)).
-
-Definition lut4BoolList (f: bool -> bool -> bool -> bool -> bool)
-                        (i : (list bool) * (list bool) * 
-                             (list bool) * (list bool)) : ident (list bool) :=
-  let '(aL, bL, cL, dL) := i in
-  ret (map (fun (i : bool * bool * bool * bool) =>
-            let '(a, b, c, d) := i in f a b c d)
-           (combine (combine (combine aL bL) cL) dL)).
-
-Definition lut5BoolList (f: bool -> bool -> bool -> bool -> bool -> bool)
-                        (i : (list bool) * (list bool) * (list bool) *
-                             (list bool) * (list bool)) : ident (list bool) :=
-  let '(aL, bL, cL, dL, eL) := i in
-  ret (map (fun (i : bool * bool * bool * bool * bool) =>
-            let '(a, b, c, d, e) := i in f a b c d e)
-           (combine (combine (combine (combine aL bL) cL) dL) eL)).
-
-Definition lut6BoolList (fn: bool -> bool -> bool -> bool -> bool -> bool -> bool)
-                        (i : (list bool) * (list bool) * (list bool) *
-                             (list bool) * (list bool) * (list bool)) :
-                        ident (list bool) :=
-  let '(aL, bL, cL, dL, eL, fL) := i in
-  ret (map (fun (i : bool * bool * bool * bool * bool * bool) =>
-            let '(a, b, c, d, e, f) := i in fn a b c d e f)
-           (combine (combine (combine (combine (combine aL bL) cL) dL) eL) fL)).
-
-Definition xorcyBoolList := xorBoolList.
-
-Definition muxcyBoolList (s : list bool) (ci : list bool) (di : list bool)  : ident (list bool) :=
-  let dici := combine di ci in
-  let s_dici := combine s dici in
-  ret (map (fun (i : bool * (bool * bool)) =>
-     let '(s, (ci, di)) := i in
-     match s with
-       | false => di
-       | true => ci
-     end) s_dici).
-
-Definition pairSelList {t: SignalType}
-                       (sel : list bool) (v: list (combType t * combType t))
-  : list (combType t) :=
-  ListUtils.map2 pairSelBool sel v.
-
-Definition indexAtBoolList {t: SignalType}
-                       {sz isz: nat}
-                       (i : list (Vector.t (combType t) sz))
-                       (sel : list (Bvector isz)) : list (combType t) :=
-  map (fun '(i, sel) => indexAtBool i sel) (combine i sel).
-
-Definition indexConstBoolList {t: SignalType} {sz: nat}
-                              (i : list (Vector.t (combType t) sz))
-                              (sel : nat) : list (combType t) :=
-  map (fun i => indexConstBool i sel) i.
-
-Definition sliceBoolList {t: SignalType}
-                         {sz: nat}
-                         (startAt len : nat)
-                         (v: list (Vector.t (combType t) sz))
-                         (H: startAt + len <= sz) :
-                         list (Vector.t (combType t) len) :=
-  map (fun v => sliceBool startAt len v H) v.
-
-Definition peelVecList {t: SignalType} {s: nat}
-                       (v: list (Vector.t (combType t) s))
-                       : Vector.t (list (combType t)) s :=
- Vector.map (fun i => map (fun j => indexConstBool j i) v) (vseq 0 s).
-
-Definition unpeelVecList' {t: SignalType} {s: nat}
-                         (v: Vector.t (list (combType t)) s)
-                         (l: nat)
-                         : list (Vector.t (combType t) s) :=
-  map (fun ni => Vector.map (fun vi => nth ni vi (defaultCombValue t)) v) (seq 0 l).
-
-Local Open Scope vector_scope.
-
-Definition unpeelVecList {t: SignalType} {s: nat}
-                         (v: Vector.t (list (combType t)) s)
-                         : list (Vector.t (combType t) s) :=
-  match s, v with
-  | O, _ => []
-  | S n, x::xs => unpeelVecList' v (length x)
-  | S _, [] => []
-  end.
-
-Local Open Scope list_scope.
-
-Definition unsignedAddBoolList {m n : nat}
-                               (av : list (Bvector m)) (bv : list (Bvector n)) :
-                               ident (list (Bvector (1 + max m n))) :=
-  mapT (fun '(a, b) => ret (unsignedAddBool a b)) (combine av bv).
-
-Definition unsignedMultBoolList {m n : nat}
-                                (av : list (Bvector m)) (bv : list (Bvector n)) :
-                                ident (list (Bvector (m + n))) :=
-  mapT (fun '(a, b) => ret (unsignedMultBool a b)) (combine av bv).
-
-Definition greaterThanOrEqualBoolList {m n : nat}
-                                      (av : list (Bvector m)) (bv : list (Bvector n)) :
-                                      ident (list bool) :=
-  mapT (fun '(a, b) => ret (greaterThanOrEqualBool a b)) (combine av bv).
-
-Definition bufBoolList (i : list bool) : ident (list bool) :=
-  ret i.
 
 Fixpoint delayEnableBoolList' (t: SignalType) (en: list bool) (i : seqType t)
                               (state: combType t) :
@@ -243,7 +102,7 @@ Fixpoint delayEnableBoolList' (t: SignalType) (en: list bool) (i : seqType t)
   | enV::enX, iV::iX =>  r <- delayEnableBoolList' t enX iX (if enV then iV else state) ;;
                          ret (state:: r)
   | _, _ => ret []
-  end.                         
+  end.
 
 Definition delayEnableBoolList (t: SignalType) (en: list bool) (i : seqType t) :
                              ident (seqType t) :=
@@ -254,44 +113,7 @@ Definition delayEnableBoolList (t: SignalType) (en: list bool) (i : seqType t) :
 (* interpretation.                                                            *)
 (******************************************************************************)
 
- Instance SequentialCombSemantics : Cava seqType :=
-  { cava := ident;
-    constant b := [b];
-    zero := ret [false];
-    one := ret [true];
-    defaultSignal t := @defaultSeqValue t;
-    inv := notBoolList;
-    and2 := andBoolList;
-    nand2 := nandBoolList;
-    or2 := orBoolList;
-    nor2 := norBoolList;
-    xor2 := xorBoolList;
-    xnor2 := xnorBoolList;
-    buf_gate := bufBoolList;
-    lut1 := lut1BoolList;
-    lut2 := lut2BoolList;
-    lut3 := lut3BoolList;
-    lut4 := lut4BoolList;
-    lut5 := lut5BoolList;
-    lut6 := lut6BoolList;
-    xorcy := xorcyBoolList;
-    muxcy := muxcyBoolList;
-    mkpair _ _ v1 v2 := combine v1 v2;
-    unpair _ _ v := split v;
-    peel _ _ v := peelVecList v;
-    unpeel _ _ v := unpeelVecList v;
-    pairSel _ v sel := pairSelList v sel;
-    indexAt t sz isz := @indexAtBoolList t sz isz;
-    indexConst t sz := @indexConstBoolList t sz;
-    slice t sz := @sliceBoolList t sz;
-    unsignedAdd m n := @unsignedAddBoolList m n;
-    unsignedMult m n := @unsignedMultBoolList m n;
-    greaterThanOrEqual m n := @greaterThanOrEqualBoolList m n;
-    instantiate _ circuit := circuit;
-    blackBox intf _ := ret (tupleInterfaceDefaultS (map port_type (circuitOutputs intf)));
-  }.
-
- Instance SequentialSemantics : CavaSeq SequentialCombSemantics :=
+Instance SequentialSemantics : CavaSeq CombinationalSemantics :=
    { delay t i := ret (@defaultCombValue t :: i);
      delayEnable t en i := delayEnableBoolList t en i;
      loopDelayS _ _ := loopSeqS;

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -268,7 +268,7 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
     indexConst t sz := @indexConstBoolVec t sz ticks;
     slice t sz := @sliceBoolVec t sz ticks;
     unsignedAdd m n x y := ret (Vector.map2 (@unsignedAddBool m n) x y);
-    unsignedMult m n x y := ret (Monad:=Monad_ident) (Vector.map2 (@unsignedMultBool m n) x y);
+    unsignedMult m n x y := ret (Vector.map2 (@unsignedMultBool m n) x y);
     greaterThanOrEqual m n x y := ret (Vector.map2 (@greaterThanOrEqualBool m n) x y);
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefaultSV ticks (map port_type (circuitOutputs intf)));

--- a/cava/Cava/Acorn/XilinxAdder.v
+++ b/cava/Cava/Acorn/XilinxAdder.v
@@ -76,22 +76,22 @@ Section WithCombinational.
   (* A quick sanity check of the Xilinx adder with carry in and out *)
   Example xilinx_add_17_52:
     combinational (xilinxAdderWithCarry
-                  (false, (N2Bv_sized 8 17, N2Bv_sized 8 52))) =
-                  (N2Bv_sized 8 69, false).
-  Proof. reflexivity. Qed.
+                  ([false], ([N2Bv_sized 8 17], [N2Bv_sized 8 52]))) =
+                  ([N2Bv_sized 8 69], [false]).
+  Proof. vm_compute. reflexivity. Qed.
 
   (* A quick sanity check of the Xilinx adder with no bit-growth *)
   Example xilinx_no_growth_add_17_52:
-    combinational (xilinxAdder (N2Bv_sized 8 17) (N2Bv_sized 8 52)) =
-                  N2Bv_sized 8 69.
+    combinational (xilinxAdder [N2Bv_sized 8 17] [N2Bv_sized 8 52]) =
+                  [N2Bv_sized 8 69].
   Proof. reflexivity. Qed.
 
   (* A proof that the the full-adder is correct. *)
   Lemma xilinxFullAdder_behaviour :
     forall (a : bool) (b : bool) (cin : bool),
-          combinational (xilinxFullAdder (cin, (a, b)))
-          = (xorb cin (xorb a b),
-            (a && b) || (b && cin) || (a && cin)).
+          combinational (xilinxFullAdder ([cin], ([a], [b])))
+          = ([xorb cin (xorb a b)],
+             [(a && b) || (b && cin) || (a && cin)]).
   Proof.
     intros.
     unfold combinational.
@@ -101,4 +101,4 @@ Section WithCombinational.
     all : reflexivity.
   Qed.
 
-End WithCombinational.  
+End WithCombinational.

--- a/cava/Cava/Lib/FullAdder.v
+++ b/cava/Cava/Lib/FullAdder.v
@@ -14,13 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Lists.List.
 Require Import Coq.Bool.Bool.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
-Import MonadNotation.
+Import ListNotations MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.
 
+Require Import Cava.ListUtils.
 Require Import Cava.Acorn.Acorn.
 
 Section WithCava.
@@ -51,18 +53,18 @@ Section WithCava.
 Section Combinational.
 
   (* A proof that the half-adder is correct. *)
-  Lemma halfAdder_behaviour : forall (a : bool) (b : bool),
-                              unIdent (halfAdder (a, b)) = (xorb a b, a && b).
-
+  Lemma halfAdder_behaviour :
+    forall (a : bool) (b : bool),
+      unIdent (halfAdder ([a], [b])) = ([xorb a b], [a && b]).
   Proof.
     auto.
   Qed.
 
   (* A proof that the the full-adder is correct. *)
   Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
-                              combinational (fullAdder (cin, (a, b)))
-                                = (xorb cin (xorb a b),
-                                  (a && b) || (b && cin) || (a && cin)).
+                              combinational (fullAdder ([cin], ([a], [b])))
+                                = ([xorb cin (xorb a b)],
+                                  [(a && b) || (b && cin) || (a && cin)]).
   Proof.
     intros.
     unfold combinational.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -117,9 +117,5 @@ library
                      String
                      Traversable
                      Wf
-                     EquivDec
-                     Injection
-                     List0
-                     RelDec
 
   default-language:  Haskell2010

--- a/silveroak-opentitan/aes/Acorn/AddRoundKey.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKey.v
@@ -46,6 +46,7 @@ Section WithCava.
 End WithCava.
 
 (* Run test as a quick-feedback check *)
+Import List.ListNotations.
 Goal
   (let signal := combType in
    (* convert between flat-vector representation and state type *)
@@ -61,8 +62,8 @@ Goal
                          fun st =>
                            let input := to_state st in
                            let k := to_state key in
-                           let output := unIdent (add_round_key k input) in
-                           from_state output
+                           let output := unIdent (add_round_key [k]%list [input]%list) in
+                           from_state (List.hd (defaultCombValue _) output)
                        | _ => aes_impl step key
                        end) = Success).
 Proof. vm_compute. reflexivity. Qed.

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -52,101 +52,116 @@ Section WithSubroutines.
   Local Notation key := (Vector.t (Vector.t byte 4) 4) (only parsing).
   Local Notation round_index := (Vector.t bool 4) (only parsing).
   Local Notation round_constant := byte (only parsing).
-  Context (sub_bytes:     bool -> state -> ident state)
-          (shift_rows:    bool -> state -> ident state)
-          (mix_columns:   bool -> state -> ident state)
-          (add_round_key : key -> state -> ident state)
-          (key_expand : bool -> round_index -> (key * round_constant) ->
-                        cava (key * round_constant)).
+  Context (sub_bytes:     list bool -> list state -> ident (list state))
+          (shift_rows:    list bool -> list state -> ident (list state))
+          (mix_columns:   list bool -> list state -> ident (list state))
+          (add_round_key : list key -> list state -> ident (list state))
+          (key_expand : list bool -> list round_index -> list key * list round_constant ->
+                        ident (list key * list round_constant)).
+  Context (sub_bytes_spec shift_rows_spec mix_columns_spec inv_sub_bytes_spec
+                          inv_shift_rows_spec inv_mix_columns_spec : state -> state)
+          (add_round_key_spec : state -> key -> state)
+          (key_expand_spec inv_key_expand_spec :
+             nat -> key * round_constant -> key * round_constant).
+  Context
+    (sub_bytes_correct : forall (is_decrypt : bool) (st : state),
+        unIdent (sub_bytes [is_decrypt] [st])
+        = [if is_decrypt then inv_sub_bytes_spec st else sub_bytes_spec st])
+    (shift_rows_correct : forall (is_decrypt : bool) (st : state),
+        unIdent (shift_rows [is_decrypt] [st])
+        = [if is_decrypt then inv_shift_rows_spec st else shift_rows_spec st])
+    (mix_columns_correct : forall (is_decrypt : bool) (st : state),
+        unIdent (mix_columns [is_decrypt] [st])
+        = [if is_decrypt then inv_mix_columns_spec st else mix_columns_spec st])
+    (add_round_key_correct :
+       forall k (st : state), unIdent (add_round_key [k] [st]) = [add_round_key_spec st k])
+    (key_expand_correct :
+       forall (is_decrypt : bool) (round_i : round_index) (k : key) (rcon : round_constant),
+         unIdent (key_expand [is_decrypt] [round_i] ([k],[rcon]))
+         = let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec in
+           let i := N.to_nat (Bv2N round_i) in
+           ([fst (spec i (k, rcon))], [snd (spec i (k, rcon))])).
+  Let add_round_key_spec' : state -> key * round_constant -> state :=
+    (fun st '(k,_) => add_round_key_spec st k).
+  Let inv_mix_columns_key_spec : key * round_constant -> key * round_constant :=
+    (fun '(k,rcon) => (inv_mix_columns_spec k, rcon)).
 
-  Let sub_bytes' : state -> state := (fun st => unIdent (sub_bytes false st)).
-  Let shift_rows' : state -> state := (fun st => unIdent (shift_rows false st)).
-  Let mix_columns' : state -> state := (fun st => unIdent (mix_columns false st)).
-  Let inv_sub_bytes' : state -> state := (fun st => unIdent (sub_bytes true st)).
-  Let inv_shift_rows' : state -> state := (fun st => unIdent (shift_rows true st)).
-  Let inv_mix_columns' : state -> state := (fun st => unIdent (mix_columns true st)).
-  Let inv_mix_columns_key' : key * round_constant -> key * round_constant :=
-    (fun '(k, rcon) => (inv_mix_columns' k, rcon)).
-  (* Note: argument order of add_round_key is switched for spec *)
-  Let add_round_key' : state -> key -> state :=
-    (fun st k => unIdent (add_round_key k st)).
-  Let add_round_key'' : state -> key * round_constant -> state :=
-    (fun st '(k, _) => unIdent (add_round_key k st)).
-  Let key_expand' : nat -> key * round_constant -> key * round_constant :=
-    (fun round_i k_rcon => unIdent (key_expand false (nat_to_bitvec_sized 4 round_i) k_rcon)).
-  Let inv_key_expand' : nat -> key * round_constant -> key * round_constant :=
-    (fun round_i k_rcon => unIdent (key_expand true (nat_to_bitvec_sized 4 round_i) k_rcon)).
+  Hint Rewrite sub_bytes_correct shift_rows_correct mix_columns_correct add_round_key_correct
+       key_expand_correct : to_spec.
 
   Local Ltac simplify_step :=
     first [ destruct_pair_let
           | rewrite N2Nat.id
           | rewrite N2Bv_sized_Bv2N
-          | rewrite pairSel_mkpair
+          | rewrite (pairSel_mkpair (t:=Vec (Vec (Vec Bit 8) 4) 4))
+          | progress autorewrite with to_spec
           | progress simpl_ident ]; [ ].
   Local Ltac simplify := repeat simplify_step.
 
   (* key_expand_and_round is equivalent to interleaved cipher rounds
      (excluding the final round) *)
   Lemma key_expand_and_round_equiv
-        (key_rcon_data : key * round_constant * state)
+        (k : key) (rcon : round_constant) (st : state)
         add_round_key_in_sel round_key_sel
         round_i :
     let round := key_expand_and_round
                    (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
                    sub_bytes shift_rows mix_columns add_round_key
-                   (mix_columns true)
-                   key_expand false in
+                   (mix_columns [true])
+                   key_expand [false] in
     let round_spec := cipher_round_interleaved
-                        add_round_key'' sub_bytes' shift_rows' mix_columns'
-                        key_expand' in
+                        add_round_key_spec' sub_bytes_spec shift_rows_spec mix_columns_spec
+                        key_expand_spec in
     let i := N.to_nat (Bv2N round_i) in
     add_round_key_in_sel = nat_to_bitvec_sized 2 (if Nat.eqb i 0 then 1 else 0) ->
     round_key_sel = false ->
-    unIdent (round key_rcon_data add_round_key_in_sel round_key_sel round_i)
-    = round_spec key_rcon_data i.
+    unIdent (round ([k], [rcon], [st]) [add_round_key_in_sel] [round_key_sel] [round_i])
+    = let '(k',rcon',data') := round_spec (k, rcon, st) i in
+      ([k'],[rcon'],[data']).
   Proof.
     cbv zeta; intros. subst_lets. subst.
     cbv [key_expand_and_round cipher_round cipher_round_interleaved mcompose].
-    cbv [nat_to_bitvec_sized].
-    destruct key_rcon_data as [[key rcon] data]. simplify.
-    rewrite <-surjective_pairing.
+    cbv [nat_to_bitvec_sized]. simplify.
     destruct_one_match;
       compute_expr (nat_to_bitvec_sized 2 0);
       compute_expr (nat_to_bitvec_sized 2 1).
-    all:rewrite mux4_mkpair; autorewrite with vsimpl.
+    all:rewrite (mux4_mkpair (t:=Vec (Vec (Vec Bit 8) 4) 4)).
+    all:simplify.
     all:reflexivity.
   Qed.
 
   (* key_expand_and_round is equivalent to (inverse) interleaved cipher rounds
      (excluding the final round) *)
   Lemma inverse_key_expand_and_round_equiv
-        (key_rcon_data : key * round_constant * state)
+        (k : key) (rcon : round_constant) (st : state)
         add_round_key_in_sel round_key_sel
         round_i :
     let round := key_expand_and_round
                    (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
                    sub_bytes shift_rows mix_columns add_round_key
-                   (mix_columns true) key_expand true in
+                   (mix_columns [true]) key_expand [true] in
     let round_spec := equivalent_inverse_cipher_round_interleaved
-                        add_round_key'' inv_sub_bytes' inv_shift_rows' inv_mix_columns'
-                        inv_key_expand' inv_mix_columns_key' in
+                        add_round_key_spec' inv_sub_bytes_spec inv_shift_rows_spec
+                        inv_mix_columns_spec inv_key_expand_spec
+                        inv_mix_columns_key_spec in
     let i := N.to_nat (Bv2N round_i) in
     add_round_key_in_sel = nat_to_bitvec_sized 2 (if Nat.eqb i 0 then 1 else 0) ->
     (* round_key_sel is true if this is a "middle round" (in this context, not round 0) *)
     (round_key_sel = if Nat.eqb i 0 then false else true) ->
-    unIdent (round key_rcon_data add_round_key_in_sel round_key_sel round_i)
-    = round_spec key_rcon_data i.
+    unIdent (round ([k], [rcon], [st]) [add_round_key_in_sel] [round_key_sel] [round_i])
+    = let '(k',rcon',data') := round_spec (k, rcon, st) i in
+      ([k'],[rcon'],[data']).
   Proof.
     cbv zeta; intros. subst_lets. subst.
     cbv [key_expand_and_round
            cipher_round equivalent_inverse_cipher_round_interleaved mcompose].
-    cbv [nat_to_bitvec_sized]. destruct key_rcon_data as [[key rcon] data].
-    simplify.
+    cbv [nat_to_bitvec_sized]. simplify.
     repeat destruct_one_match; autorewrite with boolsimpl in *; try congruence.
     all: compute_expr (N2Bv_sized 2 (N.of_nat 0)).
     all: compute_expr (N2Bv_sized 2 (N.of_nat 1)).
-    all: rewrite mux4_mkpair; autorewrite with vsimpl.
-    all: rewrite <-surjective_pairing.
+    all: rewrite (mux4_mkpair (t:=Vec (Vec (Vec Bit 8) 4) 4)).
+    all: autorewrite with vsimpl.
+    all: simplify.
     all: reflexivity.
   Qed.
 
@@ -156,38 +171,39 @@ Section WithSubroutines.
            (key_expand_and_round
               (semantics:=CombinationalSemantics)
               (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
-              sub_bytes shift_rows mix_columns add_round_key (mix_columns true) key_expand
-              is_decrypt (round_key, rcon, data) [false; true] false round_i))
+              sub_bytes shift_rows mix_columns add_round_key (mix_columns [true])
+              key_expand [is_decrypt] ([round_key], [rcon], [data])
+              [[false; true]%vector] [false] [round_i]))
     = if is_decrypt
-      then add_round_key' (inv_shift_rows' (inv_sub_bytes' data)) round_key
-      else add_round_key' (shift_rows' (sub_bytes' data)) round_key.
+      then [add_round_key_spec (inv_shift_rows_spec (inv_sub_bytes_spec data)) round_key]
+      else [add_round_key_spec (shift_rows_spec (sub_bytes_spec data)) round_key].
   Proof.
     cbv [key_expand_and_round mcompose]; intros. subst_lets.
-    simplify. rewrite mux4_mkpair. autorewrite with vsimpl.
-    destruct is_decrypt; reflexivity.
+    simplify. rewrite (mux4_mkpair (t:=Vec (Vec (Vec Bit 8) 4) 4)).
+    autorewrite with vsimpl. destruct is_decrypt; simplify; reflexivity.
   Qed.
 
   Lemma cipher_equiv
-        (Nr : nat) (init_rcon : round_constant) (round_indices : list round_index)
+        (Nr : nat) (init_rcon : round_constant) (round_indices : list (list round_index))
         (num_regular_rounds round0 : round_index)
         (first_key last_key : key) (middle_keys : list key) (input : state) :
-    let all_keys_and_rcons := all_keys key_expand' Nr (first_key, init_rcon) in
+    let all_keys_and_rcons := all_keys key_expand_spec Nr (first_key, init_rcon) in
     let all_keys := List.map fst all_keys_and_rcons in
     all_keys = (first_key :: middle_keys ++ [last_key])%list ->
     (* Nr must be at least two and small enough to fit in round_index size *)
     1 < Nr < 2 ^ 4 ->
-    round_indices = map (fun i => nat_to_bitvec_sized 4 i) (List.seq 0 (S Nr)) ->
+    round_indices = map (fun i => [nat_to_bitvec_sized 4 i]) (List.seq 0 (S Nr)) ->
     num_regular_rounds = nat_to_bitvec_sized _ Nr ->
     round0 = nat_to_bitvec_sized _ 0 ->
     unIdent
       (cipher
          (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
-         sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-         key_expand num_regular_rounds round0 false
-         first_key init_rcon round_indices input)
-    = Cipher.cipher
-        _ _ add_round_key' sub_bytes' shift_rows' mix_columns'
-        first_key last_key middle_keys input.
+         sub_bytes shift_rows mix_columns add_round_key (mix_columns [true])
+         key_expand [num_regular_rounds] [round0] [false]
+         [first_key] [init_rcon] round_indices [input])
+    = [Cipher.cipher
+         _ _ add_round_key_spec sub_bytes_spec shift_rows_spec mix_columns_spec
+         first_key last_key middle_keys input].
   Proof.
     cbv zeta; intro Hall_keys; intros. subst.
     cbv [cipher cipher_step mcompose]. simplify.
@@ -198,8 +214,8 @@ Section WithSubroutines.
     pose proof (N.size_nat_le 4 (N.of_nat Nr) ltac:(Lia.lia)).
 
     (* simplify *)
-    cbn [unpeel nor2 and2 norBool andBool CombinationalSemantics
-                bind ret Monad_ident unIdent].
+    cbn [nor2 and2 unpeel CombinationalSemantics]. cbv [lift2].
+    cbn [bind ret Monad_ident unIdent].
 
     (* separate the last round *)
     rewrite foldLM_ident_fold_left.
@@ -209,19 +225,6 @@ Section WithSubroutines.
     rewrite !eqb_nat_to_bitvec_sized, Nat.eqb_refl by Lia.lia.
     match goal with |- context [?n =? 0] => destr (n =? 0); [ Lia.lia | ] end.
     boolsimpl.
-
-    (* simplify expression within loop body and rephrase in terms of round spec *)
-    rewrite fold_left_map.
-    erewrite fold_left_ext_In.
-    2:{
-      intros *. intro Hin. apply in_seq in Hin.
-      autorewrite with natsimpl in *. repeat destruct_pair_let.
-      rewrite !eqb_nat_to_bitvec_sized by Lia.lia.
-      rewrite key_expand_and_round_equiv
-        by first [ boolsimpl; reflexivity
-                 | rewrite nat_to_bitvec_to_nat by Lia.lia;
-                   repeat destruct_one_match; (reflexivity || Lia.lia) ].
-      instantiate_app_by_reflexivity. }
 
     (* Get all states from key expansion *)
     map_inversion Hall_keys; subst.
@@ -235,26 +238,50 @@ Section WithSubroutines.
     erewrite <-cipher_interleaved_equiv by eassumption.
     cbv [cipher_interleaved]. repeat destruct_pair_let.
 
-    (* rewrite last round in terms of subroutines *)
-    rewrite key_expand_and_round_last_equiv.
-
     (* prove using loop invariant *)
+    rewrite fold_left_map.
     factor_out_loops.
-    eapply fold_left_double_invariant_seq with (I:=fun _ x y => x = y).
+    eapply fold_left_double_invariant_seq
+      with (I:=fun _ x y => y = ([fst (fst x)], [snd (fst x)], [snd x])).
     { (* invariant holds at start of loop *)
       reflexivity. }
     { (* invariant holds through loop body *)
-      intros; subst. subst add_round_key''.
+      intros; subst.
+      autorewrite with natsimpl in *. repeat destruct_pair_let.
+      rewrite !eqb_nat_to_bitvec_sized by Lia.lia.
+      erewrite (unpeelVecList_cons_singleton (A:=Bit))
+        by first [ Lia.lia | reflexivity
+                   | intros *; cbn [InV];
+                     autorewrite with vsimpl;
+                     intros [? | ?]; [ | tauto];
+                     subst; reflexivity ].
+      rewrite !pad_combine_eq by length_hammer.
+      cbn [combine map].
+      rewrite key_expand_and_round_equiv
+        by first [ boolsimpl; reflexivity
+                 | rewrite nat_to_bitvec_to_nat by Lia.lia;
+                   repeat destruct_one_match; (reflexivity || Lia.lia) ].
       rewrite nat_to_bitvec_to_nat by Lia.lia.
       cbv [cipher_round_interleaved].
-      repeat destruct_pair_let. subst_lets.
+      repeat destruct_pair_let. subst_lets. cbn [fst snd].
+      rewrite <-surjective_pairing.
       reflexivity. }
     { (* invariant implies postcondition *)
-      intros; subst; reflexivity. }
+      intros; subst. cbn [fst snd].
+      erewrite (unpeelVecList_cons_singleton (A:=Bit))
+        by first [ Lia.lia | reflexivity
+                   | intros *; cbn [InV];
+                     autorewrite with vsimpl;
+                     intros [? | ?]; [ | tauto];
+                     subst; reflexivity ].
+      rewrite !pad_combine_eq by length_hammer.
+      cbn [combine map fst snd].
+      rewrite key_expand_and_round_last_equiv.
+      reflexivity. }
   Qed.
 
-  Lemma inv_mix_columns_key'_map keys :
-    map fst (map inv_mix_columns_key' keys) = map inv_mix_columns' (map fst keys).
+  Lemma inv_mix_columns_key_spec_map keys :
+    map fst (map inv_mix_columns_key_spec keys) = map inv_mix_columns_spec (map fst keys).
   Proof.
     rewrite !map_map; apply map_ext.
     intros; subst_lets. cbv beta.
@@ -262,26 +289,26 @@ Section WithSubroutines.
   Qed.
 
   Lemma inverse_cipher_equiv
-        (Nr : nat) (init_rcon : round_constant) (round_indices : list round_index)
+        (Nr : nat) (init_rcon : round_constant) (round_indices : list (list round_index))
         (num_regular_rounds round0 : round_index)
         (first_key last_key : key) (middle_keys : list key) (input : state) :
-    let all_keys_and_rcons := all_keys inv_key_expand' Nr (first_key, init_rcon) in
+    let all_keys_and_rcons := all_keys inv_key_expand_spec Nr (first_key, init_rcon) in
     let all_keys := List.map fst all_keys_and_rcons in
     all_keys = (first_key :: middle_keys ++ [last_key])%list ->
     (* Nr must be at least two and small enough to fit in round_index size *)
     1 < Nr < 2 ^ 4 ->
-    round_indices = map (fun i => nat_to_bitvec_sized 4 i) (List.seq 0 (S Nr)) ->
+    round_indices = map (fun i => [nat_to_bitvec_sized 4 i]) (List.seq 0 (S Nr)) ->
     num_regular_rounds = nat_to_bitvec_sized _ Nr ->
     round0 = nat_to_bitvec_sized _ 0 ->
     unIdent
       (cipher
          (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
-         sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-         key_expand num_regular_rounds round0 true
-         first_key init_rcon round_indices input)
-    = Cipher.equivalent_inverse_cipher
-        _ _ add_round_key' inv_sub_bytes' inv_shift_rows' inv_mix_columns'
-        first_key last_key (map inv_mix_columns' middle_keys) input.
+         sub_bytes shift_rows mix_columns add_round_key (mix_columns [true])
+         key_expand [num_regular_rounds] [round0] [true]
+         [first_key] [init_rcon] round_indices [input])
+    = [Cipher.equivalent_inverse_cipher
+         _ _ add_round_key_spec inv_sub_bytes_spec inv_shift_rows_spec inv_mix_columns_spec
+         first_key last_key (map inv_mix_columns_spec middle_keys) input].
   Proof.
     cbv zeta; intro Hall_keys; intros. subst.
     cbv [cipher cipher_step mcompose]. simplify.
@@ -292,8 +319,8 @@ Section WithSubroutines.
     pose proof (N.size_nat_le 4 (N.of_nat Nr) ltac:(Lia.lia)).
 
     (* simplify *)
-    cbn [unpeel nor2 and2 norBool andBool CombinationalSemantics
-                bind ret Monad_ident unIdent].
+    cbn [nor2 and2 unpeel CombinationalSemantics]. cbv [lift2].
+    cbn [bind ret Monad_ident unIdent].
 
     (* separate the last round *)
     rewrite foldLM_ident_fold_left.
@@ -304,19 +331,6 @@ Section WithSubroutines.
     match goal with |- context [?n =? 0] => destr (n =? 0); [ Lia.lia | ] end.
     boolsimpl.
 
-    (* simplify expression within loop body and rephrase in terms of round spec *)
-    rewrite fold_left_map.
-    erewrite fold_left_ext_In.
-    2:{
-      intros *. intro Hin. apply in_seq in Hin.
-      autorewrite with natsimpl in *. repeat destruct_pair_let.
-      rewrite !eqb_nat_to_bitvec_sized by Lia.lia.
-      rewrite inverse_key_expand_and_round_equiv
-        by first [ boolsimpl; reflexivity
-                 | rewrite nat_to_bitvec_to_nat by Lia.lia;
-                   repeat destruct_one_match; (reflexivity || Lia.lia) ].
-      instantiate_app_by_reflexivity. }
-
     (* Extract information from key expansion expression *)
     map_inversion Hall_keys. subst.
     match goal with H : @eq (list (_ * _)) _ (_ :: _ ++ [_])%list |- _ =>
@@ -325,29 +339,53 @@ Section WithSubroutines.
     (* representation change; use full key-expansion state (key * round_constant) *)
     erewrite equivalent_inverse_cipher_change_key_rep
       with (projkey:=@fst key round_constant)
-           (middle_keys_alt:=List.map inv_mix_columns_key' _)
-      by (reflexivity || apply inv_mix_columns_key'_map).
+           (middle_keys_alt:=List.map inv_mix_columns_key_spec _)
+      by (reflexivity || apply inv_mix_columns_key_spec_map).
 
     erewrite <-equivalent_inverse_cipher_interleaved_equiv by eauto.
     cbv [equivalent_inverse_cipher_interleaved].
     repeat destruct_pair_let.
 
-    (* rewrite last round in terms of subroutines *)
-    rewrite key_expand_and_round_last_equiv.
-
     (* prove using loop invariant *)
+    rewrite fold_left_map.
     factor_out_loops.
-    eapply fold_left_double_invariant_seq with (I:=fun _ x y => x = y).
+    eapply fold_left_double_invariant_seq
+      with (I:=fun _ x y => y = ([fst (fst x)], [snd (fst x)], [snd x])).
     { (* invariant holds at start of loop *)
       reflexivity. }
     { (* invariant holds through loop body *)
-      intros; subst. subst add_round_key''.
+      intros; subst.
+      autorewrite with natsimpl in *. repeat destruct_pair_let.
+      rewrite !eqb_nat_to_bitvec_sized by Lia.lia.
+      erewrite (unpeelVecList_cons_singleton (A:=Bit))
+        by first [ Lia.lia | reflexivity
+                   | intros *; cbn [InV];
+                     autorewrite with vsimpl;
+                     intros [? | ?]; [ | tauto];
+                     subst; reflexivity ].
+      rewrite !pad_combine_eq by length_hammer.
+      cbn [combine map].
+      rewrite inverse_key_expand_and_round_equiv
+        by first [ boolsimpl; reflexivity
+                 | rewrite nat_to_bitvec_to_nat by Lia.lia;
+                   repeat destruct_one_match; (reflexivity || Lia.lia) ].
       rewrite nat_to_bitvec_to_nat by Lia.lia.
       cbv [equivalent_inverse_cipher_round_interleaved].
-      repeat destruct_pair_let. subst_lets.
+      subst_lets. repeat destruct_pair_let. cbn [fst snd].
+      rewrite <-surjective_pairing.
       reflexivity. }
     { (* invariant implies postcondition *)
-      intros; subst; reflexivity. }
+      intros; subst. cbn [fst snd].
+      erewrite (unpeelVecList_cons_singleton (A:=Bit))
+        by first [ Lia.lia | reflexivity
+                   | intros *; cbn [InV];
+                     autorewrite with vsimpl;
+                     intros [? | ?]; [ | tauto];
+                     subst; reflexivity ].
+      rewrite !pad_combine_eq by length_hammer.
+      cbn [combine map fst snd].
+      rewrite key_expand_and_round_last_equiv.
+      reflexivity. }
   Qed.
 
 End WithSubroutines.

--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -1,8 +1,10 @@
 Axioms:
 sub_bytes_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (sub_bytes false (to_cols_bitvecs st))) =
-    AES256.sub_bytes st
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (sub_bytes [is_decrypt] [st]) =
+    [if is_decrypt
+     then to_cols_bitvecs (inv_sub_bytes (from_cols_bitvecs st))
+     else to_cols_bitvecs (AES256.sub_bytes (from_cols_bitvecs st))]
 sub_bytes
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->
@@ -10,9 +12,11 @@ sub_bytes
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 shift_rows_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (shift_rows false (to_cols_bitvecs st))) =
-    AES256.shift_rows st
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (shift_rows [is_decrypt] [st]) =
+    [if is_decrypt
+     then to_cols_bitvecs (inv_shift_rows (from_cols_bitvecs st))
+     else to_cols_bitvecs (AES256.shift_rows (from_cols_bitvecs st))]
 shift_rows
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->
@@ -20,10 +24,11 @@ shift_rows
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 mix_columns_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs
-      (combinational (mix_columns false (to_cols_bitvecs st))) =
-    AES256.mix_columns st
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (mix_columns [is_decrypt] [st]) =
+    [if is_decrypt
+     then to_cols_bitvecs (inv_mix_columns (from_cols_bitvecs st))
+     else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
 mix_columns
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->
@@ -32,10 +37,13 @@ mix_columns
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
 key_expand_equiv
-  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
-    i < 16 ->
-    combinational (key_expand false (nat_to_bitvec_sized 4 i) k) =
-    unflatten_key (key_expand_spec i (flatten_key k))
+  : forall (is_decrypt : bool) (round_i : t bool 4)
+      (k : t (t (t bool 8) 4) 4) (rcon : t bool 8),
+    combinational (key_expand [is_decrypt] [round_i] ([k], [rcon])) =
+    (let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec
+       in
+     let kr := spec (N.to_nat (Bv2N round_i)) (flatten_key (k, rcon)) in
+     ([to_cols_bitvecs (fst kr)], [snd kr]))
 key_expand
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->
@@ -43,21 +51,4 @@ key_expand
     signal (Vec Bit 4) ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8))
-inv_sub_bytes_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (sub_bytes true (to_cols_bitvecs st))) =
-    inv_sub_bytes st
-inv_shift_rows_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (shift_rows true (to_cols_bitvecs st))) =
-    inv_shift_rows st
-inv_mix_columns_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (mix_columns true (to_cols_bitvecs st))) =
-    inv_mix_columns st
 inv_key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
-inv_key_expand_equiv
-  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
-    i < 16 ->
-    combinational (key_expand true (nat_to_bitvec_sized 4 i) k) =
-    unflatten_key (inv_key_expand_spec i (flatten_key k))

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -1,8 +1,10 @@
 Axioms:
 sub_bytes_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (sub_bytes false (to_cols_bitvecs st))) =
-    AES256.sub_bytes st
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (sub_bytes [is_decrypt] [st]) =
+    [if is_decrypt
+     then to_cols_bitvecs (inv_sub_bytes (from_cols_bitvecs st))
+     else to_cols_bitvecs (AES256.sub_bytes (from_cols_bitvecs st))]
 sub_bytes
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->
@@ -10,9 +12,11 @@ sub_bytes
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 shift_rows_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (shift_rows false (to_cols_bitvecs st))) =
-    AES256.shift_rows st
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (shift_rows [is_decrypt] [st]) =
+    [if is_decrypt
+     then to_cols_bitvecs (inv_shift_rows (from_cols_bitvecs st))
+     else to_cols_bitvecs (AES256.shift_rows (from_cols_bitvecs st))]
 shift_rows
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->
@@ -20,10 +24,11 @@ shift_rows
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 mix_columns_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs
-      (combinational (mix_columns false (to_cols_bitvecs st))) =
-    AES256.mix_columns st
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (mix_columns [is_decrypt] [st]) =
+    [if is_decrypt
+     then to_cols_bitvecs (inv_mix_columns (from_cols_bitvecs st))
+     else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
 mix_columns_add_round_key_comm
   : forall st k : t (t Byte.byte 4) 4,
     let to_bits := fun x : t (t Byte.byte 4) 4 => to_cols_bits (from_cols x)
@@ -45,10 +50,13 @@ mix_columns
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
 key_expand_equiv
-  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
-    i < 16 ->
-    combinational (key_expand false (nat_to_bitvec_sized 4 i) k) =
-    unflatten_key (key_expand_spec i (flatten_key k))
+  : forall (is_decrypt : bool) (round_i : t bool 4)
+      (k : t (t (t bool 8) 4) 4) (rcon : t bool 8),
+    combinational (key_expand [is_decrypt] [round_i] ([k], [rcon])) =
+    (let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec
+       in
+     let kr := spec (N.to_nat (Bv2N round_i)) (flatten_key (k, rcon)) in
+     ([to_cols_bitvecs (fst kr)], [snd kr]))
 key_expand
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->
@@ -59,21 +67,4 @@ key_expand
 inverse_mix_columns
   : forall (Nb : nat) (st : t (t Byte.byte 4) Nb),
     MixColumns.inv_mix_columns (MixColumns.mix_columns st) = st
-inv_sub_bytes_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (sub_bytes true (to_cols_bitvecs st))) =
-    inv_sub_bytes st
-inv_shift_rows_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (shift_rows true (to_cols_bitvecs st))) =
-    inv_shift_rows st
-inv_mix_columns_equiv
-  : forall st : t bool 128,
-    from_cols_bitvecs (combinational (mix_columns true (to_cols_bitvecs st))) =
-    inv_mix_columns st
 inv_key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
-inv_key_expand_equiv
-  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
-    i < 16 ->
-    combinational (key_expand true (nat_to_bitvec_sized 4 i) k) =
-    unflatten_key (inv_key_expand_spec i (flatten_key k))

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -60,12 +60,14 @@ Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 
 Lemma mux2Correct {A} (sel : seqType Bit) (f t : seqType A) :
-  sequential (mux2 sel f t) = map2 (fun (sel : bool) ft => if sel then snd ft else fst ft)
-                                   sel (combine f t).
+  sequential (mux2 sel f t) = map (fun (f_t_sel : combType A * combType A * bool) =>
+                                     let '(f, t, sel) := f_t_sel in
+                                     if sel then t else f)
+                                   (pad_combine (pad_combine f t) sel).
 Proof.
   intros; cbv [mux2 sequential]. seqsimpl.
-  cbv [pairSel pairSelList pairSelBool SequentialCombSemantics].
-  apply map2_ext; intros; reflexivity.
+  cbv [pairSel pairSelList CombinationalSemantics]. fold combType.
+  apply map_ext; intros. reflexivity.
 Qed.
 Hint Rewrite @mux2Correct using solve [eauto] : seqsimpl.
 

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -57,7 +57,7 @@ Definition addNSpec {n} (a b : seqType (Vec Bit n)) :=
   map2 bvadd a b.
 
 Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (semantics:=SequentialCombSemantics) (a, b)) = addNSpec a b.
+  sequential (addN (semantics:=CombinationalSemantics) (a, b)) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -46,17 +46,21 @@ Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
   map2 bvadd a b.
 
 Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (semantics:=SequentialCombSemantics) (a, b)) = addNSpec a b.
+  unIdent (addN (semantics:=CombinationalSemantics) (a, b)) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
+
+Axiom magic : forall {t}, t.
 
 Lemma countForkCorrect:
   forall (i : Bvector 8) (s : Bvector 8),
     sequential ((addN >=> fork2) ([i], [s]))
     = (addNSpec [i] [s], addNSpec [i] [s]).
 Proof.
-  intros; cbv [addNSpec mcompose].
-  seqsimpl. reflexivity.
+  intros; cbv [mcompose].
+  cbn [bind ret Monad_ident].
+  rewrite fork2Correct, !addNCorrect;
+  reflexivity.
 Qed.
 Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/Instantiate.v
+++ b/tests/Instantiate.v
@@ -66,7 +66,8 @@ Definition instantiate_tb_inputs : list (bool * bool * bool) :=
 
 (* Compute expected outputs. *)
 Definition instantiate_tb_expected_outputs : list bool :=
-  map (fun i => combinational (nand3_gate i)) instantiate_tb_inputs.
+  map (fun '(i0,i1,i2) => List.hd false (combinational (nand3_gate ([i0],[i1],[i2])%list)))
+      instantiate_tb_inputs.
 
 Definition instantiate_tb :=
   testBench "instantiate_tb" nand3Interface instantiate_tb_inputs instantiate_tb_expected_outputs.

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -46,11 +46,11 @@ Definition bv3_7  := N2Bv_sized 3  7.
 Definition bv5_15 := N2Bv_sized 5 15.
 
 (* Check 3 * 5 = 30 *)
-Example mult3_5 : combinational (unsignedMult bv2_3 bv3_5) = bv5_15.
+Example mult3_5 : combinational (unsignedMult [bv2_3] [bv3_5]) = [bv5_15].
 Proof. reflexivity. Qed.
 
 (* Check 3 * 5 = 30 *)
-Example mult3_5_top : combinational (multiplier (bv2_3, bv3_5)) = bv5_15.
+Example mult3_5_top : combinational (multiplier ([bv2_3], [bv3_5])) = [bv5_15].
 Proof. reflexivity. Qed.
 
 (******************************************************************************)
@@ -72,7 +72,9 @@ Definition mult2_3_5_tb_inputs
   := [(bv2_3, bv3_5); (bv2_3, bv3_7); (bv2_0, bv3_0)].
 
 Definition mult2_3_5_tb_expected_outputs
-  := map (fun ab => combinational (multiplier ab)) mult2_3_5_tb_inputs.
+  := map (fun '(a,b) => List.hd (Vector.const false _)
+                         (combinational (multiplier ([a],[b])%list)))
+         mult2_3_5_tb_inputs.
 
 Definition  mult2_3_5_tb
   := testBench "mult2_3_5_tb" mult2_3_5Interface

--- a/tests/xilinx/LUTTests.v
+++ b/tests/xilinx/LUTTests.v
@@ -66,7 +66,8 @@ End WithCava.
   Definition lut1_inv_tb_inputs := [false; true].
 
   Definition lut1_inv_tb_expected_outputs : list bool :=
-    map (fun i => combinational (lut1_inv i)) lut1_inv_tb_inputs.
+    map (fun i => List.hd (defaultCombValue _) (combinational (lut1_inv [i]%list)))
+        lut1_inv_tb_inputs.
 
   Definition lut1_inv_tb :=
     testBench "lut1_inv_tb" lut1_inv_Interface
@@ -88,7 +89,8 @@ Definition lut2_and_tb_inputs : list (bool * bool) :=
  [(false, false); (false, true); (true, false); (true, true)].
 
  Definition lut2_and_tb_expected_outputs : list bool :=
-  map (fun i => combinational (lut2_and i)) lut2_and_tb_inputs.
+   map (fun '(i0,i1) => List.hd (defaultCombValue _)
+                             (combinational (lut2_and ([i0],[i1])%list))) lut2_and_tb_inputs.
 
 Definition lut2_and_tb :=
   testBench "lut2_and_tb" lut2_and_Interface
@@ -115,7 +117,9 @@ Definition lut3_mux_tb_inputs : list (bool * bool * bool) :=
   (true, true, true)].
 
  Definition lut3_mux_tb_expected_outputs : list bool :=
-  map (fun i => combinational (lut3_mux i)) lut3_mux_tb_inputs.
+   map (fun '(i0,i1,i2) =>
+          List.hd (defaultCombValue _) (combinational (lut3_mux ([i0],[i1],[i2])%list)))
+       lut3_mux_tb_inputs.
 
 Definition lut3_mux_tb :=
   testBench "lut3_mux_tb" lut3_mux_Interface
@@ -141,7 +145,10 @@ Definition lut4_and_tb_inputs : list (bool * bool * bool * bool) :=
   (true, true, true, true)].
 
 Definition lut4_and_tb_expected_outputs : list bool :=
-  map (fun i => combinational (lut4_and i)) lut4_and_tb_inputs.
+  map (fun '(i0,i1,i2,i3) =>
+         List.hd (defaultCombValue _)
+                 (combinational (lut4_and ([i0],[i1],[i2],[i3])%list)))
+      lut4_and_tb_inputs.
 
 Definition lut4_and_tb :=
   testBench "lut4_and_tb" lut4_and_Interface
@@ -168,7 +175,10 @@ Definition lut5_and_tb_inputs : list (bool * bool * bool * bool * bool) :=
   (true, true, true, true, true)].
 
 Definition lut5_and_tb_expected_outputs : list bool :=
-  map (fun i => combinational (lut5_and i)) lut5_and_tb_inputs.
+  map (fun '(i0,i1,i2,i3,i4) =>
+         List.hd (defaultCombValue _)
+                 (combinational (lut5_and ([i0],[i1],[i2],[i3],[i4])%list)))
+      lut5_and_tb_inputs.
 
 Definition lut5_and_tb :=
   testBench "lut5_and_tb" lut5_and_Interface
@@ -195,8 +205,12 @@ Definition lut6_and_tb_inputs : list (bool * bool * bool * bool * bool * bool) :
  [(false, false, false, false, false, false);
   (true, true, true, true, true, true)].
 
+
 Definition lut6_and_tb_expected_outputs : list bool :=
-  map (fun i => combinational (lut6_and i)) lut6_and_tb_inputs.
+  map (fun '(i0,i1,i2,i3,i4,i5) =>
+         List.hd (defaultCombValue _)
+                 (combinational (lut6_and ([i0],[i1],[i2],[i3],[i4],[i5])%list)))
+      lut6_and_tb_inputs.
 
 Definition lut6_and_tb :=
   testBench "lut6_and_tb" lut6_and_Interface


### PR DESCRIPTION
Resolves #422 

This PR redefines `CombinationalSemantics` on a list datatype (previously `SequentialCombSemantics`), and adapts all our existing combinational proofs/tests to be proofs over singleton lists. The change is fairly huge, because I had to change pretty much every circuit proof or test in the repository to get it to compile. To make reviewing easier, I separated it into two commits, one for "boilerplate" changes that are essentially just putting list expressions around things, and one for the changes to the core typeclasses and changes that required actual modification of proofs. **Definitely best reviewed commit-by-commit**.

In the future, we probably want to prove our combinational circuits for any length of input, rather than just for singleton lists; this was just the quickest, lowest code-churn way I could get the repo to build. The singleton-list proofs should be enough for AES, since the combinational part is wrapped in a top-level loop that calls the body on singleton input.

~This is a draft PR for now because, given that this change somewhat significantly increases proof complexity, I'd like to do a little more investigation into alternatives before we commit to it. But I figured it might be useful to put it up for viewing and discussion anyway.~

One lingering TODO here is that the `UnsignedAdderProofs` are currently broken and admitted -- they're not on the critical path to AES and it seemed like the proof-porting process wouldn't be straightforward, so I thought I'd save that change for a later PR.