### PR TITLE
Make some AES state representations little-endian

### DIFF
--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -39,6 +39,7 @@ Require Import AcornAes.CipherEquivalence.
 Require Import AcornAes.Common.
 Import ListNotations.
 Import Common.Notations.
+Import StateTypeConversions.LittleEndian.
 
 Local Notation round_constant := (Vec Bit 8) (only parsing).
 Local Notation round_index := (Vec Bit 4) (only parsing).

--- a/silveroak-opentitan/aes/Acorn/AddRoundKey.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKey.v
@@ -51,9 +51,9 @@ Goal
   (let signal := combType in
    (* convert between flat-vector representation and state type *)
    let to_state : Vector.t bool 128 -> signal state :=
-       fun st => map reshape (to_cols_bits st) in
+       fun st => map reshape (LittleEndian.to_cols_bits st) in
    let from_state : signal state -> Vector.t bool 128 :=
-       fun st => from_cols_bits (map flatten st) in
+       fun st => LittleEndian.from_cols_bits (map flatten st) in
    (* run encrypt test with this version of add_round_key plugged in *)
    aes_test_encrypt Matrix
                     (fun step key =>

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
@@ -29,6 +29,7 @@ Import ListNotations.
 Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
 Require Import AcornAes.AddRoundKey.
+Import StateTypeConversions.LittleEndian.
 
 Existing Instance CombinationalSemantics.
 

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -31,10 +31,10 @@ mix_columns_equiv
      else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
 mix_columns_add_round_key_comm
   : forall st k : t (t Byte.byte 4) 4,
-    let to_bits := fun x : t (t Byte.byte 4) 4 => to_cols_bits (from_cols x)
-      in
+    let to_bits :=
+      fun x : t (t Byte.byte 4) 4 => to_cols_bits (BigEndian.from_cols x) in
     let from_bits :=
-      fun x : t (t bool (4 * 8)) 4 => to_cols (from_cols_bits x) in
+      fun x : t (t bool (4 * 8)) 4 => BigEndian.to_cols (from_cols_bits x) in
     AesSpec.AddRoundKey.add_round_key 32 4
       (to_bits (MixColumns.inv_mix_columns st))
       (to_bits (MixColumns.inv_mix_columns k)) =

--- a/silveroak-opentitan/aes/Spec/AES256.v
+++ b/silveroak-opentitan/aes/Spec/AES256.v
@@ -27,14 +27,16 @@ Require Import AesSpec.Cipher.
 Require Import AesSpec.CommuteProperties.
 Require Import AesSpec.StateTypeConversions.
 
+Import StateTypeConversions.BigEndian.
+
 (* TODO: these definitions need to be filled in once the mixcolumns spec is finalized *)
 Axiom inverse_mix_columns :
   forall Nb (st : Vector.t _ Nb), inv_mix_columns (mix_columns st) = st.
 
 Axiom mix_columns_add_round_key_comm :
   forall (st k : Vector.t _ 4),
-    let to_bits x := to_cols_bits (from_cols x) in
-    let from_bits x := to_cols (from_cols_bits x) in
+    let to_bits x := LittleEndian.to_cols_bits (from_cols x) in
+    let from_bits x := to_cols (LittleEndian.from_cols_bits x) in
     add_round_key 32 4
                   (to_bits (inv_mix_columns st))
                   (to_bits (inv_mix_columns k))
@@ -52,9 +54,9 @@ Section Equivalence.
   Let Nr := 14%nat. (* From FIPS -- number of rounds *)
 
   Definition add_round_key (st : state) (k : round_key) : state :=
-    let st := to_cols_bits st in
-    let k := to_cols_bits k in
-    from_cols_bits (add_round_key bits_per_word Nb st k).
+    let st := LittleEndian.to_cols_bits st in
+    let k := LittleEndian.to_cols_bits k in
+    LittleEndian.from_cols_bits (add_round_key bits_per_word Nb st k).
 
   Definition sub_bytes (st : state) : state :=
     from_list_rows (sub_bytes (to_list_rows st)).

--- a/silveroak-opentitan/aes/Spec/AES256_Assumptions.out
+++ b/silveroak-opentitan/aes/Spec/AES256_Assumptions.out
@@ -2,11 +2,11 @@ Axioms:
 mix_columns_add_round_key_comm
   : forall st k : Vector.t (Vector.t Byte.byte 4) 4,
     let to_bits :=
-      fun x : Vector.t (Vector.t Byte.byte 4) 4 => to_cols_bits (from_cols x)
-      in
+      fun x : Vector.t (Vector.t Byte.byte 4) 4 =>
+      LittleEndian.to_cols_bits (from_cols x) in
     let from_bits :=
       fun x : Vector.t (Vector.t bool (4 * 8)) 4 =>
-      to_cols (from_cols_bits x) in
+      to_cols (LittleEndian.from_cols_bits x) in
     AddRoundKey.add_round_key 32 4 (to_bits (MixColumns.inv_mix_columns st))
       (to_bits (MixColumns.inv_mix_columns k)) =
     to_bits

--- a/silveroak-opentitan/aes/Spec/Tests/CipherTest.v
+++ b/silveroak-opentitan/aes/Spec/Tests/CipherTest.v
@@ -24,6 +24,8 @@ Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
 Local Open Scope string_scope.
 
+Import StateTypeConversions.BigEndian.
+
 Local Notation byte := Byte.byte (only parsing).
 Local Notation round_key := (Vector.t bool 128) (only parsing).
 Local Notation state := (Vector.t bool 128) (only parsing).


### PR DESCRIPTION
Thanks to @smore-lore for flagging this one!

There's a conflict between Coq and FIPS in terms of endianness: Coq (and Cava, by extension) expects little-endian bit vectors, and FIPS is all big-endian. Previously, the conversions in `StateTypeConversions` handled this by taking a little-endian flat bitvector and turning it into big-endian rows and columns, which was most convenient for working with the FIPS-based subroutine specifications. However, some of the type conversions are meant for _implementations_, which will use Cava/Coq and therefore are best left little-endian.

The `cols_bits` and `cols_bitvecs` representationsare used almost exclusively in implementation rather than specification (`add_round_key` uses this representation in specification, but since it's just an xor it doesn't care about endianness). So this PR converts them to little-endian representations to make implementation more convenient.

This PR also separates the type conversions into two modules `BigEndian` and `LittleEndian` that have to be separately imported, to make it clearer what representation is being used. Now, when you import `StateTypeConversions`, you have `BigEndian.to_cols` and `LittleEndian.to_cols_bitvecs` instead of `to_cols` and `to_cols_bitvecs`. You can `Import BIgEndian` or `Import LittleEndian`, but I'd recommend importing at most one of these to avoid confusion.