### PR TITLE
Remove now redundant mux2 from Combinators

### DIFF
--- a/acorn-examples/MuxExamples.v
+++ b/acorn-examples/MuxExamples.v
@@ -23,7 +23,6 @@ Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
-Require Import Cava.Lib.Multiplexers.
 
 Require Import Coq.Bool.Bvector.
 Import Vector.VectorNotations.
@@ -47,19 +46,19 @@ End WithCava.
 Local Close Scope vector_scope.
 
 (******************************************************************************)
-(* mux2_1                                                                     *)
+(* muxPair tests                                                              *)
 (******************************************************************************)
 
-Example m1: combinational (mux2 (A:=Bit) [true] ([false], [false])) = [false].
+Example m1: combinational (muxPair (A:=Bit) [true] ([false], [false])) = [false].
 Proof. reflexivity. Qed.
 
-Example m2: combinational (mux2 (A:=Bit) [false] ([false], [true])) = [false].
+Example m2: combinational (muxPair (A:=Bit) [false] ([false], [true])) = [false].
 Proof. reflexivity. Qed.
 
-Example m3: combinational (mux2 (A:=Bit) [true] ([true], [false])) = [false].
+Example m3: combinational (muxPair (A:=Bit) [true] ([true], [false])) = [false].
 Proof. reflexivity. Qed.
 
-Example m4: combinational (mux2 (A:=Bit) [false] ([true], [false])) = [true].
+Example m4: combinational (muxPair (A:=Bit) [false] ([true], [false])) = [true].
 Proof. reflexivity. Qed.
 
 Definition mux2_1_Interface
@@ -69,7 +68,7 @@ Definition mux2_1_Interface
      [].
 
 Definition mux2_1Netlist
-  := makeNetlist mux2_1_Interface (fun '(sel, a, b) => mux2 sel (a, b)).
+  := makeNetlist mux2_1_Interface (fun '(sel, a, b) => muxPair sel (a, b)).
 
 Definition mux2_1_tb_inputs :=
   [(false, false, true);
@@ -79,7 +78,7 @@ Definition mux2_1_tb_inputs :=
 
 Definition mux2_1_tb_expected_outputs
   := map (fun '(i0,i1,i2) =>
-            List.hd false (combinational (mux2 (A:=Bit) [i0] ([i1],[i2]))))
+            List.hd false (combinational (muxPair (A:=Bit) [i0] ([i1],[i2]))))
          mux2_1_tb_inputs.
 
 Definition mux2_1_tb

--- a/cava/Cava/Acorn/Acorn.v
+++ b/cava/Cava/Acorn/Acorn.v
@@ -20,3 +20,4 @@ Require Export Cava.Acorn.CombinationalMonad.
 Require Export Cava.Acorn.Sequential.
 Require Export Cava.Acorn.Combinators.
 Require Export Cava.Acorn.NetlistGeneration.
+Require Export Cava.Acorn.CavaPrelude.

--- a/cava/Cava/Acorn/CavaPrelude.v
+++ b/cava/Cava/Acorn/CavaPrelude.v
@@ -21,17 +21,22 @@ Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
 Import MonadNotation.
 
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.CavaClass.
+Require Import Cava.Signal.
 
 Section WithCava.
   Context {signal} `{Cava signal} `{Monad cava}.
 
-(* A two to one multiplexer that takes its two arguments as a pair rather
-   than as a 2 element vector which is what indexAt works over. *)
+  (* Ideally muxPair would be in Cava.Lib but we need to use it in the Cava
+     core modules for a definition is Sequential.v
+  *)
 
-Definition mux2 {A : SignalType}
-                (sel : signal Bit)
-                (ab : signal A * signal A) : cava (signal A) :=
+  (* A two to one multiplexer that takes its two arguments as a pair rather
+     than as a 2 element vector which is what indexAt works over. *)
+
+  Definition muxPair {A : SignalType}
+                     (sel : signal Bit)
+                     (ab : signal A * signal A) : cava (signal A) :=
   let (a, b) := ab in
   ret (indexAt (unpeel [a; b]) (unpeel [sel])).
 

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -87,12 +87,6 @@ Section WithCava.
                        cava (signal A * (signal B * signal C)) :=
    let '((a, b), c) := i in
    ret (a, (b, c)).
-
-  Definition mux2 {A : SignalType}
-                  (sel : signal Bit)
-                  (i : signal A * signal A) :
-                  cava (signal A) :=
-  ret (pairSel sel (mkpair (fst i) (snd i))).
  
   (* Use a circuit to zip together two vectors. *)
   Definition zipWith {A B C : SignalType} {n : nat}

--- a/cava/Cava/Acorn/Sequential.v
+++ b/cava/Cava/Acorn/Sequential.v
@@ -14,7 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-
 From Coq Require Import Lists.List.
 Import ListNotations.
 Require Import ExtLib.Structures.Monads.
@@ -30,6 +29,7 @@ Require Import Cava.Tactics.
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.CombinationalMonad.
 Require Import Cava.Acorn.Combinators.
+Require Import Cava.Acorn.CavaPrelude.
 
 (* Given two sequential inputs, combine them by combining all the elements of
    the first with the elements of the second that *do not overlap* when the
@@ -127,7 +127,7 @@ Instance SequentialSemantics : CavaSeq CombinationalSemantics :=
                        pairLeft >=>    (* ((i, state), state) *)
                        first f >=>     (* (f (i, state), state) *)
                        swap >=>        (* (state, f (i, state) *)
-                       mux2 en)        (* if en then f (i, state) else state *)
+                       muxPair en)     (* if en then f (i, state) else state *)
                        (i, state)) (mkpair en input)
    }.
 

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -36,10 +36,10 @@ Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.Combinators.
 Require Import Cava.Acorn.NetlistGeneration.
 Require Import Cava.Acorn.XilinxAdder.
+Require Import Cava.Acorn.CavaPrelude.
 
 Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Lib.FullAdder.
-Require Import Cava.Lib.Multiplexers.
 Require Import Cava.Lib.UnsignedAdders.
 
 Recursive Extraction Library BitArithmetic.
@@ -57,8 +57,8 @@ Recursive Extraction Library Types.
 Recursive Extraction Library VectorUtils.
 Recursive Extraction Library UnsignedAdders.
 Recursive Extraction Library XilinxAdder.
+Recursive Extraction Library CavaPrelude.
 
 Recursive Extraction Library BitVectorOps.
 Recursive Extraction Library FullAdder.
-Recursive Extraction Library Multiplexers.
 Recursive Extraction Library UnsignedAdders.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -47,6 +47,7 @@ library
                      Bool
                      Bvector
                      CavaClass
+                     CavaPrelude
                      Combinators
                      CombinationalMonad
                      Datatypes
@@ -57,7 +58,6 @@ library
                      List
                      Logic
                      Monad
-                     Multiplexers
                      Netlist
                      NetlistGeneration
                      Nat


### PR DESCRIPTION
I had to move `mux2` from `Lib.Multiplexers` to a prelude file since it is now used "in the core".
Also rename `mux2` to `muxPair` which more accurately reflects what it is doing.
 #450