### PR TITLE
Simplify mux test

### DIFF
--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -155,6 +155,22 @@ Definition tupleInterfaceDefaultSV (ticks : nat) (v : list SignalType)
   : tupleInterface (seqVType ticks) v :=
   rebalance (seqVType ticks) v (tupleInterfaceDefaultRSV ticks v).
 
+(* Sometimes it is convenient to convert a list of tuples to a tuple of
+   lists e.g. in test benches. *)
+
+Fixpoint fromListOfTuplesR (ts: list SignalType)
+                           (i : (list (tupleInterfaceR combType ts)))
+                           : tupleInterfaceR seqType ts :=
+  match ts, i with
+  | [], _ => tt
+  | t::ts, ix => (map fst ix, fromListOfTuplesR ts (map snd ix))
+  end.
+
+Definition fromListOfTuples (ts: list SignalType)
+                            (i : (list (tupleInterface combType ts)))
+                            : tupleInterface seqType ts :=
+  rebalance seqType ts (fromListOfTuplesR ts (map (unbalance combType ts) i)).
+
 (******************************************************************************)
 (* Netlist AST representation for signal expressions.                         *)
 (******************************************************************************)
@@ -195,7 +211,6 @@ Fixpoint defaultNetSignal (t: SignalType) : Signal t :=
   | Pair lt rt => SignalPair (defaultNetSignal lt) (defaultNetSignal rt)
   | ExternalType s => UninterpretedSignal "default-defaultSignal"
   end.
-
 
 (* To allow us to represent a heterogenous list of Signal t values where
    the Signal t varies we make a wrapper that erase the Kind index type.


### PR DESCRIPTION
With the new combinational simulation semantics we can test combinational circuits with a single `Example` test that works over a stream of values, with each value representing a test vector. Before we had to create separate `Example`s. This PR updates `MuxTest` to remove the single-shot tests and have just one `Example` test. It defines a helper function to map a list of tuples (convenient for cycle by cycle representation of test vectors) to a tuple of lists (which is what the Coq simulation semantics expects). Note question about why I need to explicitly give the `list SignalType` argument to `fromListOfTuples` in `MuxTest.v`: I had guessed this could have been left implicit and inferred from context.

CC: @blaxill 