### PR TITLE
Make synthsizable arithmetic operations expressions, not circuits

### DIFF
--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -41,7 +41,7 @@ Definition twoSorter {signal} `{Cava signal} `{Monad cava} {n}
                      cava (signal (Vec (Vec Bit n) 2)) :=
    let a := indexConst ab 0 in
    let b := indexConst ab 1 in
-   comparison <- greaterThanOrEqual a b ;;
+   let comparison := greaterThanOrEqual (a, b) in
    negComparison <- inv comparison ;;
    let sorted : Vector.t (signal (Vec Bit n)) 2 :=
      [indexAt ab (unpeel [comparison]);

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -57,14 +57,19 @@ Section WithCava.
   Context {signal} `{Cava signal} `{Monad cava}.
 
   (****************************************************************************)
-  (* Unsigned addition with growth examples.                                              *)
+  (* Unsigned addition with growth examples.                                  *)
   (****************************************************************************)
+
+  Definition unsignedAddCircuit {m n : nat}
+                                (ab : signal (Vec Bit m) * signal (Vec Bit n))
+                                : cava (signal (Vec Bit (1 + max m n))) :=
+    ret (unsignedAdd (fst ab, snd ab)).
 
   Definition adderGrowth {aSize bSize: nat}
                         (ab: signal (Vec Bit aSize) * signal (Vec Bit bSize)) :
                         cava (signal (Vec Bit (1 + max aSize bSize))) :=
     let (a, b) := ab in
-    unsignedAdd a b.
+    unsignedAddCircuit (a, b) .
 
   Definition add3InputTuple (aSize bSize cSize: nat)
                             (abc: signal (Vec Bit aSize) *
@@ -109,10 +114,10 @@ Definition adder4Netlist
 Definition adder4_tb_inputs
   := [(bv4_0, bv4_0); (bv4_1, bv4_2); (bv4_15, bv4_1); (bv4_15, bv4_15)].
 
+Definition adder4_tb_inputs' := fromListOfTuples [Vec Bit 4; Vec Bit 4] adder4_tb_inputs.  
+
 Definition adder4_tb_expected_outputs
-  := map (fun '(a, b) =>
-            List.hd (defaultCombValue _)
-                    (combinational (unsignedAdd [a] [b]))) adder4_tb_inputs.
+  := combinational (unsignedAddCircuit adder4_tb_inputs').
 
 Definition adder4_tb
   := testBench "adder4_tb" adder4Interface

--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -73,13 +73,13 @@ Class Cava (signal : SignalType -> Type) := {
                  (startAt + len <= sz) ->
                  signal (Vec t len);
   (* Synthesizable arithmetic operations. *)
-  unsignedAdd : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b) ->
-                cava (signal (Vec Bit (1 + max a b)));
-  unsignedMult : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b)->
-                cava (signal (Vec Bit (a + b)));              
+  unsignedAdd : forall {a b : nat}, signal (Vec Bit a) * signal (Vec Bit b) ->
+                signal (Vec Bit (1 + max a b));
+  unsignedMult : forall {a b : nat}, signal (Vec Bit a) * signal (Vec Bit b)->
+                signal (Vec Bit (a + b));              
   (* Synthesizable relational operators *)
-  greaterThanOrEqual : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b) ->
-                       cava (signal Bit);
+  greaterThanOrEqual : forall {a b : nat}, signal (Vec Bit a) * signal (Vec Bit b) ->
+                      signal Bit;
   (* Hierarchy *)
   instantiate : forall (intf: CircuitInterface),
                  (tupleInterface signal (map port_type (circuitInputs intf)) ->

--- a/cava/Cava/Acorn/CombinationalMonad.v
+++ b/cava/Cava/Acorn/CombinationalMonad.v
@@ -52,6 +52,12 @@ Definition lift1 {A B} (f : combType A -> combType B) (a : seqType A)
   : ident (seqType B) :=
   ret (map f a).
 
+Definition liftP {A B C} (f : combType A * combType B -> combType C)
+           (ab : seqType A * seqType B)
+  : seqType C :=
+  let (a, b) := ab in
+  map f (pad_combine a b).
+
 Definition lift2 {A B C} (f : combType A -> combType B -> combType C)
            (a : seqType A) (b : seqType B)
   : ident (seqType C) :=
@@ -177,11 +183,10 @@ Instance CombinationalSemantics : Cava seqType :=
     indexAt t sz isz := @indexAtBoolList t sz isz;
     indexConst t sz := @indexConstBoolList t sz;
     slice t sz := @sliceBoolList t sz;
-    unsignedAdd m n := @lift2 (Vec Bit _) (Vec Bit _) (Vec Bit (1 + Nat.max m n))
-                              (@unsignedAddBool m n);
-    unsignedMult m n := @lift2 (Vec Bit _) (Vec Bit _) (Vec Bit _)
+    unsignedAdd m n := @liftP (Vec Bit m) (Vec Bit n) (Vec Bit (1 + max m n)) (@unsignedAddBool m n);
+    unsignedMult m n := @liftP (Vec Bit _) (Vec Bit _) (Vec Bit _)
                                (@unsignedMultBool m n);
-    greaterThanOrEqual m n := @lift2 (Vec Bit _) (Vec Bit _) Bit
+    greaterThanOrEqual m n := @liftP (Vec Bit _) (Vec Bit _) Bit
                                      (@greaterThanOrEqualBool m n);
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefaultS (map port_type (circuitOutputs intf)));

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -205,29 +205,6 @@ Definition sliceNet {t: SignalType} {sz: nat}
                     Signal (Vec t len) :=
   unpeelNet (sliceVector (peelNet v) startAt len H).
 
-Definition unsignedAddNet {m n : nat}
-                          (a : Signal (Vec Bit m))
-                          (b : Signal (Vec Bit n)) :
-                          state CavaState (Signal (Vec Bit (1 + max m n))) :=
-  sum <- newVector Bit (1 + max m n) ;;
-  addInstance (UnsignedAdd a b sum) ;;
-  ret sum.
-
-Definition unsignedMultNet {m n : nat}
-                           (a : Signal (Vec Bit m))
-                           (b : Signal (Vec Bit n)) :
-                           state CavaState (Signal (Vec Bit (m + n))) :=
-  product <- newVector Bit (m + n) ;;
-  addInstance (UnsignedMultiply a b product) ;;
-  ret product.
-
-Definition greaterThanOrEqualNet {m n : nat}
-                                 (a : Signal (Vec Bit m)) (b : Signal (Vec Bit n)) :
-                                 state CavaState (Signal Bit) :=
-  comparison <- newWire ;;
-  addInstance (GreaterThanOrEqual a b comparison) ;;
-  ret comparison.
-
 Definition delayNet (t: SignalType)
                     (i : Signal t)
                     : state CavaState (Signal t) :=
@@ -313,9 +290,9 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     indexAt k sz isz := IndexAt;
     indexConst k sz := IndexConst;
     slice k sz := @sliceNet k sz;
-    unsignedAdd m n := @unsignedAddNet m n;
-    unsignedMult m n := @unsignedMultNet m n;
-    greaterThanOrEqual m n := @greaterThanOrEqualNet m n;
+    unsignedAdd m n ab := @UnsignedAdd m n (1 + max m n) (fst ab) (snd ab);
+    unsignedMult m n ab := @UnsignedMultiply m n (m + n) (fst ab) (snd ab);
+    greaterThanOrEqual m n ab := @GreaterThanOrEqual m n (fst ab) (snd ab);
     instantiate := instantiateNet;
     blackBox := blackBoxNet;
 }.

--- a/cava/Cava/Acorn/SequentialTimed.v
+++ b/cava/Cava/Acorn/SequentialTimed.v
@@ -106,17 +106,17 @@ Definition indexAtBoolF {t sz isz}
            (v : combType (Vec t sz)) (sel : combType (Vec Bit isz)) :=
   nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v.
 
-Definition unsignedAddBoolF {m n : nat} (av : Bvector m) (bv : Bvector n)
-  : timed (Bvector (1 + max m n)) :=
-  ret (unsignedAddBool av bv).
+Definition unsignedAddBoolF {m n : nat} (av_bv : Bvector m * Bvector n)
+  : Bvector (1 + max m n) :=
+   unsignedAddBool av_bv.
 
-Definition unsignedMultBoolF {m n : nat} (av : Bvector m) (bv : Bvector n)
-  : timed (Bvector (m + n)) :=
-  ret (unsignedMultBool av bv).
+Definition unsignedMultBoolF {m n : nat} (av_bv : Bvector m * Bvector n)
+  : Bvector (m + n) :=
+  unsignedMultBool av_bv.
 
-Definition greaterThanOrEqualBoolF {m n : nat} (av : Bvector m) (bv : Bvector n)
-  : timed bool :=
-  ret (greaterThanOrEqualBool av bv).
+Definition greaterThanOrEqualBoolF {m n : nat} (av_bv : Bvector m * Bvector n)
+  : bool :=
+  greaterThanOrEqualBool av_bv.
 
 
 Definition blackBoxF (intf : CircuitInterface)

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -263,9 +263,9 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
     indexAt t sz isz := @indexAtBoolVec t sz isz ticks;
     indexConst t sz := @indexConstBoolVec t sz ticks;
     slice t sz := @sliceBoolVec t sz ticks;
-    unsignedAdd m n x y := ret (Vector.map2 (@unsignedAddBool m n) x y);
-    unsignedMult m n x y := ret (Vector.map2 (@unsignedMultBool m n) x y);
-    greaterThanOrEqual m n x y := ret (Vector.map2 (@greaterThanOrEqualBool m n) x y);
+    unsignedAdd m n xy := Vector.map (@unsignedAddBool m n) (vcombine (fst xy) (snd xy));
+    unsignedMult m n xy := Vector.map (@unsignedMultBool m n) (vcombine (fst xy) (snd xy));
+    greaterThanOrEqual m n xy := Vector.map (@greaterThanOrEqualBool m n) (vcombine (fst xy) (snd xy));
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefaultSV ticks (map port_type (circuitOutputs intf)));
   }.

--- a/cava/Cava/BitArithmetic.v
+++ b/cava/Cava/BitArithmetic.v
@@ -581,8 +581,9 @@ Ltac constant_bitvec_cases vec :=
 (******************************************************************************)
 
 Definition unsignedAddBool {m n : nat}
-                           (av : Bvector m) (bv : Bvector n)
+                           (av_bv : Bvector m *  Bvector n)
 : Bvector (1 + max m n) :=
+  let (av, bv) := av_bv in
   let a := Bv2N av in
   let b := Bv2N bv in
   let sumSize := 1 + max m n in
@@ -590,13 +591,15 @@ Definition unsignedAddBool {m n : nat}
   N2Bv_sized sumSize sum.
 
 Definition unsignedMultBool {m n : nat}
-           (av : Bvector m) (bv : Bvector n)
+           (av_bv : Bvector m *  Bvector n)
   : Bvector (m + n) :=
+  let (av, bv) := av_bv in
   let a := Bv2N av in
   let b := Bv2N bv in
   let product := (a * b)%N in
   N2Bv_sized (m + n) product.
 
 Definition greaterThanOrEqualBool {m n : nat}
-           (av : Bvector m) (bv : Bvector n) : bool :=
+           (av_bv : Bvector m *  Bvector n) : bool :=
+  let (av, bv) := av_bv in
   (Bv2N bv <=? Bv2N av)%N.

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -81,8 +81,8 @@ Section WithCava.
                           (c : signal (Vec Bit cSize)) :
                           cava (signal (Vec Bit (1 + max (1 + max aSize bSize) cSize)))
                           :=
-    a_plus_b <- unsignedAdd a b ;;
-    sum <- unsignedAdd a_plus_b c ;;
+    let a_plus_b := unsignedAdd (a, b) in
+    let sum := unsignedAdd (a_plus_b, c) in
     ret sum.
 
   Local Close Scope vector_scope.

--- a/cava/Cava/Netlist.v
+++ b/cava/Cava/Netlist.v
@@ -78,24 +78,6 @@ Inductive Instance : Type :=
   | DelayBit:  Signal Bit -> Signal Bit -> Instance
   (* Assignment of bit wire *)
   | AssignSignal: forall {k: SignalType}, Signal k -> Signal k -> Instance
-  (* Arithmetic operations *)
-  | UnsignedAdd : forall {a b c : nat}, Signal (Vec Bit a) ->
-                                        Signal (Vec Bit b) ->
-                                        Signal (Vec Bit c) ->
-                                        Instance
-  | UnsignedSubtract : forall {a b c : nat}, Signal (Vec Bit a) ->
-                                        Signal (Vec Bit b) ->
-                                        Signal (Vec Bit c) ->
-                                        Instance
-  | UnsignedMultiply : forall {a b c : nat}, Signal (Vec Bit a) ->
-                                        Signal (Vec Bit b) ->
-                                        Signal (Vec Bit c) ->
-                                        Instance
-  (* Relational operations *)
-  | GreaterThanOrEqual: forall {a b : nat}, Signal (Vec Bit a) ->
-                                            Signal (Vec Bit b) ->
-                                            Signal Bit ->
-                                            Instance
   (* TODO(satnam): Switch to using tupleInterface instead of UntypedSignal *)
   | Component: string ->
                list (string * ConstExpr) ->

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -198,7 +198,19 @@ Inductive Signal : SignalType -> Type :=
   | SignalSnd : forall {t1 t2}, Signal (Pair t1 t2) -> Signal t2
   (* Static slice *)
   | Slice: forall {t sz} (start len: nat), Signal (Vec t sz) ->
-                                           Signal (Vec t len).
+                                           Signal (Vec t len)
+  (* Synthesizable arithmetic operations. *)
+  | UnsignedAdd: forall {a b c : nat}, Signal (Vec Bit a) -> Signal (Vec Bit b) ->
+                                       Signal (Vec Bit c)
+  | UnsignedSubtract : forall {a b c : nat}, Signal (Vec Bit a) ->
+                                        Signal (Vec Bit b) ->
+                                        Signal (Vec Bit c)
+  | UnsignedMultiply : forall {a b c : nat}, Signal (Vec Bit a) ->
+                                        Signal (Vec Bit b) ->
+                                        Signal (Vec Bit c)
+  | GreaterThanOrEqual: forall {a b : nat}, Signal (Vec Bit a) ->
+                                            Signal (Vec Bit b) ->
+                                            Signal Bit.
 
 Definition denoteSignal (t : SignalType) : Type := Signal t.
 

--- a/cava/Cava2SystemVerilog.hs
+++ b/cava/Cava2SystemVerilog.hs
@@ -170,6 +170,10 @@ showSignal signal
       SignalSnd _ _ (SignalPair _ _ _ b) -> showSignal b
       -- SignalPair should never occur but added here to aid debugging.
       SignalPair _ _ a b -> "(" ++ showSignal a ++ ", " ++ showSignal b ++ ")"
+      UnsignedAdd _ _ _ a b -> "(" ++ showSignal a ++ " + " ++ showSignal b ++ ")"
+      UnsignedSubtract _ _ _ a b -> "(" ++ showSignal a ++ " - " ++ showSignal b ++ ")"
+      UnsignedMultiply _ _ _ a b -> "(" ++ showSignal a ++ " * " ++ showSignal b ++ ")"
+      GreaterThanOrEqual _ _ a b -> "(" ++ showSignal a ++ " >= " ++ showSignal b ++ ")"
       other -> error ("showSignal: unsupported expresson: " ++ show other)
 
 showSliceIndex :: SignalType -> Integer -> Integer -> String
@@ -254,14 +258,6 @@ generateInstance _ (Component name parameters connections) instNr =
   mkInstance name parameters connections' instNr
   where
   connections' = [(n, extractSignal us) | (n, us) <- connections]
-generateInstance _ (UnsignedAdd _ _ _ a b c) _
-   = "  assign " ++ showSignal c ++ " = " ++ showSignal a ++ " + " ++ showSignal b ++ ";"
-generateInstance _ (UnsignedSubtract _ _ _ a b c) _
-   = "  assign " ++ showSignal c ++ " = " ++ showSignal a ++ " - " ++ showSignal b ++ ";"
-generateInstance _ (UnsignedMultiply _ _ _ a b c) _
-   = "  assign " ++ showSignal c ++ " = " ++ showSignal a ++ " * " ++ showSignal b ++ ";"
-generateInstance _ (GreaterThanOrEqual _ _ a b g) _
-   = "  assign " ++ showSignal g ++ " = " ++ showSignal a ++ " >= " ++ showSignal b ++ ";"
 
 primitiveInstance :: String -> [Signal] -> Int -> String
 primitiveInstance instName args instNr
@@ -594,26 +590,6 @@ mapSignalsInInstanceM f inst
       AssignSignal k t v -> do ft <- f t
                                fv <- f v
                                return (AssignSignal k ft fv)
-      UnsignedAdd s1 s2 s3 a b c ->
-        do fa <- f a
-           fb <- f b
-           fc <- f c
-           return (UnsignedAdd s1 s2 s3 fa fb fc)
-      UnsignedSubtract s1 s2 s3 a b c ->
-        do fa <- f a
-           fb <- f b
-           fc <- f c
-           return (UnsignedSubtract s1 s2 s3 fa fb fc)
-      UnsignedMultiply s1 s2 s3 a b c ->
-        do fa <- f a
-           fb <- f b
-           fc <- f c
-           return (UnsignedMultiply s1 s2 s3 fa fb fc)     
-      GreaterThanOrEqual s1 s2 a b t ->
-        do fa <- f a
-           fb <- f b
-           ft <- f t
-           return (GreaterThanOrEqual s1 s2 fa fb ft)
       Component name args vals ->
         do let sigs = map (extractSignal . snd) vals
            sigs' <- sequence (map f sigs)

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -34,7 +34,7 @@ Section WithCava.
                         (ab: signal (Vec Bit aSize) * signal (Vec Bit bSize)):
                         cava (signal (Vec Bit (aSize + bSize))) :=
     let (a, b) := ab in
-    unsignedMult a b.
+    ret (unsignedMult (a, b)).
 
 End WithCava.
 
@@ -46,7 +46,7 @@ Definition bv3_7  := N2Bv_sized 3  7.
 Definition bv5_15 := N2Bv_sized 5 15.
 
 (* Check 3 * 5 = 30 *)
-Example mult3_5 : combinational (unsignedMult [bv2_3] [bv3_5]) = [bv5_15].
+Example mult3_5 : combinational (multiplier ([bv2_3], [bv3_5])) = [bv5_15].
 Proof. reflexivity. Qed.
 
 (* Check 3 * 5 = 30 *)
@@ -71,10 +71,10 @@ Definition mult2_3_5Netlist
 Definition mult2_3_5_tb_inputs
   := [(bv2_3, bv3_5); (bv2_3, bv3_7); (bv2_0, bv3_0)].
 
+Definition mult2_3_5_tb_inputs' := fromListOfTuples[Vec Bit 2; Vec Bit 3] mult2_3_5_tb_inputs.
+
 Definition mult2_3_5_tb_expected_outputs
-  := map (fun '(a,b) => List.hd (Vector.const false _)
-                         (combinational (multiplier ([a],[b])%list)))
-         mult2_3_5_tb_inputs.
+  := combinational (multiplier mult2_3_5_tb_inputs').
 
 Definition  mult2_3_5_tb
   := testBench "mult2_3_5_tb" mult2_3_5Interface


### PR DESCRIPTION
I think it is much better to have the synthesizable arithmetic operations as expressions rather than instantiated circuits. Their types have also been changed to work over tuples to make them easier to use in point-free style (except when specializing on one input in which case the original curried version would have been better).