### PR TITLE
Add loops with initial states

### DIFF
--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -277,6 +277,70 @@ Lemma pairAssoc_mkpair {A B C} a b c :
   @pairAssoc _ _ A B C (mkpair (mkpair [a] [b]) [c]) = mkpair [a] (mkpair [b] [c]).
 Proof. reflexivity. Qed.
 
+Lemma unpair_default {A B} :
+  unpair [defaultCombValue (Pair A B)] = ([defaultCombValue A], [defaultCombValue B]).
+Proof. reflexivity. Qed.
+
+Lemma unpair_nth {A B} (p : seqType (Pair A B)) n d :
+  List.nth n p d = (List.nth n (fst (unpair p)) (fst d),
+                    List.nth n (snd (unpair p)) (snd d)).
+Proof. apply split_nth. Qed.
+
+Lemma muxPair_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
+  unIdent (muxPair [sel] (([i0] : seqType _), ([i1] : seqType _))) = [if sel then i1 else i0].
+Proof. destruct sel; reflexivity. Qed.
+
+Lemma mkpair_single {A B} (a : combType A) (b : seqType B):
+  length b <> 0 ->
+  mkpair [a] b = mkpair (repeat a (length b)) b.
+Proof.
+  intros; cbv [mkpair pad_combine CombinationalSemantics].
+  cbv [lastSignal]. cbn [List.last].
+  destruct b; cbn [length] in *; [ lia | ].
+  cbn [repeat]; rewrite repeat_cons, last_last.
+  cbv [extend]. autorewrite with push_length natsimpl.
+  cbn [repeat]. autorewrite with listsimpl.
+  rewrite <-repeat_cons. reflexivity.
+Qed.
+
+Lemma mkpair_one {t} (x : seqType t):
+  length x <> 0 ->
+  mkpair one x = mkpair (repeat true (length x)) x.
+Proof.
+  intros; cbn [one constant CombinationalSemantics].
+  rewrite (mkpair_single (A:=Bit)) by auto.
+  reflexivity.
+Qed.
+
+Lemma mkpair_zero {t} (x : seqType t):
+  length x <> 0 ->
+  mkpair zero x = mkpair (repeat false (length x)) x.
+Proof.
+  intros; cbn [zero constant CombinationalSemantics].
+  rewrite (mkpair_single (A:=Bit)) by auto.
+  reflexivity.
+Qed.
+
+Lemma fst_unpair {A B} (ab : seqType (Pair A B)) :
+  fst (unpair ab) = List.map fst ab.
+Proof.
+  cbv [unpair CombinationalSemantics].
+  induction ab; [ reflexivity | ].
+  cbn [split List.map].
+  repeat destruct_pair_let.
+  rewrite <-IHab. reflexivity.
+Qed.
+
+Lemma snd_unpair {A B} (ab : seqType (Pair A B)) :
+  snd (unpair ab) = List.map snd ab.
+Proof.
+  cbv [unpair CombinationalSemantics].
+  induction ab; [ reflexivity | ].
+  cbn [split List.map].
+  repeat destruct_pair_let.
+  rewrite <-IHab. reflexivity.
+Qed.
+
 Lemma mux4_mkpair {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
   mux4 (mkpair (mkpair (mkpair [i0] [i1]) [i2]) [i3]) [sel] =
   [if Vector.hd (Vector.tl sel)

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -688,6 +688,23 @@ Section WithCava.
              input ;;
       ret (fst (unpair bc)).
 
+    (* A loop with an initial state. The circuit diagram looks like:
+
+                      _______
+               ______| delay |____________
+              |      |_______|            |
+              |       _______             |
+              |   ___| delay |_________   |
+              |  |   |_______|         |  |
+              |  |                     |  |
+              |  |                     |  |
+              |  |_                  one  |
+              |_|   \       _________     |
+initial_state __|mux |-----|         |    |
+                |___/      |  body   |____|
+        input -------------|_________|
+
+     *)
     Definition loopDelaySWithInitialState {A B: SignalType}
                (body : signal A * signal B -> cava (signal B))
                (input : signal A) (initial_state : signal B)

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -687,5 +687,22 @@ Section WithCava.
                 ret (mkpair b c))
              input ;;
       ret (fst (unpair bc)).
+
+    Definition loopDelaySWithInitialState {A B: SignalType}
+               (body : signal A * signal B -> cava (signal B))
+               (input : signal A) (initial_state : signal B)
+      : cava (signal B) :=
+      loop_out <- loopDelayS
+                   (B:=Pair Bit B)
+                   (fun (loop_state : signal A * signal (Pair Bit B)) =>
+                      let inp := fst loop_state in
+                      let '(use_feedback_state, feedback_state) :=
+                          unpair (snd loop_state) in
+                      state <- muxPair use_feedback_state
+                                      (initial_state, feedback_state) ;;
+                      new_state <- body (inp, state) ;;
+                      ret (mkpair one new_state))
+                   input ;;
+      ret (snd (unpair loop_out)).
   End Sequential.
  End WithCava.

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -172,10 +172,4 @@ Hint Rewrite @zipWith_unIdent @xorV_unIdent
 Ltac simpl_ident :=
   repeat
     first [ progress autorewrite with simpl_ident
-          | erewrite map2_ext; [ | intros; progress simpl_ident;
-                                   instantiate_app_by_reflexivity ]
-          | erewrite map_ext; [ | intros; progress simpl_ident;
-                                  instantiate_app_by_reflexivity ]
-          | erewrite fold_left_ext; [ | intros; progress simpl_ident;
-                                        instantiate_app_by_reflexivity ]
           | progress cbn [fst snd bind ret Monad_ident unIdent] ].


### PR DESCRIPTION
Needed for #413 

Our current loop formulations don't work idiomatically for AES because the initial state is always the "default values" i.e. zero. However, the AES loop wants to start with a specified initial state and iterate from there. This PR adds a new loop definition and proof that handles initial states. (It's defined in terms of `loopDelayS`, so there are no new elements in `CavaClass`.)

The circuit diagram for the new loop looks like:
```
                      _______
               ______| delay |____________
              |      |_______|            |
              |       _______             |
              |   ___| delay |_________   |
              |  |   |_______|         |  |
              |  |                     |  |
              |  |                     |  |
              |  |_                  one  |
              |_|   \       _________     |
initial_state __|mux |-----|         |    |
                |___/      |  body   |____|
        input -------------|_________|
```
In short, the loop has two pieces of state, one of which is a single bit that is true for every cycle after the very first one. This bit is used to select the initial state for the first cycle and the feedback state for every cycle thereafter. Correct behavior relies on the default for `Bit` being `false`.