### PR TITLE
Set up SystemVerilog extraction and simulation for aes_mix_columns

### DIFF
--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -44,6 +44,7 @@ library
                      BinNums
                      BinInt
                      BitArithmetic
+                     BitVectorOps
                      Bool
                      Bvector
                      CavaClass
@@ -65,6 +66,7 @@ library
                      Sequential
                      Signal
                      StateMonad
+                     Traversable
                      UnsignedAdders
                      VectorDef
                      Vector
@@ -98,7 +100,6 @@ library
                      Ascii
                      Basics
                      String
-                     Traversable
                      Wf
 
   default-language:  Haskell2010

--- a/silveroak-opentitan/aes/Acorn/.gitignore
+++ b/silveroak-opentitan/aes/Acorn/.gitignore
@@ -1,0 +1,1 @@
+!AESSV.hs

--- a/silveroak-opentitan/aes/Acorn/AESExtraction.v
+++ b/silveroak-opentitan/aes/Acorn/AESExtraction.v
@@ -1,0 +1,28 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import AcornAes.Pkg.
+Require Import AcornAes.MixColumns.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
+
+Extraction Language Haskell.
+
+Extraction Library Pkg.
+Extraction Library MixColumns.

--- a/silveroak-opentitan/aes/Acorn/AESSV.hs
+++ b/silveroak-opentitan/aes/Acorn/AESSV.hs
@@ -1,0 +1,23 @@
+{- Copyright 2021 The Project Oak Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-}
+
+module Main where
+
+import Cava2SystemVerilog
+import MixColumns
+
+main :: IO ()
+main = do writeSystemVerilog aes_mix_columns_Netlist
+          writeTestBench aes_mix_columns_tb

--- a/silveroak-opentitan/aes/Acorn/Makefile
+++ b/silveroak-opentitan/aes/Acorn/Makefile
@@ -16,7 +16,18 @@
 
 .PHONY: all coq minimize-requires clean _CoqProject
 
-all:		coq 
+SV = aes_mix_columns.sv
+
+BENCHES = $(SV:.sv=_tb.sv)
+CPPS = $(SV:.sv=_tb.cpp)
+VCDS = $(SV:.sv=_tb.vcd)
+
+.PRECIOUS: $(VCDS)
+
+all:		coq $(VCDS)
+
+VERILATOR = verilator +1800-2012ext+sv verilator.vlt
+VLINT = $(VERILATOR) --lint-only
 
 _CoqProject:
 		@echo "INSTALLDEFAULTROOT = AcornAes" > _CoqProject
@@ -33,6 +44,10 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+AESSV:		coq AESSV.hs
+		ghc --make AESSV.hs
+		./AESSV
+
 minimize-requires: coq
 	../../../tools/minimize-requires.sh
 	$(MAKE) coq
@@ -40,6 +55,15 @@ minimize-requires: coq
 %.vo:		Makefile.coq
 		$(MAKE) -f Makefile.coq $@
 
+$(SV) $(BENCHES) $(CPPS):	AESSV
+
+%_tb.vcd:	%.sv %_tb.sv %_tb.cpp
+		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp
+		make -C obj_dir -f V$*_tb.mk V$*_tb
+		obj_dir/V$*_tb
+
+
 clean:		
 		-@$(MAKE) -f Makefile.coq clean
-		rm -rf _CoqProject Makefile.coq Makefile.coq.conf
+		rm -rf _CoqProject Makefile.coq Makefile.coq.conf AESSV
+		git clean -Xfd

--- a/silveroak-opentitan/aes/Acorn/README.md
+++ b/silveroak-opentitan/aes/Acorn/README.md
@@ -4,3 +4,8 @@
 We must use the snapshot of the OpenTitan source from 11 May 2020 as the baseline reference implementation
 at commit hash [783edaf444](https://github.com/lowRISC/opentitan/tree/783edaf444eb0d9eaf9df71c785089bffcda574e) on the OpenTitan GitHub repo. For consistency and to allow us to produce a single FPGA implementation we should design and verify all our Silver Oak OpenTitan
 components against this OpenTitan commit hash.
+
+## Baseline OpenTitan SystemVerilog Components
+* [aes_mix_columns.sv](https://github.com/lowRISC/opentitan/blob/783edaf444eb0d9eaf9df71c785089bffcda574e/hw/ip/aes/rtl/aes_mix_columns.sv)
+* [aes_shift_rows.sv](https://github.com/lowRISC/opentitan/blob/783edaf444eb0d9eaf9df71c785089bffcda574e/hw/ip/aes/rtl/aes_shift_rows.sv)
+* [aes_sbox.sv](https://github.com/lowRISC/opentitan/blob/783edaf444eb0d9eaf9df71c785089bffcda574e/hw/ip/aes/rtl/aes_sbox.sv)

--- a/silveroak-opentitan/aes/Acorn/verilator.vlt
+++ b/silveroak-opentitan/aes/Acorn/verilator.vlt
@@ -1,0 +1,3 @@
+`verilator_config
+lint_off -rule UNOPTFLAT
+lint_off -rule BLKANDNBLK


### PR DESCRIPTION
This PR illustrates sets up SystemVerilog extraction for `aes_mix_columns` but right now it only uses an empty test bench to just check that this block is compiles and is legal SystemVerilog and that it can be processed by Verilator.
Part of addressing issue #458 