### PR TITLE
Implement pair selection in terms of array indexing

### DIFF
--- a/cava/Cava2SystemVerilog.hs
+++ b/cava/Cava2SystemVerilog.hs
@@ -437,9 +437,8 @@ unsmashSignal signal
 freshen :: Signal -> State CavaState Signal
 freshen signal
   = case signal of
-      VecLit k s v -> do vf <- mapM freshen (Vector.to_list s v)
-                         freshV <- freshVector k s
-                         addAssignment (Vec k s) freshV (VecLit k s (Vector.of_list vf))
+      VecLit k s v -> do freshV <- freshVector k s
+                         addAssignment (Vec k s) freshV (VecLit k s v)
                          return freshV
       IndexAt k sz isz v i -> do vf <- freshen v
                                  return (IndexAt k sz isz vf i)

--- a/cava/SystemVerilogUtils.hs
+++ b/cava/SystemVerilogUtils.hs
@@ -21,7 +21,7 @@ import Signal
 insertCommas :: [String] -> [String]
 insertCommas [] = []
 insertCommas [x] = [x]
-insertCommas (x:y:xs) = (x ++ ",") : insertCommas (y:xs)
+insertCommas (x:y:xs) = (x ++ ", ") : insertCommas (y:xs)
 
 vectorDeclaration' ::  SignalType -> Integer -> String
 vectorDeclaration' k s


### PR DESCRIPTION
This PR makes the implementation of pair selection work by translation into vector-indexing. This means we no longer need to emit conditional expressions in the generated SystemVerilog. Pair selection can now be defined in a library or prelude module, once the proofs can be adapted.