### PR TITLE
FPGA implementation of Silver Oak aes_sub_bytes

### DIFF
--- a/silveroak-opentitan/aes/Acorn/.gitignore
+++ b/silveroak-opentitan/aes/Acorn/.gitignore
@@ -1,1 +1,2 @@
 !AESSV.hs
+!aes_sub_bytes.tcl

--- a/silveroak-opentitan/aes/Acorn/Makefile
+++ b/silveroak-opentitan/aes/Acorn/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-.PHONY: all coq minimize-requires clean _CoqProject
+.PHONY: all coq minimize-requires clean _CoqProject impl
 
 SV = aes_mix_columns.sv
 
@@ -64,6 +64,8 @@ obj_dir/V%_tb:	%.sv %_tb.sv %_tb.cpp
 %_tb.vcd:	obj_dir/V%_tb
 		$<
 
+impl:		
+		vivado -mode tcl -source aes_sub_bytes.tcl
 
 clean:		
 		-@$(MAKE) -f Makefile.coq clean

--- a/silveroak-opentitan/aes/Acorn/aes_sub_bytes.tcl
+++ b/silveroak-opentitan/aes/Acorn/aes_sub_bytes.tcl
@@ -1,0 +1,37 @@
+#
+# Copyright 2021 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set outputDir ./aes_implementation/aes_sub_bytes
+file mkdir $outputDir
+#
+read_verilog -sv aes_sub_bytes.sv
+#
+synth_design -top aes_sub_bytes -part xc7a200tsbg484-1
+write_checkpoint -force $outputDir/post_synth
+report_utilization -file $outputDir/post_synth_util.rpt
+opt_design
+place_design
+phys_opt_design
+write_checkpoint -force $outputDir/post_place
+report_timing_summary -file $outputDir/post_place_timing_summary.rpt
+#
+route_design
+write_checkpoint -force $outputDir/post_route
+report_timing_summary -file $outputDir/post_route_timing_summary.rpt
+report_timing -sort_by group -max_paths 100 -path_type summary -file $outputDir/post_route_timing.rpt
+report_clock_utilization -file $outputDir/clock_util.rpt
+report_utilization -file $outputDir/post_route_util.rpt
+exit


### PR DESCRIPTION
This PR contains a tcl file for driving the FPGA implementation of the Silver Oak `aes_sub_bytes` block and a rule `impl` that invokes the Xilinx Vivado tool to run the implementation to produce utilization reports (but not bitstream generation). There is no clean to clean the generated output directory because we should be careful about wiping it since it will in general contain artifacts that took a long time to generate.

The comparison with the OpenTitan `aes_sub_bytes` block shows identical utilization.
Part of issue #466

