### PR TITLE
Prove that inv_mix_columns and add_round_key commute

### DIFF
--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -29,19 +29,6 @@ mix_columns_equiv
     [if is_decrypt
      then to_cols_bitvecs (inv_mix_columns (from_cols_bitvecs st))
      else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
-mix_columns_add_round_key_comm
-  : forall st k : t (t Byte.byte 4) 4,
-    let to_bits :=
-      fun x : t (t Byte.byte 4) 4 => to_cols_bits (BigEndian.from_cols x) in
-    let from_bits :=
-      fun x : t (t bool (4 * 8)) 4 => BigEndian.to_cols (from_cols_bits x) in
-    AesSpec.AddRoundKey.add_round_key 32 4
-      (to_bits (MixColumns.inv_mix_columns st))
-      (to_bits (MixColumns.inv_mix_columns k)) =
-    to_bits
-      (MixColumns.inv_mix_columns
-         (from_bits
-            (AesSpec.AddRoundKey.add_round_key 32 4 (to_bits st) (to_bits k))))
 mix_columns
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     Monad cava ->

--- a/silveroak-opentitan/aes/Spec/AES256.v
+++ b/silveroak-opentitan/aes/Spec/AES256.v
@@ -31,19 +31,6 @@ Require Import AesSpec.StateTypeConversions.
 
 Import StateTypeConversions.BigEndian.
 
-Axiom mix_columns_add_round_key_comm :
-  forall (st k : Vector.t _ 4),
-    let to_bits x := LittleEndian.to_cols_bits (from_cols x) in
-    let from_bits x := to_cols (LittleEndian.from_cols_bits x) in
-    add_round_key 32 4
-                  (to_bits (inv_mix_columns st))
-                  (to_bits (inv_mix_columns k))
-    = to_bits
-        (inv_mix_columns
-           (from_bits
-              (add_round_key
-                 32 4 (to_bits st) (to_bits k)))).
-
 Section Equivalence.
   Let state := Vector.t bool 128.
   Let round_key := Vector.t bool 128.
@@ -88,7 +75,8 @@ Section Equivalence.
       first_key last_key middle_keys input.
 
   Hint Rewrite @inverse_add_round_key @inverse_shift_rows @inverse_sub_bytes
-       @inverse_mix_columns @sub_bytes_shift_rows_comm @mix_columns_add_round_key_comm
+       @inverse_mix_columns @sub_bytes_shift_rows_comm
+       @inv_mix_columns_add_round_key_comm
        using solve [eauto] : inverse.
 
   Lemma aes256_decrypt_encrypt first_key last_key middle_keys input :

--- a/silveroak-opentitan/aes/Spec/AES256_Assumptions.out
+++ b/silveroak-opentitan/aes/Spec/AES256_Assumptions.out
@@ -1,14 +1,1 @@
-Axioms:
-mix_columns_add_round_key_comm
-  : forall st k : Vector.t (Vector.t Byte.byte 4) 4,
-    let to_bits :=
-      fun x : Vector.t (Vector.t Byte.byte 4) 4 =>
-      LittleEndian.to_cols_bits (from_cols x) in
-    let from_bits :=
-      fun x : Vector.t (Vector.t bool (4 * 8)) 4 =>
-      to_cols (LittleEndian.from_cols_bits x) in
-    AddRoundKey.add_round_key 32 4 (to_bits (MixColumns.inv_mix_columns st))
-      (to_bits (MixColumns.inv_mix_columns k)) =
-    to_bits
-      (MixColumns.inv_mix_columns
-         (from_bits (AddRoundKey.add_round_key 32 4 (to_bits st) (to_bits k))))
+Closed under the global context

--- a/silveroak-opentitan/aes/Spec/CommuteProperties.v
+++ b/silveroak-opentitan/aes/Spec/CommuteProperties.v
@@ -16,57 +16,123 @@
 
 Require Import Coq.Init.Byte.
 Require Import Coq.Lists.List.
+Require Coq.Vectors.Vector.
 
+Require Import Cava.BitArithmetic.
+Require Import Cava.ListUtils.
+Require Import Cava.VectorUtils.
+Require Import AesSpec.AddRoundKey.
+Require Import AesSpec.MixColumns.
 Require Import AesSpec.ShiftRows.
 Require Import AesSpec.SubBytes.
 Require Import AesSpec.Sbox.
+Require Import AesSpec.StateTypeConversions.
 
-Section Spec.
-  Section Properties.
-    Lemma sub_byte_shift_row_once_comm : forall row,
-      shift_row_once (map forward_sbox row) =
-      map forward_sbox (shift_row_once row).
-    Proof.
-      intros.
-      destruct row; [reflexivity|].
-      simpl.
-      rewrite map_app.
-      reflexivity.
-    Qed.
+Section SubBytesShiftRows.
+  Lemma sub_byte_shift_row_once_comm : forall row,
+    shift_row_once (map forward_sbox row) =
+    map forward_sbox (shift_row_once row).
+  Proof.
+    intros.
+    destruct row; [reflexivity|].
+    simpl.
+    rewrite map_app.
+    reflexivity.
+  Qed.
 
-    Lemma sub_byte_shift_row_comm : forall row shift,
+  Lemma sub_byte_shift_row_comm : forall row shift,
       shift_row (map forward_sbox row) shift =
       map forward_sbox (shift_row row shift).
-    Proof.
-      intros.
-      generalize dependent row.
-      induction shift; [reflexivity|].
-      intros.
-      simpl.
-      rewrite <- IHshift.
-      rewrite sub_byte_shift_row_once_comm.
-      reflexivity.
-    Qed.
+  Proof.
+    intros.
+    generalize dependent row.
+    induction shift; [reflexivity|].
+    intros.
+    simpl.
+    rewrite <- IHshift.
+    rewrite sub_byte_shift_row_once_comm.
+    reflexivity.
+  Qed.
 
-    Lemma sub_bytes_shift_rows_start_comm : forall st n,
+  Lemma sub_bytes_shift_rows_start_comm : forall st n,
       shift_rows_start (sub_bytes st) n =
       sub_bytes (shift_rows_start st n).
-    Proof.
-      induction st; [reflexivity|].
-      intro n.
-      unfold shift_rows_start.
-      simpl.
-      rewrite sub_byte_shift_row_comm.
-      unfold shift_rows_start in IHst.
-      rewrite IHst.
-      reflexivity.
-    Qed.
+  Proof.
+    induction st; [reflexivity|].
+    intro n.
+    unfold shift_rows_start.
+    simpl.
+    rewrite sub_byte_shift_row_comm.
+    unfold shift_rows_start in IHst.
+    rewrite IHst.
+    reflexivity.
+  Qed.
 
-    Theorem sub_bytes_shift_rows_comm : forall st,
+  Theorem sub_bytes_shift_rows_comm : forall st,
       shift_rows (sub_bytes st) = sub_bytes (shift_rows st).
-    Proof.
-      intros.
-      apply (sub_bytes_shift_rows_start_comm st 0).
-    Qed.
-  End Properties.
-End Spec.
+  Proof.
+    intros.
+    apply (sub_bytes_shift_rows_start_comm st 0).
+  Qed.
+End SubBytesShiftRows.
+
+Section MixColsAddRoundKey.
+  Existing Instance byteops.
+  Local Notation to_bits x := (LittleEndian.to_cols_bits (BigEndian.from_cols x)) (only parsing).
+  Local Notation from_bits x := (BigEndian.to_cols (LittleEndian.from_cols_bits x)) (only parsing).
+
+
+  Lemma poly_to_byte_to_bitvec b :
+    length b = 8%nat ->
+    byte_to_bitvec (poly_to_byte b) = of_list_sized false 8 b.
+  Proof.
+    intros. destruct_lists_by_length.
+    cbv [byte_to_bitvec poly_to_byte].
+    repeat match goal with b : bool |- _ => destruct b end;
+      vm_compute; reflexivity.
+  Qed.
+
+  Lemma byte_add_is_xor b1 b2 :
+    byte_to_bitvec (Polynomial.fadd b1 b2)
+    = Vector.map2 xorb (byte_to_bitvec b1) (byte_to_bitvec b2).
+  Proof.
+    cbv [Polynomial.fadd byteops].
+    rewrite poly_to_byte_to_bitvec by length_hammer.
+    apply to_list_inj. autorewrite with push_to_list.
+    rewrite to_list_of_list_sized by length_hammer.
+    cbv [Polynomial.add_poly].
+    rewrite !extend_le by length_hammer.
+    reflexivity.
+  Qed.
+
+  Lemma add_round_key_byte_add (st k : Vector.t (Vector.t byte 4) 4) :
+    add_round_key 32 4 (to_bits st) (to_bits k)
+    = to_bits (Vector.map2 (Vector.map2 Polynomial.fadd) st k).
+  Proof.
+    cbv [add_round_key Bvector.BVxor].
+    cbv [LittleEndian.to_cols_bits].
+    autorewrite with conversions.
+    rewrite map_map2, <-reverse_map2, map2_map.
+    f_equal. apply map2_ext; intros.
+    rewrite reverse_map2.
+    cbv [bytevec_to_bitvec].
+    rewrite map2_flatten with (m:=4) (n:=8).
+    rewrite map_map2, map2_map. f_equal.
+    apply map2_ext; intros.
+    rewrite byte_add_is_xor; reflexivity.
+  Qed.
+
+  Lemma inv_mix_columns_add_round_key_comm (st k : Vector.t (Vector.t byte 4) 4) :
+    add_round_key 32 4
+                  (to_bits (inv_mix_columns st))
+                  (to_bits (inv_mix_columns k))
+    = to_bits
+        (inv_mix_columns
+           (from_bits (add_round_key 32 4 (to_bits st) (to_bits k)))).
+  Proof.
+    intros. rewrite !add_round_key_byte_add.
+    rewrite inv_mix_columns_add_comm.
+    autorewrite with conversions.
+    reflexivity.
+  Qed.
+End MixColsAddRoundKey.


### PR DESCRIPTION
Resolves #312 

With this PR, we are **completely done** with the proofs on top of the AES specification (i.e. the proofs that decryption is the inverse of encryption). The only proofs now remaining for the top-level theorems are proofs that the Cava implementations match the specification.

The diff is a bit confused because I de-indented the proofs that `shift_rows` and `sub_bytes` commute -- I didn't actually change any of the code there.