### PR TITLE
Fix slowness in equivalence proofs

### DIFF
--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -114,6 +114,26 @@ Definition full_cipher {signal} {semantics : Cava signal} {monad : Monad cava}
     (fun k => mix_columns one k) (* Hard-wire is_decrypt to '1' *)
     key_expand num_rounds_regular round_0.
 
+Local Ltac solve_side_conditions :=
+  cbv zeta; intros;
+  lazymatch goal with
+  | |- ?x = ?x => reflexivity
+  | |- context [unIdent (add_round_key _ _) = _] =>
+    eapply add_round_key_equiv
+  | |- context [unIdent (sub_bytes _ _) = _] =>
+    eapply sub_bytes_equiv
+  | |- context [unIdent (shift_rows _ _) = _] =>
+    eapply shift_rows_equiv
+  | |- context [unIdent (mix_columns _ _) = _] =>
+    eapply mix_columns_equiv
+  | |- context [unIdent (key_expand [?is_decrypt] _ _) = _] =>
+    rewrite key_expand_equiv; cbv zeta;
+    destruct is_decrypt; reflexivity
+  | |- context [_ < 2 ^ 4] => change (2 ^ 4)%nat with 16; Lia.lia
+  | |- map fst (all_keys _ _ _) = _ => solve [eauto]
+  | _ => idtac
+  end.
+
 Lemma full_cipher_equiv
       (is_decrypt : bool) (first_rcon : t bool 8)
       (first_key last_key : combType key)
@@ -151,25 +171,7 @@ Proof.
            fun i k_rcon => unflatten_key (key_expand_spec i (flatten_key k_rcon)))
         (inv_key_expand_spec:=
            fun i k_rcon => unflatten_key (inv_key_expand_spec i (flatten_key k_rcon)))
-        by
-          lazymatch goal with
-          | |- ?x = ?x => reflexivity
-          | |- context [unIdent (add_round_key _ _) = _] =>
-            intros; eapply add_round_key_equiv
-          | |- context [unIdent (sub_bytes _ _) = _] =>
-            intros; eapply sub_bytes_equiv
-          | |- context [unIdent (shift_rows _ _) = _] =>
-            intros; eapply shift_rows_equiv
-          | |- context [unIdent (mix_columns _ _) = _] =>
-            intros; eapply mix_columns_equiv
-          | |- context [unIdent (key_expand _ _ _) = _] =>
-            cbv zeta; intros;
-              rewrite key_expand_equiv; cbv zeta;
-                destruct is_decrypt; reflexivity
-          | |- context [_ < 2 ^ 4] => change (2 ^ 4)%nat with 16; Lia.lia
-          | |- map fst (all_keys _ _ _) = _ => solve [eauto]
-          | _ => idtac
-          end.
+      by solve_side_conditions.
 
     cbv [aes256_decrypt].
 
@@ -200,25 +202,7 @@ Proof.
            fun i k_rcon => unflatten_key (key_expand_spec i (flatten_key k_rcon)))
         (inv_key_expand_spec:=
            fun i k_rcon => unflatten_key (inv_key_expand_spec i (flatten_key k_rcon)))
-        by
-          lazymatch goal with
-          | |- ?x = ?x => reflexivity
-          | |- context [unIdent (add_round_key _ _) = _] =>
-            intros; eapply add_round_key_equiv
-          | |- context [unIdent (sub_bytes _ _) = _] =>
-            intros; eapply sub_bytes_equiv
-          | |- context [unIdent (shift_rows _ _) = _] =>
-            intros; eapply shift_rows_equiv
-          | |- context [unIdent (mix_columns _ _) = _] =>
-            intros; eapply mix_columns_equiv
-          | |- context [unIdent (key_expand _ _ _) = _] =>
-            cbv zeta; intros;
-              rewrite key_expand_equiv; cbv zeta;
-                destruct is_decrypt; reflexivity
-          | |- context [_ < 2 ^ 4] => change (2 ^ 4)%nat with 16; Lia.lia
-          | |- map fst (all_keys _ _ _) = _ => solve [eauto]
-          | _ => idtac
-          end.
+        by solve_side_conditions.
 
     cbv [aes256_encrypt].
 

--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -5,12 +5,6 @@ sub_bytes_equiv
     [if is_decrypt
      then to_cols_bitvecs (inv_sub_bytes (from_cols_bitvecs st))
      else to_cols_bitvecs (AES256.sub_bytes (from_cols_bitvecs st))]
-sub_bytes
-  : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
-    signal Bit ->
-    signal (Vec (Vec (Vec Bit 8) 4) 4) ->
-    cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 shift_rows_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (shift_rows [is_decrypt] [st]) =

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -5,12 +5,6 @@ sub_bytes_equiv
     [if is_decrypt
      then to_cols_bitvecs (inv_sub_bytes (from_cols_bitvecs st))
      else to_cols_bitvecs (AES256.sub_bytes (from_cols_bitvecs st))]
-sub_bytes
-  : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
-    signal Bit ->
-    signal (Vec (Vec (Vec Bit 8) 4) 4) ->
-    cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 shift_rows_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (shift_rows [is_decrypt] [st]) =


### PR DESCRIPTION
Resolves #497 

Instead of `first`, trying every side-condition solving strategy in turn, use a `lazymatch` to more specifically try certain strategies on certain goals. This fixes the proof-slowness issue that prevented us from removing the `sub_bytes` axiom before.