### PR TITLE
[aes_mix_columns] Updated FPGA implementation report

### DIFF
--- a/silveroak-opentitan/aes/Acorn/.gitignore
+++ b/silveroak-opentitan/aes/Acorn/.gitignore
@@ -1,2 +1,2 @@
 !AESSV.hs
-!aes_sub_bytes.tcl
+!aes_util.tcl

--- a/silveroak-opentitan/aes/Acorn/Makefile
+++ b/silveroak-opentitan/aes/Acorn/Makefile
@@ -14,7 +14,21 @@
 # limitations under the License.
 #
 
-.PHONY: all coq minimize-requires clean _CoqProject impl
+# To produce the SystemVerilog AES implementation files and their
+# associated test artifcats do:
+#
+# $ make
+#
+# To run FPGA implementation of the AES subcomponents and generate
+# utilization reports do:
+#
+# $ make util
+#
+# The resulting implementations will be in the aes_implementation directory.
+# This step will require the installation of the Xilinx Vivado
+# FPAG design tools.
+
+.PHONY: all coq minimize-requires clean _CoqProject
 
 SV = aes_mix_columns.sv
 
@@ -25,6 +39,7 @@ VCDS = $(SV:.sv=_tb.vcd)
 .PRECIOUS: $(VCDS)
 
 all:		coq $(VCDS)
+util:		aes_sub_bytes_util aes_mix_columns_util
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only
@@ -64,8 +79,10 @@ obj_dir/V%_tb:	%.sv %_tb.sv %_tb.cpp
 %_tb.vcd:	obj_dir/V%_tb
 		$<
 
-impl:		
-		vivado -mode tcl -source aes_sub_bytes.tcl
+# Run FPGA implementation to the palcement stage to get a utilization report.
+%_util:		
+		echo "Utilization report for " $*
+		vivado -mode tcl -source aes_util.tcl -tclargs $*
 
 clean:		
 		-@$(MAKE) -f Makefile.coq clean

--- a/silveroak-opentitan/aes/Acorn/Makefile
+++ b/silveroak-opentitan/aes/Acorn/Makefile
@@ -39,7 +39,8 @@ VCDS = $(SV:.sv=_tb.vcd)
 .PRECIOUS: $(VCDS)
 
 all:		coq $(VCDS)
-util:		aes_sub_bytes_util aes_mix_columns_util
+util:		aes_sub_bytes_util aes_mix_columns_util aes_add_round_key_util \
+		aes_shift_rows_util aes_sbox_lut_util
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only

--- a/silveroak-opentitan/aes/Acorn/README.md
+++ b/silveroak-opentitan/aes/Acorn/README.md
@@ -6,6 +6,10 @@ at commit hash [783edaf444](https://github.com/lowRISC/opentitan/tree/783edaf444
 components against this OpenTitan commit hash.
 
 ## Generating utilization reports
+To generate utilization reports for all the circuit modules type:
+```console
+$ make util
+```
 To generate a utilization report for a particular module invoke the Makefile with the name of the module followed by `_util` e.g.
 ```console
 $ make aes_sub_bytes_util

--- a/silveroak-opentitan/aes/Acorn/aes_util.tcl
+++ b/silveroak-opentitan/aes/Acorn/aes_util.tcl
@@ -26,7 +26,7 @@ file mkdir $outputDir
 #
 read_verilog -sv $circuit.sv
 #
-synth_design -top $circuit -part xc7a200tsbg484-1
+synth_design -top $circuit -part xc7a200tsbg484-1 -mode out_of_context
 write_checkpoint -force $outputDir/post_synth
 report_utilization -file $outputDir/post_synth_util.rpt
 opt_design

--- a/silveroak-opentitan/aes/Acorn/aes_util.tcl
+++ b/silveroak-opentitan/aes/Acorn/aes_util.tcl
@@ -14,18 +14,26 @@
 # limitations under the License.
 #
 
-set outputDir ./aes_implementation/aes_sub_bytes
+# This tcl script drives FPGA implementation far enough
+# to get a post-placement utilization report. Give the
+# root name of the module as the sole argument e.g.
+# vivado -mode tcl -source aes_util.tcl -tclargs aes_sub_bytes
+
+puts "Utilization report for [lindex $argv 0]"
+set circuit [lindex $argv 0]
+set outputDir ./aes_implementation/$circuit
 file mkdir $outputDir
 #
-read_verilog -sv aes_sub_bytes.sv
+read_verilog -sv $circuit.sv
 #
-synth_design -top aes_sub_bytes -part xc7a200tsbg484-1
+synth_design -top $circuit -part xc7a200tsbg484-1
 write_checkpoint -force $outputDir/post_synth
 report_utilization -file $outputDir/post_synth_util.rpt
 opt_design
 place_design
 phys_opt_design
 write_checkpoint -force $outputDir/post_place
+report_utilization -file $outputDir/post_route_util.rpt
 report_timing_summary -file $outputDir/post_place_timing_summary.rpt
 #
 route_design


### PR DESCRIPTION
The updated report with the fix Silver Oak `aes_mix_columns` report shows that we are 4% larger which is not bad. I could investigate to see where this 4% comes from, but I think anything less than 5% is probably not worth worrying about too much.

PR includes documentation to show how to re-generate the reports using the `Makefile`.
Part of issue #468 