### PR TITLE
Pack monad instance into CavaClass

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -41,7 +41,7 @@ Existing Instance CavaCombinationalNet.
 (******************************************************************************)
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (* An adder-tree with no bit-growth. *)
   Definition adderTree {sz: nat}

--- a/acorn-examples/FullAdderExample.v
+++ b/acorn-examples/FullAdderExample.v
@@ -26,7 +26,7 @@ Require Import Cava.Lib.FullAdder.
 Require Import Cava.Acorn.XilinxAdder.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (****************************************************************************)
   (* Build a full-adder that takes a flat-tuple for netlist generation.       *)

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -32,7 +32,7 @@ Open Scope monad_scope.
 Open Scope list_scope.
 
 Section WithCava.
-  Context `{semantics: Cava} {monad : Monad cava}.
+  Context `{semantics: Cava}.
 
   Definition half_adder (input : signal Bit * signal Bit)
   : cava (signal Bit * signal Bit) :=

--- a/acorn-examples/NandGate.v
+++ b/acorn-examples/NandGate.v
@@ -32,7 +32,7 @@ Local Open Scope string_scope.
 
 Section WithCava.
   Context {signal} {combsemantics : Cava signal}
-          {seqsemantics: CavaSeq combsemantics} `{Monad cava}.
+          {seqsemantics: CavaSeq combsemantics}.
 
   (* NAND gate example. First, let's define an overloaded NAND gate
      description. *)

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -34,9 +34,9 @@ Require Import Coq.micromega.Lia.
 Local Open Scope vector_scope.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
-Definition twoSorter {signal} `{Cava signal} `{Monad cava} {n}
+Definition twoSorter {signal} `{Cava signal} {n}
                      (ab:  signal (Vec (Vec Bit n) 2)) :
                      cava (signal (Vec (Vec Bit n) 2)) :=
    let a := indexConst ab 0 in

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -54,7 +54,7 @@ Example add15_1 : combinational (addN ([bv4_15], [bv4_1])) = [bv4_0].
 Proof. reflexivity. Qed.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (****************************************************************************)
   (* Unsigned addition with growth examples.                                  *)

--- a/acorn-examples/xilinx/NandLUT.v
+++ b/acorn-examples/xilinx/NandLUT.v
@@ -23,7 +23,7 @@ Require Import ExtLib.Structures.Monads.
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 
-Definition lutNAND {signal} `{Cava signal} `{Monad cava}
+Definition lutNAND {signal} `{Cava signal}
            (i0i1 : signal Bit * signal Bit) : cava (signal Bit) :=
   x <- lut2 (andb) i0i1 ;;
   z <- lut1 (negb) x ;;

--- a/acorn-examples/xilinx/XilinxAdderExamples.v
+++ b/acorn-examples/xilinx/XilinxAdderExamples.v
@@ -74,7 +74,7 @@ Definition adder8Interface
      [].
 
 (* Produce a version of the xilinxAdderWithCarry with a flat-tuple input. *)
-Definition xilinxAdderWithCarryFlat {signal} `{Cava signal} `{Monad cava} {n}
+Definition xilinxAdderWithCarryFlat {signal} `{Cava signal} {n}
                                     '(cin, a, b)
                                     : cava (signal (Vec Bit n) * signal Bit) :=
   xilinxAdderWithCarry (cin, (a, b)).

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -32,7 +32,7 @@ Require Import Cava.Acorn.Acorn.
 Require Import Cava.Acorn.XilinxAdder.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (****************************************************************************)
   (* A generic description of all adder trees made from a Xilinx adder        *)

--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-
+Require Import ExtLib.Structures.Monad.
 Require Import Cava.Netlist.
 Require Import Cava.Signal.
 
@@ -25,7 +25,8 @@ Local Open Scope type_scope.
    us to define both circuit netlist interpretations for the Cava class
    as well as behavioural interpretations for attributing semantics. *)
 Class Cava (signal : SignalType -> Type) := {
-  cava : Type -> Type;    
+  cava : Type -> Type;
+  monad :> Monad cava;
   (* Constant values. *)
   constant : bool -> signal Bit;
   (* Default values. *)

--- a/cava/Cava/Acorn/CavaPrelude.v
+++ b/cava/Cava/Acorn/CavaPrelude.v
@@ -25,7 +25,7 @@ Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Signal.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{CavaSeq signal} `{Monad cava}.
+  Context {signal} `{Cava signal} `{CavaSeq signal}.
 
   (* Constant signals. *)
 

--- a/cava/Cava/Acorn/CombinationalMonad.v
+++ b/cava/Cava/Acorn/CombinationalMonad.v
@@ -157,6 +157,7 @@ Local Notation lift6Bool := (@lift6 Bit Bit Bit Bit Bit Bit Bit).
 
 Instance CombinationalSemantics : Cava seqType :=
   { cava := ident;
+    monad := Monad_ident;
     constant := fun x => [x];
     defaultSignal t := [];
     inv := lift1Bool negb;

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -42,7 +42,7 @@ Local Open Scope monad_scope.
 Local Open Scope type_scope.
 
 Section WithCava.
-  Context {signal} {semantics: Cava signal} {monad: Monad cava}.
+  Context {signal} {semantics: Cava signal}.
 
   (****************************************************************************)
   (* Lava-style circuit combinators.                                          *)
@@ -313,29 +313,29 @@ Section WithCava.
   (* Forks in wires                                                           *)
   (****************************************************************************)
 
-  Definition fork2 `{Monad_m : Monad cava} {A} (a:A) := ret (a, a).
+  Definition fork2 {A} (a:A) := ret (a, a).
 
   (****************************************************************************)
   (* Operations over pairs.                                                   *)
   (****************************************************************************)
 
-  Definition first `{Monad_m : Monad cava} {A B C} (f : A -> cava C) (ab : A * B) : cava (C * B) :=
+  Definition first {A B C} (f : A -> cava C) (ab : A * B) : cava (C * B) :=
     let '(a, b) := ab in
     c <- f a ;;
     ret (c, b).
 
-  Definition second `{Monad_m : Monad cava} {A B C} (f : B -> cava C) (ab : A * B) : cava (A * C) :=
+  Definition second {A B C} (f : B -> cava C) (ab : A * B) : cava (A * C) :=
     let '(a, b) := ab in
     c <- f b ;;
     ret (a, c).
 
   (* Project out the first element of a pair. *)
-  Definition projFst `{Monad_m : Monad cava} {A B} (ab : A * B) : cava A :=
+  Definition projFst {A B} (ab : A * B) : cava A :=
     let '(a, _) := ab in
     ret a.
 
   (* Project out the second element of a pair. *)
-  Definition projSnd `{Monad_m : Monad cava} {A B} (ab : A * B) : cava B :=
+  Definition projSnd {A B} (ab : A * B) : cava B :=
     let '(_, b) := ab in
     ret b.
 
@@ -343,7 +343,7 @@ Section WithCava.
   (* Swap                                                                     *)
   (****************************************************************************)
 
-  Definition swap `{Monad_m : Monad cava} {A B}
+  Definition swap {A B}
                   (i : signal A * signal B) 
                   : cava (signal B * signal A) :=
     let (a, b) := i in

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -104,11 +104,11 @@ Section Combinators.
         (va : combType (Vec A n)) (vb : combType (Vec B n)) :
     n <> 0 ->
     (forall a b, unIdent (f ([a], [b])) = [spec a b]) ->
-    unIdent (@zipWith _ _ Monad_ident A B C n f [va] [vb])
+    unIdent (@zipWith _ _ A B C n f [va] [vb])
     = [Vector.map2 spec va vb].
   Proof.
     cbv [zipWith Traversable.mapT Traversable_vector].
-    cbn [peel unpeel CombinationalSemantics].
+    cbn [peel unpeel monad CombinationalSemantics].
     cbn [bind ret Monad_ident unIdent] in *.
     rewrite mapT_vector_ident.
     revert va vb; induction n; intros; [ lia | ].
@@ -154,7 +154,7 @@ End Combinators.
 Section Vectors.
   Lemma xorV_unIdent n a b :
     n <> 0 ->
-    unIdent (@xorV _ _ Monad_ident n ([a],[b])) = [Vector.map2 xorb a b].
+    unIdent (@xorV _ _ n ([a],[b])) = [Vector.map2 xorb a b].
   Proof.
     intros. cbv [xorV]. cbn [fst snd].
     erewrite zipWith_unIdent; [ reflexivity | lia | ].
@@ -178,4 +178,5 @@ Ltac simpl_ident :=
                                   instantiate_app_by_reflexivity ]
           | erewrite fold_left_ext; [ | intros; progress simpl_ident;
                                         instantiate_app_by_reflexivity ]
-          | progress cbn [fst snd bind ret Monad_ident unIdent] ].
+          | progress cbn [fst snd bind ret Monad_ident monad
+                              CombinationalSemantics unIdent] ].

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -291,6 +291,7 @@ Definition instantiateNet (intf : CircuitInterface)
 
 Instance CavaCombinationalNet : Cava denoteSignal := {
     cava := state CavaState;
+    monad := Monad_state _;
     constant b := if b then Vcc else Gnd;
     defaultSignal := defaultNetSignal;
     inv := invNet;

--- a/cava/Cava/Acorn/XilinxAdder.v
+++ b/cava/Cava/Acorn/XilinxAdder.v
@@ -33,7 +33,6 @@ Local Open Scope type_scope.
 
 Section WithCava.
   Context {signal} {m : Cava signal}.
-  Context {monad: Monad cava}.
 
   (****************************************************************************)
   (* Build a full-adder with explicit use of Xilinx FPGA fast carry logic     *)

--- a/cava/Cava/Lib/BitVectorOps.v
+++ b/cava/Cava/Lib/BitVectorOps.v
@@ -27,7 +27,7 @@ Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (* A circuit to xor two bit-vectors *)
   Definition xorV {n : nat} (ab: signal (Vec Bit n) * signal (Vec Bit n)) :

--- a/cava/Cava/Lib/FullAdder.v
+++ b/cava/Cava/Lib/FullAdder.v
@@ -26,7 +26,7 @@ Require Import Cava.ListUtils.
 Require Import Cava.Acorn.Acorn.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (****************************************************************************)
   (* Build a half-adder                                                       *)

--- a/cava/Cava/Lib/UnsignedAdderProofs.v
+++ b/cava/Cava/Lib/UnsignedAdderProofs.v
@@ -129,7 +129,7 @@ Proof.
 Qed.
 
 Lemma colV_colL {A B C} {n} circuit inputs d :
-  @colV _ CombinationalSemantics _ A B C n circuit inputs =
+  @colV _ CombinationalSemantics A B C n circuit inputs =
   (let inputL := (fst inputs, to_list (snd inputs)) in
    rL <- colL circuit inputL ;;
       let rV := VectorUtils.resize_default

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -31,7 +31,7 @@ Require Import Cava.Lib.FullAdder.
 Local Open Scope vector_scope.
 
 Section WithCava.
-  Context {signal} {semantics: Cava signal} `{Monad cava}.
+  Context {signal} {semantics: Cava signal}.
 
   (* Vector version *)
 

--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -45,12 +45,12 @@ Import StateTypeConversions.LittleEndian.
 Local Notation round_constant := (Vec Bit 8) (only parsing).
 Local Notation round_index := (Vec Bit 4) (only parsing).
 
-Axiom shift_rows : forall {signal} {semantics : Cava signal} {monad : Monad cava},
+Axiom shift_rows : forall {signal} {semantics : Cava signal},
     signal Bit -> signal state -> cava (signal state).
-Axiom mix_columns : forall {signal} {semantics : Cava signal} {monad : Monad cava},
+Axiom mix_columns : forall {signal} {semantics : Cava signal},
     signal Bit -> signal state -> cava (signal state).
 
-Axiom key_expand : forall {signal} {semantics : Cava signal} {monad : Monad cava},
+Axiom key_expand : forall {signal} {semantics : Cava signal},
     signal Bit -> signal round_index -> signal key * signal round_constant ->
     cava (signal key * signal round_constant).
 Axiom key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8.
@@ -103,7 +103,7 @@ Axiom key_expand_equiv :
 Hint Resolve add_round_key_equiv sub_bytes_equiv shift_rows_equiv
      mix_columns_equiv : subroutines_equiv.
 
-Definition full_cipher {signal} {semantics : Cava signal} {monad : Monad cava}
+Definition full_cipher {signal} {semantics : Cava signal}
            (num_rounds_regular round_0 : signal (Vec Bit 4))
   : signal Bit -> signal key -> signal (Vec Bit 8) ->
     list (signal (Vec Bit 4)) -> signal state -> cava (signal state) :=

--- a/silveroak-opentitan/aes/Acorn/AddRoundKey.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKey.v
@@ -34,7 +34,6 @@ Import Common.Notations.
 
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
-  Context {monad: Monad cava}.
 
   (* Perform the bitwise XOR of two 4-element vectors of 8-bit values. *)
   Definition xor4xV

--- a/silveroak-opentitan/aes/Acorn/CipherRound.v
+++ b/silveroak-opentitan/aes/Acorn/CipherRound.v
@@ -31,7 +31,7 @@ Import Common.Notations.
 Local Open Scope monad_scope.
 
 Section WithCava.
-  Context {signal} {semantics : Cava signal} {monad: Monad cava}.
+  Context {signal} {semantics : Cava signal}.
   Context {round_index round_constant : SignalType}.
 
   Context (sub_bytes:     signal Bit -> signal state -> cava (signal state))

--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -13,7 +13,6 @@ shift_rows_equiv
      else to_cols_bitvecs (AES256.shift_rows (from_cols_bitvecs st))]
 shift_rows
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
     signal Bit ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
@@ -25,7 +24,6 @@ mix_columns_equiv
      else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
 mix_columns
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
     signal Bit ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
@@ -40,7 +38,6 @@ key_expand_equiv
      ([to_cols_bitvecs (fst kr)], [snd kr]))
 key_expand
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
     signal Bit ->
     signal (Vec Bit 4) ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8) ->

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -13,7 +13,6 @@ shift_rows_equiv
      else to_cols_bitvecs (AES256.shift_rows (from_cols_bitvecs st))]
 shift_rows
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
     signal Bit ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
@@ -25,7 +24,6 @@ mix_columns_equiv
      else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
 mix_columns
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
     signal Bit ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
@@ -40,7 +38,6 @@ key_expand_equiv
      ([to_cols_bitvecs (fst kr)], [snd kr]))
 key_expand
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    Monad cava ->
     signal Bit ->
     signal (Vec Bit 4) ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8) ->

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -43,7 +43,6 @@ Local Notation "v [@ n ]" := (indexConst v n) (at level 1, format "v [@ n ]").
 
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
-  Context {monad: Monad cava}.
 
   Definition aes_mix_single_column
     (op_i: signal Bit) (data_i: signal (Vec byte 4))

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -35,7 +35,6 @@ Local Notation "v [@ n ]" := (indexConst v n) (at level 1, format "v [@ n ]").
 
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
-  Context {monad: Monad cava}.
 
   Definition aes_transpose {n m}
       (matrix : signal (Vec (Vec byte n) m))

--- a/silveroak-opentitan/aes/Acorn/ShiftRows.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRows.v
@@ -41,7 +41,6 @@ Local Notation "v [@ n ]" := (indexConst v n) (at level 1, format "v [@ n ]").
 
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
-  Context {monad: Monad cava}.
 
   Definition aes_circ_byte_shift (shift: nat) (input: signal (Vec byte 4)):
     cava (signal (Vec byte 4)) :=

--- a/silveroak-opentitan/aes/Acorn/SubBytes.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytes.v
@@ -138,7 +138,6 @@ End SboxLut.
 
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
-  Context {monad: Monad cava}.
 
   Definition bitvec_to_signal {n : nat} (lut : t bool n) : signal (Vec Bit n) :=
     unpeel (map constant lut).

--- a/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
+++ b/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
@@ -65,7 +65,7 @@ out    0  0  0  3  7 12 12 19
 
 Section WithCava.
   Context {signal} {combsemantics: Cava signal}
-          {semantics: CavaSeq combsemantics} `{Monad cava}.
+          {semantics: CavaSeq combsemantics}.
 
   Definition mux2 {A} (sel : signal Bit) (f : signal A) (t : signal A)
     : cava (signal A) :=
@@ -115,7 +115,7 @@ Definition accumulatingAdderEnable_Netlist
 
 Section WithCava.
   Context {signal} {combsemantics: Cava signal}
-          {semantics: CavaSeq combsemantics} `{Monad cava}.
+          {semantics: CavaSeq combsemantics}.
 
   Definition accumulatingAdderEnable2 (en : signal Bit) :
                                        signal (Vec Bit 8) ->

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -65,7 +65,7 @@ s   :  0 0 14  7 17 1
 
 Section WithCava.
   Context {signal} {combsemantics: Cava signal}
-          {semantics: CavaSeq combsemantics} `{Monad cava}.
+          {semantics: CavaSeq combsemantics}.
 
   Definition addWithDelay : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
     := loopDelayS (addN >=> delay).

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -33,7 +33,7 @@ Require Import Coq.Bool.Bvector.
 From Coq Require Import Bool.Bvector.
 
 Section WithCava.
-  Context `{CavaSeq} `{Monad cava}.
+  Context `{CavaSeq}.
 
   Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : signal (Vec Bit n) :=
     unpeel (Vector.map constant lut).

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -49,7 +49,7 @@ bit-growth i.e. it computes (a + b) mod 256.
 
 Section WithCava.
   Context {signal} {combsemantics: Cava signal}
-          {semantics: CavaSeq combsemantics} `{Monad cava}.
+          {semantics: CavaSeq combsemantics}.
 
   Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
     := loopDelayS addN.

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -58,7 +58,8 @@ Lemma countForkCorrect:
     = (addNSpec [i] [s], addNSpec [i] [s]).
 Proof.
   intros; cbv [mcompose].
-  cbn [bind ret Monad_ident].
+  cbn [bind ret monad CombinationalSemantics
+            Monad_ident].
   rewrite fork2Correct, !addNCorrect;
   reflexivity.
 Qed.

--- a/tests/CountBy/TimedProofs.v
+++ b/tests/CountBy/TimedProofs.v
@@ -37,7 +37,7 @@ Require Import Tests.CountBy.CountBy.
 (* Need to redefine count-by to use the version of sequential semantics that
    assumes the sequential part is in the monad *)
 Section WithCava.
-  Context `{semantics:CavaSeqMonad} `{Monad cava}.
+  Context `{semantics:CavaSeqMonad}.
 
   Definition countBy : cava (signal (Vec Bit 8)) -> cava (signal (Vec Bit 8))
     := loopDelaySm addN.

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -54,6 +54,7 @@ Definition addNSpec {ticks : nat} {n} (a b : Vector.t (Bvector n) ticks)
 Local Ltac seqsimpl_step :=
   first [ progress cbn beta iota delta
                    [fst snd hd loopSeqSV' loopDelayS loopDelaySR
+                        monad SequentialVectorCombSemantics
                         SequentialVectorSemantics]
         | progress cbv beta iota delta [loopSeqSV]; seqsimpl_step
         | progress autorewrite with seqsimpl
@@ -79,7 +80,7 @@ Lemma countForkStepOnce (ticks: nat) (i s : Vector.t (Bvector 8) 1) :
   = countBySpec' (Vector.hd s) i.
 Proof.
   intros. unfold mcompose. cbv [countBySpec' stepOnce].
-  simpl_ident.
+  cbn [monad SequentialVectorCombSemantics]. simpl_ident.
   change (t (Signal.combType (Signal.Vec Signal.Bit 8)) (S ticks)) with
       (Signal.seqVType (S ticks) (Signal.Vec Signal.Bit 8)).
   rewrite addNCorrect with (ticks:=S ticks).

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -33,7 +33,7 @@ From Coq Require Import Bool.Bvector.
 (******************************************************************************)
 
 Section WithCava.
-  Context `{CavaSeq} `{Monad cava}.
+  Context `{CavaSeq}.
 
   Definition delayByte (i : signal (Vec Bit 8))
                        : cava (signal (Vec Bit 8)) :=
@@ -84,7 +84,7 @@ Definition delayByte_tb
 (******************************************************************************)
 
 Section WithCava.
-  Context `{CavaSeq} `{Monad cava}.
+  Context `{CavaSeq}.
 
   Definition delayEnableByte (en_i : signal Bit * signal (Vec Bit 8))
                              : cava (signal (Vec Bit 8)) :=
@@ -145,7 +145,7 @@ Definition delayEnableByte_tb
 (******************************************************************************)
 
 Section WithCava.
-  Context `{semantics: CavaSeq} `{Monad cava}.
+  Context `{semantics: CavaSeq}.
 
  (* A nand-gate with registers after the AND gate and the INV gate. *)
   Definition pipelinedNAND : signal Bit * signal Bit -> cava (signal Bit) :=

--- a/tests/Instantiate.v
+++ b/tests/Instantiate.v
@@ -29,7 +29,7 @@ Local Open Scope monad_scope.
 Local Open Scope string_scope.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   Definition nand2_gate (ab : signal Bit * signal Bit) : cava (signal Bit) :=
     x <- and2 ab ;;

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -30,7 +30,7 @@ Import Vector.VectorNotations.
 Local Open Scope vector_scope.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (* muxPair specialized to single bit inputs *)
   Definition mux2_1: signal Bit -> signal Bit * signal Bit -> cava (signal Bit)

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -26,7 +26,7 @@ Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   (* A top-level multiplier circuit that can be compiled to a top-level
     SystemVerilog circuit. *)

--- a/tests/xilinx/LUTTests.v
+++ b/tests/xilinx/LUTTests.v
@@ -24,7 +24,7 @@ Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} `{Cava signal}.
 
   Definition lut1_inv (i: signal Bit) : cava (signal Bit) :=
     o <- lut1 negb i ;;


### PR DESCRIPTION
Following up on a conversation with @satnam6502 

Previously, we've had section headers like:
```coq
Context {signal} {semantics : Cava signal} {monad: Monad cava}
```
This PR removes the need to specify the `Monad` instance by including it in `CavaClass` using a special syntax `:>` that makes typeclass inference pick up on the instance. The header changes to just:
```coq
Context {signal} {semantics : Cava signal}.
```