### PR TITLE
Remove pairSel from CavaClass

### DIFF
--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -58,8 +58,6 @@ Class Cava (signal : SignalType -> Type) := {
   (* Converting to/from Vector.t *)
   peel : forall {t : SignalType} {s : nat}, signal (Vec t s) -> Vector.t (signal t) s;
   unpeel : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> signal (Vec t s);
-  (* Dynamic indexing *)
-  pairSel : forall {t : SignalType}, signal Bit -> signal (Pair t t) -> signal t;
   indexAt : forall {t : SignalType} {sz isz: nat},
             signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
             signal (Vec Bit isz) ->  (* A bit-vector index of size isz bits *)

--- a/cava/Cava/Acorn/CavaPrelude.v
+++ b/cava/Cava/Acorn/CavaPrelude.v
@@ -48,6 +48,13 @@ Section WithCava.
   let (a, b) := ab in
   ret (indexAt (unpeel [a; b]) (unpeel [sel])).
 
+  (* A variant of muxPair that works over a Cava pair. *)
+  Definition pairSel {A : SignalType}
+                     (sel : signal Bit)
+                     (ab : signal (Pair A A)) : signal A :=
+  let (a, b) := unpair ab in
+  indexAt (unpeel [a; b]) (unpeel [sel]).
+
   (* A unit delay with a default reset value. *)
   Definition delay {A : SignalType} (i : signal A) : cava (signal A) :=
     delayWith (defaultCombValue A) i.

--- a/cava/Cava/Acorn/CombinationalMonad.v
+++ b/cava/Cava/Acorn/CombinationalMonad.v
@@ -107,10 +107,6 @@ Definition pairSelBool {t : SignalType}
                        (sel : bool) (v : combType t * combType t) :=
   if sel then snd v else fst v.
 
-Definition pairSelList {t: SignalType} (sel : seqType Bit) (v: seqType (Pair t t))
-  : list (combType t) :=
-  map (fun '(x,y,sel) => if (sel : bool) then y else x) (pad_combine v sel).
-
 Definition indexConstBoolList {t: SignalType} {sz: nat}
            (v : seqType (Vec t sz)) (sel : nat)
   : seqType t :=
@@ -180,7 +176,6 @@ Instance CombinationalSemantics : Cava seqType :=
     mkpair _ _ v1 v2 := pad_combine v1 v2;
     peel _ _ v := peelVecList v;
     unpeel _ _ v := unpeelVecList v;
-    pairSel t sel v := pairSelList sel v;
     indexAt t sz isz := @indexAtBoolList t sz isz;
     indexConst t sz := @indexConstBoolList t sz;
     slice t sz := @sliceBoolList t sz;

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -201,14 +201,6 @@ Definition peelNet {t : SignalType} {s : nat} (v : Signal (Vec t s)) : Vector.t 
 Definition unpeelNet {t : SignalType} {s : nat} (v: Vector.t (Signal t) s) : Signal (Vec t s) :=
   VecLit v.
 
-Local Open Scope vector_scope.
-
-Definition pairSelNet {t : SignalType}
-                      (sel : Signal Bit)
-                      (ab : Signal (Pair t t)) : Signal t :=
- let (a, b) := unpairNet ab in
- IndexAt (unpeelNet [a; b]) (unpeelNet [sel]).
-
 Definition sliceNet {t: SignalType} {sz: nat}
                     (startAt len: nat)
                     (v: Signal (Vec t sz))
@@ -314,7 +306,6 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     unpair := @unpairNet;
     peel := @peelNet;
     unpeel := @unpeelNet;
-    pairSel t := pairSelNet;
     indexAt k sz isz := IndexAt;
     indexConst k sz := IndexConst;
     slice k sz := @sliceNet k sz;

--- a/cava/Cava/Acorn/SequentialTimed.v
+++ b/cava/Cava/Acorn/SequentialTimed.v
@@ -153,7 +153,6 @@ Definition blackBoxF (intf : CircuitInterface)
     unpair _ _ v := v;
     peel _ _ v := v;
     unpeel _ _ v := v;
-    pairSel _ v sel := pairSelBool v sel;
     indexAt t sz isz := @indexAtBoolF t sz isz;
     indexConst t sz := @indexConstBoolF t sz;
     slice t sz startAt len v H := sliceVector v startAt len H;

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -259,7 +259,6 @@ Definition delayV (ticks : nat) (t : SignalType) (def : combType t) : seqVType t
     unpair _ _ v := separate v;
     peel _ _ v := peelVecVec ticks v;
     unpeel _ _ v := unpeelVecVec ticks v;
-    pairSel t v sel := map2 pairSelBool v sel;
     indexAt t sz isz := @indexAtBoolVec t sz isz ticks;
     indexConst t sz := @indexConstBoolVec t sz ticks;
     slice t sz := @sliceBoolVec t sz ticks;

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -1125,6 +1125,26 @@ Section InV.
            | H : ?P |- _ \/ ?P => right; assumption
            end.
   Qed.
+
+  Lemma map_ext_InV {A B n} (f g : A -> B) (v : Vector.t A n) :
+    (forall a, InV a v -> f a = g a) -> map f v = map g v.
+  Proof.
+    revert v; induction n; intros;
+      [ eapply case0 with (v:=v); cbn [InV]; tauto | ].
+    rewrite (eta v) in *; cbn [InV] in *.
+    autorewrite with push_vector_map vsimpl in *.
+    f_equal; auto.
+  Qed.
+
+  Lemma map2_ext_InV {A B C n} (f g : A -> B -> C) (va : Vector.t A n) vb :
+    (forall a b, InV a va -> InV b vb -> f a b = g a b) -> map2 f va vb = map2 g va vb.
+  Proof.
+    revert va vb; induction n; intros;
+      [ eapply case0 with (v:=va); cbn [InV]; tauto | ].
+    rewrite (eta va), (eta vb) in *; cbn [InV] in *.
+    autorewrite with push_vector_map vsimpl in *.
+    f_equal; auto.
+  Qed.
 End InV.
 
 Section ForallV.

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -93,7 +93,7 @@ Section WithSubroutines.
     first [ destruct_pair_let
           | rewrite N2Nat.id
           | rewrite N2Bv_sized_Bv2N
-          | rewrite (pairSel_mkpair (t:=Vec (Vec (Vec Bit 8) 4) 4))
+          | rewrite (pairSel_mkpair_singleton (t:=Vec (Vec (Vec Bit 8) 4) 4))
           | progress autorewrite with to_spec
           | progress simpl_ident ]; [ ].
   Local Ltac simplify := repeat simplify_step.

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -29,6 +29,7 @@ Require Import Cava.ListUtils.
 Require Import Cava.Tactics.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Acorn.Identity.
+Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Acorn.SequentialProperties.
 Require Import Cava.Lib.UnsignedAdders.
 
@@ -66,7 +67,10 @@ Lemma mux2Correct {A} (sel : seqType Bit) (f t : seqType A) :
                                    (pad_combine (pad_combine f t) sel).
 Proof.
   intros; cbv [mux2 sequential]. seqsimpl.
-  cbv [pairSel pairSelList CombinationalSemantics]. fold combType.
+  cbv [pairSel mkpair unpeel unpeelVecList
+               Vector.map Vector.fold_left
+               CombinationalSemantics].
+  fold combType.
   apply map_ext; intros. reflexivity.
 Qed.
 Hint Rewrite @mux2Correct using solve [eauto] : seqsimpl.

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -67,11 +67,7 @@ Lemma mux2Correct {A} (sel : seqType Bit) (f t : seqType A) :
                                    (pad_combine (pad_combine f t) sel).
 Proof.
   intros; cbv [mux2 sequential]. seqsimpl.
-  cbv [pairSel mkpair unpeel unpeelVecList
-               Vector.map Vector.fold_left
-               CombinationalSemantics].
-  fold combType.
-  apply map_ext; intros. reflexivity.
+  apply pairSel_mkpair.
 Qed.
 Hint Rewrite @mux2Correct using solve [eauto] : seqsimpl.
 


### PR DESCRIPTION
Remove pairSel from CavaClass because it does not need an axiomatic definition because it can be defined in terms of vectors and vector indexing i.e. `indexAt`.
Some proofs will beed to be updated. @jadephilipoom please can you take care of that and if everything looks good then go ahead and merge? Thank you kindly.