### PR TITLE
Correct and clear specifications for OT AES subcircuits

### DIFF
--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -2,15 +2,11 @@ Axioms:
 sub_bytes_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (sub_bytes [is_decrypt] [st]) =
-    [if is_decrypt
-     then to_cols_bitvecs (inv_sub_bytes (from_cols_bitvecs st))
-     else to_cols_bitvecs (AES256.sub_bytes (from_cols_bitvecs st))]
+    [aes_sub_bytes_circuit_spec is_decrypt st]
 shift_rows_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (shift_rows [is_decrypt] [st]) =
-    [if is_decrypt
-     then to_cols_bitvecs (inv_shift_rows (from_cols_bitvecs st))
-     else to_cols_bitvecs (AES256.shift_rows (from_cols_bitvecs st))]
+    [aes_shift_rows_circuit_spec is_decrypt st]
 shift_rows
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     signal Bit ->
@@ -19,9 +15,7 @@ shift_rows
 mix_columns_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (mix_columns [is_decrypt] [st]) =
-    [if is_decrypt
-     then to_cols_bitvecs (inv_mix_columns (from_cols_bitvecs st))
-     else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
+    [aes_mix_columns_circuit_spec is_decrypt st]
 mix_columns
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     signal Bit ->
@@ -35,7 +29,7 @@ key_expand_equiv
     (let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec
        in
      let kr := spec (N.to_nat (Bv2N round_i)) (flatten_key (k, rcon)) in
-     ([to_cols_bitvecs (fst kr)], [snd kr]))
+     ([from_flat (fst kr)], [snd kr]))
 key_expand
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     signal Bit ->

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -2,15 +2,11 @@ Axioms:
 sub_bytes_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (sub_bytes [is_decrypt] [st]) =
-    [if is_decrypt
-     then to_cols_bitvecs (inv_sub_bytes (from_cols_bitvecs st))
-     else to_cols_bitvecs (AES256.sub_bytes (from_cols_bitvecs st))]
+    [aes_sub_bytes_circuit_spec is_decrypt st]
 shift_rows_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (shift_rows [is_decrypt] [st]) =
-    [if is_decrypt
-     then to_cols_bitvecs (inv_shift_rows (from_cols_bitvecs st))
-     else to_cols_bitvecs (AES256.shift_rows (from_cols_bitvecs st))]
+    [aes_shift_rows_circuit_spec is_decrypt st]
 shift_rows
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     signal Bit ->
@@ -19,9 +15,7 @@ shift_rows
 mix_columns_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (mix_columns [is_decrypt] [st]) =
-    [if is_decrypt
-     then to_cols_bitvecs (inv_mix_columns (from_cols_bitvecs st))
-     else to_cols_bitvecs (AES256.mix_columns (from_cols_bitvecs st))]
+    [aes_mix_columns_circuit_spec is_decrypt st]
 mix_columns
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     signal Bit ->
@@ -35,7 +29,7 @@ key_expand_equiv
     (let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec
        in
      let kr := spec (N.to_nat (Bv2N round_i)) (flatten_key (k, rcon)) in
-     ([to_cols_bitvecs (fst kr)], [snd kr]))
+     ([from_flat (fst kr)], [snd kr]))
 key_expand
   : forall (signal : SignalType -> Type) (semantics : Cava signal),
     signal Bit ->

--- a/silveroak-opentitan/aes/Spec/StateTypeConversions.v
+++ b/silveroak-opentitan/aes/Spec/StateTypeConversions.v
@@ -206,6 +206,21 @@ Section Properties.
   Proof. cbv [from_list_rows to_list_rows]. inverse. Qed.
   Hint Rewrite from_list_rows_to_list_rows : inverse.
 
+  Lemma map2_to_cols_bits (f : bool -> bool -> bool) (v1 v2 : Vector.t bool 128):
+    Vector.map2 (Vector.map2 f) (to_cols_bits v1) (to_cols_bits v2)
+    = to_cols_bits (Vector.map2 f v1 v2).
+  Proof.
+    cbv [to_cols_bits to_cols to_big_endian_bytes
+                      bitvec_to_bytevec bytevec_to_bitvec ].
+    repeat first [ rewrite map_map
+                 | rewrite map2_map
+                 | rewrite map_map2
+                 | rewrite bitvec_to_byte_to_bitvec
+                 | apply map2_ext; intros
+                 | rewrite map2_flatten; apply (f_equal flatten)
+                 | progress autorewrite with pull_vector_map ].
+    reflexivity.
+  Qed.
 End Properties.
 Hint Rewrite to_big_endian_bytes_from_big_endian_bytes
      from_big_endian_bytes_to_big_endian_bytes
@@ -217,5 +232,7 @@ Hint Rewrite to_big_endian_bytes_from_big_endian_bytes
      using solve [eauto] : conversions.
 Hint Rewrite to_list_rows_from_list_rows
      using solve [length_hammer] : conversions.
+Hint Rewrite @map2_to_cols_bits using solve [eauto] : push_vector_map.
+Hint Rewrite <- @map2_to_cols_bits using solve [eauto] : pull_vector_map.
 Hint Resolve to_list_rows_length_outer
      to_list_rows_length_inner : length.


### PR DESCRIPTION
In #494, we added a section to `Spec/AES256.v` with a conversion to and from the representation used by OpenTitan (which is actually row-major, not column-major as in FIPS) for use with tests. A few of our circuit-equivalence axioms (`shift_rows_equiv` and `mix_columns_equiv`) were therefore incorrect as stated; they assumed a column-major order. I said I'd follow up with something that made us use this conversion everywhere and clarify our circuit specs a bit, and this is that follow-up!

Changes:
- Added specifications for all subcircuits using the new `to_flat` and `from_flat` definitions to convert back and forth between OT's representation to the flat vector used by the specs
- Change axioms in `AESEquivalence` and `add_round_key` lemma statement to use the new specifications
- Repaired `add_round_key_equiv` proof (now that the implementation is row-major, it was slightly more complicated because it had a `transpose` in it, but I added some automation so the proof actually got shorter)
- Helper vector lemmas needed for `add_round_key_equiv`

This change reduces confusion about state representation and makes our equivalence proof statements a little cleaner; the axiom for `shift_rows` equivalence, for instance, went from:
```coq
Axiom shift_rows_equiv :
  forall (is_decrypt : bool) (st : combType state),
    unIdent (shift_rows [is_decrypt] [st])
    = [if is_decrypt
       then to_cols_bitvecs (AES256.inv_shift_rows (from_cols_bitvecs st))
       else to_cols_bitvecs (AES256.shift_rows (from_cols_bitvecs st))].
```
to
```coq
Axiom shift_rows_equiv :
  forall (is_decrypt : bool) (st : combType state),
    unIdent (shift_rows [is_decrypt] [st])
    = [AES256.aes_shift_rows_circuit_spec is_decrypt st].
```

@smore-lore @blaxill If you've already written lemma statements for the `sub_bytes` and `shift_rows` equivalence proofs based on the old axioms, you should update to the new ones. Sorry for the conflict!