### PR TITLE
Faster simpl_ident

### DIFF
--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -172,11 +172,5 @@ Hint Rewrite @zipWith_unIdent @xorV_unIdent
 Ltac simpl_ident :=
   repeat
     first [ progress autorewrite with simpl_ident
-          | erewrite map2_ext; [ | intros; progress simpl_ident;
-                                   instantiate_app_by_reflexivity ]
-          | erewrite map_ext; [ | intros; progress simpl_ident;
-                                  instantiate_app_by_reflexivity ]
-          | erewrite fold_left_ext; [ | intros; progress simpl_ident;
-                                        instantiate_app_by_reflexivity ]
           | progress cbn [fst snd bind ret Monad_ident monad
                               CombinationalSemantics unIdent] ].


### PR DESCRIPTION
The `simpl_ident` tactic was slow on a few goals I've tried it on, and on one seemed to even maybe be infinite-looping. It turns out we don't use the recursive cases anyway, so I've just removed them to improve the tactic's performance.