### PR TITLE
Plug in mix-columns and shift-rows implementations

### DIFF
--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -5,22 +5,12 @@ sub_bytes_equiv
     [aes_sub_bytes_circuit_spec is_decrypt st]
 shift_rows_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
-    unIdent (shift_rows [is_decrypt] [st]) =
+    unIdent (aes_shift_rows [is_decrypt] [st]) =
     [aes_shift_rows_circuit_spec is_decrypt st]
-shift_rows
-  : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    signal Bit ->
-    signal (Vec (Vec (Vec Bit 8) 4) 4) ->
-    cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 mix_columns_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
-    unIdent (mix_columns [is_decrypt] [st]) =
+    unIdent (aes_mix_columns [is_decrypt] [st]) =
     [aes_mix_columns_circuit_spec is_decrypt st]
-mix_columns
-  : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    signal Bit ->
-    signal (Vec (Vec (Vec Bit 8) 4) 4) ->
-    cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
 key_expand_equiv
   : forall (is_decrypt : bool) (round_i : t bool 4)

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -5,22 +5,12 @@ sub_bytes_equiv
     [aes_sub_bytes_circuit_spec is_decrypt st]
 shift_rows_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
-    unIdent (shift_rows [is_decrypt] [st]) =
+    unIdent (aes_shift_rows [is_decrypt] [st]) =
     [aes_shift_rows_circuit_spec is_decrypt st]
-shift_rows
-  : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    signal Bit ->
-    signal (Vec (Vec (Vec Bit 8) 4) 4) ->
-    cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 mix_columns_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
-    unIdent (mix_columns [is_decrypt] [st]) =
+    unIdent (aes_mix_columns [is_decrypt] [st]) =
     [aes_mix_columns_circuit_spec is_decrypt st]
-mix_columns
-  : forall (signal : SignalType -> Type) (semantics : Cava signal),
-    signal Bit ->
-    signal (Vec (Vec (Vec Bit 8) 4) 4) ->
-    cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
 key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
 key_expand_equiv
   : forall (is_decrypt : bool) (round_i : t bool 4)


### PR DESCRIPTION
Equivalence proofs are still admitted, but since we now have implementations for `mix_columns` and `shift_rows` I removed the axioms in `AESEquivalence.v`. The equivalence proofs are still admitted, but at least we have some assurance that the types match and there are no more proof-slowness problems around unfolding the implementations like we had with `sub_bytes`.