### PR TITLE
Add assumption-tracking files back to version control

### DIFF
--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -1,0 +1,25 @@
+Axioms:
+sub_bytes_equiv
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (aes_sub_bytes [is_decrypt] [st]) =
+    [aes_sub_bytes_circuit_spec is_decrypt st]
+mix_columns_equiv
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (aes_mix_columns [is_decrypt] [st]) =
+    [aes_mix_columns_circuit_spec is_decrypt st]
+key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
+key_expand_equiv
+  : forall (is_decrypt : bool) (round_i : t bool 4)
+      (k : t (t (t bool 8) 4) 4) (rcon : t bool 8),
+    combinational (key_expand [is_decrypt] [round_i] ([k], [rcon])) =
+    (let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec
+       in
+     let kr := spec (N.to_nat (Bv2N round_i)) (flatten_key (k, rcon)) in
+     ([from_flat (fst kr)], [snd kr]))
+key_expand
+  : forall (signal : SignalType -> Type) (semantics : Cava signal),
+    signal Bit ->
+    signal (Vec Bit 4) ->
+    signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8) ->
+    cava (signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8))
+inv_key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -1,0 +1,25 @@
+Axioms:
+sub_bytes_equiv
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (aes_sub_bytes [is_decrypt] [st]) =
+    [aes_sub_bytes_circuit_spec is_decrypt st]
+mix_columns_equiv
+  : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
+    unIdent (aes_mix_columns [is_decrypt] [st]) =
+    [aes_mix_columns_circuit_spec is_decrypt st]
+key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
+key_expand_equiv
+  : forall (is_decrypt : bool) (round_i : t bool 4)
+      (k : t (t (t bool 8) 4) 4) (rcon : t bool 8),
+    combinational (key_expand [is_decrypt] [round_i] ([k], [rcon])) =
+    (let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec
+       in
+     let kr := spec (N.to_nat (Bv2N round_i)) (flatten_key (k, rcon)) in
+     ([from_flat (fst kr)], [snd kr]))
+key_expand
+  : forall (signal : SignalType -> Type) (semantics : Cava signal),
+    signal Bit ->
+    signal (Vec Bit 4) ->
+    signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8) ->
+    cava (signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8))
+inv_key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8


### PR DESCRIPTION
I completely missed in reviewing #532 that these files were removed. They are autogenerated files, but my argument for keeping them version-controlled is that they're a good way to track exactly what assumptions our top-level theorems depend on. And if some change introduces a new axiom (for example, one of the axioms provided by the standard library in certain imports like `Classical`), it will automatically show up here and raise the proper red flags!