### PR TITLE
Add `aes_cipher_core` without additional status signals

### DIFF
--- a/silveroak-opentitan/aes/Acorn/Cipher.v
+++ b/silveroak-opentitan/aes/Acorn/Cipher.v
@@ -181,7 +181,7 @@ Section WithCava.
              (round_i : signal round_index) (input : signal state)
     : cava (signal state) :=
     initial_rcon <- muxPair is_decrypt (initial_rcon_forward, initial_rcon_backward) ;;
-    let initial_state := mkpair (mkpair initial_key initial_rcon) input in
+    let initial_state := packed_signal cipher_state (initial_key, initial_rcon, input) in
     (* join all signals that are needed inside the cipher loop *)
     let loop_input := packed_signal cipher_signals
       (is_decrypt, num_rounds_regular, round_0, initial_state, round_i) in

--- a/silveroak-opentitan/aes/Acorn/Cipher.v
+++ b/silveroak-opentitan/aes/Acorn/Cipher.v
@@ -42,6 +42,7 @@ Section WithCava.
   Context (key_expand : signal Bit -> signal round_index ->
                         (signal key  * signal round_constant) ->
                         cava (signal key * signal round_constant)).
+
   Local Infix "==?" := eqb (at level 40).
   Local Infix "**" := Pair (at level 40, left associativity).
 
@@ -49,11 +50,43 @@ Section WithCava.
   Let cipher_state : SignalType := key ** round_constant ** state.
   (* The non-state signals that each round of the cipher loop needs access to *)
   Let cipher_signals : SignalType :=
-    round_index (* num_rounds_regular : round index of final round *)
+    Bit (* op_i/is_decrypt : true for decryption, false for encryption *)
+      ** round_index (* num_rounds_regular : round index of final round *)
       ** round_index (* round_0 : round index of first round *)
-      ** Bit (* op_i/is_decrypt : true for decryption, false for encryption *)
       ** cipher_state (* initial state, ignored for all rounds except first *)
       ** round_index (* current round_index *).
+
+  Let cipher_control_state : SignalType :=
+    Bit            (* idle *)
+    ** Bit         (* generating decryption key *)
+    ** round_index (* current round *)
+    ** Bit         (* in_ready_o *)
+    ** Bit         (* out_valid_o *)
+    ** state       (* state_o *)
+    ** Bit         (* out latch when not accepted *).
+
+  Section Packing.
+    Fixpoint unpacked_left_type A: Type :=
+      match A with
+      | Pair a b => unpacked_left_type a * signal b
+      | x => signal x
+      end.
+
+    Fixpoint unpacked_signal {A}: signal A -> unpacked_left_type A :=
+      match A as A return signal A -> unpacked_left_type A with
+      | Pair a b => fun x =>
+        let '(y,z) := unpair x in
+        (unpacked_signal y, z)
+      | _ => fun x => x
+      end.
+
+    Fixpoint packed_signal A: unpacked_left_type A -> signal A :=
+      match A with
+      | Pair a b => fun '(x,y) =>
+        mkpair (packed_signal _ x) y
+      | _ => fun x => x
+      end.
+  End Packing.
 
   Definition cipher_round
              (is_decrypt : signal Bit) (input: signal state) (key : signal key)
@@ -123,33 +156,102 @@ Section WithCava.
              (input_and_state : signal cipher_signals * signal cipher_state)
     : cava (signal cipher_state) :=
     let '(input, feedback_state) := input_and_state in
-    let '(input, idx) := unpair input in
-    let '(input, initial_state) := unpair input in
-    let '(input, is_decrypt) := unpair input in
-    let '(num_rounds_regular, round_0) := unpair input in
+    let '(is_decrypt, num_rounds_regular, round_0, initial_state, idx) := unpacked_signal input in
     is_first_round <- idx ==? round_0 ;;
-    cipher_state <- muxPair is_first_round (initial_state, feedback_state) ;;
-    let '(key_round, st) := unpair cipher_state in
-    let '(k, round) := unpair key_round in
-    '(key_round, st) <- cipher_step num_rounds_regular round_0 is_decrypt
+    cipher_state' <- muxPair is_first_round (initial_state, feedback_state) ;;
+    let '(k, round, st) := unpacked_signal cipher_state' in
+    '(k, round, st) <- cipher_step num_rounds_regular round_0 is_decrypt
                                    (k, round, st) idx ;;
-    ret (mkpair (mkpair (fst key_round) (snd key_round)) st).
+    ret (packed_signal cipher_state (k, round, st)).
 
   Context {seqsemantics : CavaSeq semantics}.
+  Context (initial_rcon_forward: signal round_constant). (* #1 *)
+  Context (initial_rcon_backward: signal round_constant). (* #64 *)
 
   Definition cipher_new
              (num_rounds_regular round_0 : signal (round_index))
              (is_decrypt : signal Bit) (* called op_i in OpenTitan *)
-             (initial_key : signal key) (initial_rcon : signal round_constant)
+             (initial_key : signal key)
              (round_i : signal round_index) (input : signal state)
     : cava (signal state) :=
+    initial_rcon <- muxPair is_decrypt (initial_rcon_forward, initial_rcon_backward) ;;
     let initial_state := mkpair (mkpair initial_key initial_rcon) input in
     (* join all signals that are needed inside the cipher loop *)
-    let loop_input :=
-        mkpair (mkpair (mkpair (mkpair num_rounds_regular round_0)
-                               is_decrypt) initial_state) round_i in
+    let loop_input := packed_signal cipher_signals
+      (is_decrypt, num_rounds_regular, round_0, initial_state, round_i) in
     loop_out <- loopDelayS cipher_inner_loop loop_input ;;
     let '(_, final_data) := unpair loop_out in
     ret final_data.
+
+  Context (num_rounds_regular round_0 round_1 round_final: signal (round_index)).
+  Context (inc_round: signal round_index -> cava (signal round_index)).
+
+  (* Comparable to OpenTitan aes_cipher_core but with simplified signalling *)
+  Definition aes_cipher_core_simplified
+    (is_decrypt: signal Bit)
+    (in_valid_i out_ready_i: signal Bit)
+    (initial_key: signal key)
+    (initial_state: signal state)
+    : cava
+    ( signal Bit (* in_ready_o *)
+    * signal Bit (* out_valid_o *)
+    * signal state (* state_o *)
+    ) :=
+    st <- loopDelayS
+    (* state and key buffers are handled by `cipher_new` so we don't explicitly
+    * register them here. There is an additional state buffer here for storing the output
+    * until it is accepted via out_ready_i. *)
+      (fun '((inputs, st) : signal (Pair Bit Bit)  * signal cipher_control_state) =>
+
+        (* unpack inputs and state from Cava 'Pair's *)
+        let '(in_valid_i, out_valid_i) := unpair inputs in
+        let '(last_idle, last_gen_dec_key, last_round, _, _, last_buffered_state, last_output_latch)
+          := unpacked_signal st in
+
+        (* Are we still processing an input (or generating a decryption key) *)
+        is_final_round <- last_round ==? round_final ;;
+        is_finishing <- and2 (is_final_round, last_gen_dec_key) ;;
+        becoming_idle <- or2 (last_idle, is_finishing) ;;
+        inv_last_idle <- inv last_idle ;;
+        (* If we weren't idle and we are about to finish,
+        * we must be producing a new result *)
+        producing_output <- and2 (inv_last_idle, is_finishing) ;;
+        (* Accept input if we are not busy next cycle *)
+        accepted_input <- and2 (becoming_idle, in_valid_i) ;;
+        (* We are only truly idle if there was no incoming input *)
+        inv_in_valid_i <- inv in_valid_i ;;
+        idle <- and2 (becoming_idle, inv_in_valid_i) ;;
+
+        (* Are we generating decryption key?
+        * Decryption requires a full pass to generate decryption key
+        * Currently not implemented/supported *)
+        let generating_decryption_key := constant false in
+
+        (* Update round, hold at 0 if idle. This is correct when accepting input
+        * as acceptance requires becoming_idle is true *)
+        next_round <- inc_round last_round ;;
+        round <- muxPair becoming_idle (round_0, next_round) ;;
+
+        (* we only need to grab the state at the last round *)
+        st <- cipher_new round_final round_0 is_decrypt initial_key round initial_state ;;
+        buffered_state <- muxPair producing_output (st, last_buffered_state) ;;
+
+        out_valid_o <- or2 (last_output_latch, producing_output) ;;
+        inv_out_valid_i <- inv out_valid_i ;;
+        output_latch <- and2 (out_valid_o, inv_out_valid_i) ;;
+
+        ret (packed_signal cipher_control_state
+          ( idle
+          , generating_decryption_key
+          , round
+          , becoming_idle
+          , out_valid_o
+          , buffered_state
+          , output_latch
+          ))
+      ) (mkpair in_valid_i out_ready_i) ;;
+
+    let '(_, _, _, in_ready_o, out_valid_o, state_o, _) := unpacked_signal st in
+    ret (in_ready_o, out_valid_o, state_o).
 
 End WithCava.

--- a/silveroak-opentitan/aes/Acorn/Cipher.v
+++ b/silveroak-opentitan/aes/Acorn/Cipher.v
@@ -42,7 +42,6 @@ Section WithCava.
   Context (key_expand : signal Bit -> signal round_index ->
                         (signal key  * signal round_constant) ->
                         cava (signal key * signal round_constant)).
-
   Local Infix "==?" := eqb (at level 40).
   Local Infix "**" := Pair (at level 40, left associativity).
 


### PR DESCRIPTION
- Additional status signals might be required for OpenTitan
- Inverse/decryption mode currently not operational

Part of #489 