### PR TITLE
Make loop combinator use a Gallina tuple for feedback

### DIFF
--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -104,6 +104,13 @@ Class CavaSeq {signal : SignalType -> Type} (combinationalSemantics : Cava signa
                 (signal A * signal B -> cava (signal B)) ->
                 signal A ->
                 cava (signal B);
+  (* A version of loopDelaySRAlt that has a composite state value of a tuple-type computed
+     from the list B, or a scalar type when B is a singleton list. *)
+  loopDelaySRAlt : forall {A : SignalType} {B : list SignalType},
+                   tupleInterface combType B ->
+                   (signal A * tupleInterface signal B -> cava (tupleInterface signal B)) ->
+                   signal A ->
+                   cava (tupleInterface signal B); 
   (* A version of loopDelayEnable with a clock enable and current state at
      the output. *)
   loopDelaySEnableR : forall {A B: SignalType},

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -277,6 +277,7 @@ Definition delayV (ticks : nat) (t : SignalType) (def : combType t) : seqVType t
      *)
      delayEnableWith k d en i := delayV ticks k d i;
      loopDelaySR A B := @loopSeqSV A B ticks;
+     loopDelaySRAlt A B r f i := ret (tupleInterfaceDefaultSV ticks B); (* dummy *)
      (* TODO(satnam6502, jadep): Placeholder definition for loopDelayEnable for
         now. Replace with actual definition that models clock enable behaviour.
      *)

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -69,6 +69,10 @@ Section WithCava.
 
   Definition addWithDelay : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
     := loopDelayS (addN >=> delay).
+  
+  (* A version to test loopDelaySR *)
+  Definition addWithDelayAlt : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
+    := loopDelaySRAlt (tupleInterfaceDefault [Vec Bit 8]) (addN >=> delay).
 
 End WithCava.
 
@@ -85,4 +89,15 @@ Example addWithDelay_ex2: sequential (addWithDelay (# [1;1;1;1;1;1;1;1;1])) = # 
 Proof. reflexivity. Qed.
 
 Example addWithDelay_ex3: sequential (addWithDelay (# [14; 7; 3; 250])) = # [0; 14; 7; 17; 1].
+Proof. reflexivity. Qed.
+
+(* Test the versions made with loopDelaySRAlt *)
+
+Example addWithDelayAlt_ex1: sequential (addWithDelayAlt (# [0;1;2;3;4;5;6;7;8])) = # [0;0;1;2;4;6;9;12;16;20].
+Proof. reflexivity. Qed.
+
+Example addWithDelayAlt_ex2: sequential (addWithDelayAlt (# [1;1;1;1;1;1;1;1;1])) = # [0;1;1;2;2;3;3;4;4;5].
+Proof. reflexivity. Qed.
+
+Example addWithDelayAlt_ex3: sequential (addWithDelayAlt (# [14; 7; 3; 250])) = # [0; 14; 7; 17; 1].
 Proof. reflexivity. Qed.

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -54,6 +54,16 @@ Section WithCava.
   Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
     := loopDelayS addN.
 
+  (* A version that uses loopDelaySRAlt *)
+  Definition countByAlt : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
+    := loopDelaySRAlt (tupleInterfaceDefault [Vec Bit 8]) addN.
+
+  (* A use of loopDelaySRAlt that has a composite signal which in this case
+     is a toggling output bit in the second element of the state pair. *)
+  Definition countByInvAlt : signal (Vec Bit 8) -> cava (signal (Vec Bit 8) * signal Bit)
+    := loopDelaySRAlt (tupleInterfaceDefault [Vec Bit 8; Bit])
+       (pairLeft >=> first addN >=> second inv).
+
 End WithCava.
 
 (* Convenience notations for certain bytes *)
@@ -69,6 +79,15 @@ Definition b250 := N2Bv_sized 8 250.
 Local Open Scope list_scope.
 
 Example countBy_ex1: sequential (countBy [b14; b7; b3; b250]) = [b14; b21; b24; b18].
+Proof. reflexivity. Qed.
+
+(* Check loopDelaySRAlt version *)
+Example countByAlt_ex1: sequential (countByAlt [b14; b7; b3; b250]) = [b14; b21; b24; b18].
+Proof. reflexivity. Qed.
+
+(* Check the toggling output version. *)
+Example countByInvAlt_ex1: sequential (countByInvAlt [b14; b7; b3; b250])
+  = ([b14; b21; b24; b18], [true; false; true; false]).
 Proof. reflexivity. Qed.
 
 Definition countBy_Interface
@@ -88,3 +107,37 @@ Definition countBy_tb_expected_inputs := sequential (countBy countBy_tb_inputs).
 Definition countBy_tb
   := testBench "countBy_tb" countBy_Interface
      countBy_tb_inputs countBy_tb_expected_inputs.
+
+(* Also generate netlist for loopDelaySRAlt version *)
+
+Definition countByAlt_Interface
+  := sequentialInterface "countByAlt"
+     "clk" PositiveEdge "rst" PositiveEdge
+     [mkPort "i" (Vec Bit 8)]
+     [mkPort "o" (Vec Bit 8)]
+     [].
+
+Definition countByAlt_Netlist := makeNetlist countByAlt_Interface countByAlt.
+
+Definition countByAlt_tb
+  := testBench "countByAlt_tb" countBy_Interface
+     countBy_tb_inputs countBy_tb_expected_inputs.
+
+(* Check netlist generation for loops with composite feedback. *)
+
+Definition countByInvAlt_Interface
+  := sequentialInterface "countByInvAlt"
+     "clk" PositiveEdge "rst" PositiveEdge
+     [mkPort "i" (Vec Bit 8)]
+     [mkPort "o" (Vec Bit 8); mkPort "t" Bit]
+     [].
+
+Definition countByInvAlt_Netlist := makeNetlist countByInvAlt_Interface countByInvAlt.
+
+Definition countByInvAlt_tb
+  := testBench "countByInvAlt_tb" countByInvAlt_Interface
+     countBy_tb_inputs [(b0, false); (b14, true); (b21, false); (b24, true); (b18, false)].
+
+(* Question: why does the Example testbench above not produce the output for the first
+   cycle i.e. (b0, false) ? 
+*)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,8 @@
 ################################################################################
 
 SV = instantiate.sv mux2_1.sv muxBus4_8.sv mult2_3_5.sv \
-     delayByte.sv delayEnableByte.sv countBy.sv arrayTest.sv multiDimArrayTest.sv
+     delayByte.sv delayEnableByte.sv countBy.sv countByAlt.sv countByInvAlt.sv \
+     arrayTest.sv multiDimArrayTest.sv
 
 BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)

--- a/tests/TestsSV.hs
+++ b/tests/TestsSV.hs
@@ -1,4 +1,4 @@
-{- Copyright 2020 The Project Oak Authors
+{- Copyright 2021 The Project Oak Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -42,6 +42,10 @@ main = do writeSystemVerilog mux2_1Netlist
           -- writeTestBench pipelinedNAND_tb
           writeSystemVerilog countBy_Netlist
           writeTestBench countBy_tb
+          writeSystemVerilog countByAlt_Netlist
+          writeTestBench countByAlt_tb
+          writeSystemVerilog countByInvAlt_Netlist
+          writeTestBench countByInvAlt_tb
           writeSystemVerilog accumulatingAdderEnable_Netlist
           writeSystemVerilog accumulatingAdderEnable2_Netlist
           writeSystemVerilog arrayTest_Netlist


### PR DESCRIPTION
As part of the process of eliminating the tuple type from `SignalType` and doing away with `mkpair` and `unpair` this PR proposes an alternative formulation for a loop combinator that uses a Gallina flat-tuple to structure feedback information. The PR needs proofs to be done for the new combinator, which I am leaving to @jadephilipoom to add as further commits to this PR. Please delete the old combinators e.g. `loopDelaySR` and then rename `loopDelaySRAlt` to `loopDelaySR` etc. Thank you kindly.

The PR demonstrates how to use the existing `tupleInterface` infrastructure we have to define a tuple feedback tuple for `loopDelaySR`:

```coq
  loopDelaySRAlt : forall {A : SignalType} {B : list SignalType},
                   tupleInterface combType B ->
                   (signal A * tupleInterface signal B -> cava (tupleInterface signal B)) ->
                   signal A ->
                   cava (tupleInterface signal B); 
```

For example, bit `B = [Bit]` then a specific loop type would be:
```coq
forall {A : SignalType} 
                   Bool ->
                   (signal A * signal Bit -> cava (signal Bit)) ->
                   signal A ->
                   cava (signal Bit); 
```
If `B = [Bit; Vec Bit 8]` then we would have:
```coq
forall {A : SignalType} 
                   (Bool, Vector.t Bool 8) ->
                   (signal A * (signal Bit, signal (Vec Bit 8)) -> cava (signal Bit * signal (Vec Bit 8))) ->
                   signal A ->
                   cava (signal Bit * signal (Vec Bit 8)); 
```

This might be a good time to make `loopDelaySEnableR` the sole primitive loop combinator in `CavaSeq` and then define all the others as specialized versions in a library module (or `Combinators.v`). Another thing that could be considered at this stage is to merge back `CavaSeq` back into `CavaClass` (or this can be left for a later PR).

Note how we have separate signals for each component of the composite state, and the netlist layer generates separate registers for each of the elements of the composite state. So now we can have multiple streams of values flowing into the core of the loop body which can be taken apart and merged with combinators. The current formulation has been restricting us to a single feedback signal (which can contain values built using our `SignalType` tuples), which I think is not what we really want.

Once the loop combinators are ported over we should be able to delete the `SignalType` tuples, `mkpair`, `unpair` etc. assuming these definitions do not add more complexity for proofs than they remove.

A concrete test example added in the PR, along with a Coq-level `Example` test and netlist generation for a SystemVerilog test:
```coq
  Definition countByInvAlt : signal (Vec Bit 8) -> cava (signal (Vec Bit 8) * signal Bit)
    := loopDelaySRAlt (tupleInterfaceDefault [Vec Bit 8; Bit])
       (pairLeft >=> first addN >=> second inv).
```
The Coq test:
```coq
(* Check the toggling output version. *)
Example countByInvAlt_ex1: sequential (countByInvAlt [b14; b7; b3; b250])
  = ([b14; b21; b24; b18], [true; false; true; false]).
Proof. reflexivity. Qed.
```
The SystemVerilog test:
```
clang++ -L/usr/local/opt/sqlite/lib    countByInvAlt_tb.o verilated.o verilated_vcd_c.o VcountByInvAlt_tb__ALL.a    -o VcountByInvAlt_tb -lm -lstdc++ 
obj_dir/VcountByInvAlt_tb
                  10: tick = 0,  i = 14,  o = 0,  t = 0
                  20: tick = 1,  i = 7,  o = 14,  t = 1
                  30: tick = 2,  i = 3,  o = 21,  t = 0
                  40: tick = 3,  i = 250,  o = 24,  t = 1
```
**QUESTION** : Why does the Coq `Example` test omit the first output i.e. `(0, false)`?
The generated SystemVerilog does produce this first output value, hence the different expected output given for the SysemVerilog test bench for this case vs. the `Example` expected output.

CC: @blaxill 

Addresses part of #416  
