### PR TITLE
_CoqProject generation w/ find.

### DIFF
--- a/acorn-examples/Makefile
+++ b/acorn-examples/Makefile
@@ -35,13 +35,13 @@ xilinx:		adder8.vcd
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' -not -path "*/xilinx/*" | sort)
 		@echo "INSTALLDEFAULTROOT = AcornExamples" > _CoqProject
 		@echo "-R . AcornExamples" >> _CoqProject
 		@echo "-R ../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" | grep -v "^xilinx/" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/acorn-examples/xilinx/Makefile
+++ b/acorn-examples/xilinx/Makefile
@@ -43,13 +43,13 @@ extraction:	$(SV)
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt -y $(XILINX)/data/verilog/src/unisims
 VLINT = $(VERILATOR) --lint-only
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = XilinxExamples" > _CoqProject
 		@echo "-R . XilinxExamples" >> _CoqProject
 		@echo "-R ../../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/cava/Makefile
+++ b/cava/Makefile
@@ -42,12 +42,12 @@ haskell:	coq FixupHaskell
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = Cava" > _CoqProject
 		@echo "-R Cava Cava" >> _CoqProject
 		@echo "-R ../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 clean:
 		-@$(MAKE) -f Makefile.coq clean

--- a/investigations/Arrow/aes/Makefile
+++ b/investigations/Arrow/aes/Makefile
@@ -18,14 +18,14 @@
 
 all:		coq
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = Aes" > _CoqProject
 		@echo "-R . Aes" >> _CoqProject
 		@echo "-R ../Spec AesSpec" >> _CoqProject
 		@echo "-R ../../../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../../../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:   _CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/investigations/Arrow/arrow-examples/Makefile
+++ b/investigations/Arrow/arrow-examples/Makefile
@@ -31,13 +31,13 @@ all:		coq $(VCDS)
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = ArrowExamples" > _CoqProject
 		@echo "-R . ArrowExamples" >> _CoqProject
 		@echo "-R ../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/silveroak-opentitan/aes/Acorn/Makefile
+++ b/silveroak-opentitan/aes/Acorn/Makefile
@@ -45,14 +45,14 @@ util:		aes_sub_bytes_util aes_mix_columns_util aes_add_round_key_util \
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = AcornAes" > _CoqProject
 		@echo "-R . AcornAes" >> _CoqProject
 		@echo "-R ../Spec AesSpec" >> _CoqProject
 		@echo "-R ../../../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../../../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/silveroak-opentitan/aes/Spec/Makefile
+++ b/silveroak-opentitan/aes/Spec/Makefile
@@ -18,13 +18,13 @@
 
 all:		coq
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = AesSpec" > _CoqProject
 		@echo "-R . AesSpec" >> _CoqProject
 		@echo "-R ../../../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../../../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/silveroak-opentitan/pinmux/Makefile
+++ b/silveroak-opentitan/pinmux/Makefile
@@ -21,13 +21,13 @@ all:		coq pinmux.sv compile_pinmux
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = Pinmux" > _CoqProject
 		@echo "-R . Pinmux" >> _CoqProject
 		@echo "-R ../../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,13 +33,13 @@ all:		coq $(VCDS)
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' -not -path "*/xilinx/*" | sort)
 		@echo "INSTALLDEFAULTROOT = Tests" > _CoqProject
 		@echo "-R . Tests" >> _CoqProject
 		@echo "-R ../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" | grep -v "^xilinx/" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/tests/xilinx/Makefile
+++ b/tests/xilinx/Makefile
@@ -37,13 +37,13 @@ extraction:	$(SV)
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt -y $(XILINX)/data/verilog/src/xeclib
 VLINT = $(VERILATOR) --lint-only
 
-_CoqProject:
+_CoqProject:    $(shell find . -name '*.v' | sort)
 		@echo "INSTALLDEFAULTROOT = VivadoTests" > _CoqProject
 		@echo "-R . VivadoTests" >> _CoqProject
 		@echo "-R ../../cava/Cava Cava" >> _CoqProject
 		@echo "-R ../../third_party/coq-ext-lib/theories ExtLib" >> _CoqProject
 		@echo "-R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil" >> _CoqProject
-		git ls-files | grep "\.v$$" >> _CoqProject
+		@printf '%s\n' $^ >> _CoqProject
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq


### PR DESCRIPTION
Closes #472 

This change:
- declares '.v' files as prerequisites for generating _CoqProject
  (avoids running rule, and thereby touching _CoqProject, if no .v
  files are changed, for faster incremental builds).
- uses 'find' over 'git ls-files'. Making code git-agnostic,
  specifically when creating a new file, don't need to `git add` in
  order to build it.
- adds assumption that file names don't have spaces

Future considerations:
- avoid 'xilinx' subdir excludes, for consistent style
- consider factoring out file lookup logic into a define or include
  which can use args or variables to specify source globs + dependency
  graph (this would also make it easier to order sources - which we
  now rely on being ordered alphabetically)