### PR TITLE
Avoid potentially creating Pairs inside Vecs in muxPair/pairSel

### DIFF
--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -350,7 +350,7 @@ Proof.
       [ repeat match goal with
                | x : Vector.t _ 0 |- _ => eapply case0 with (v:=x); clear x
                end; split; reflexivity | ].
-    erewrite (zipWith_unIdent (A:=t) (B:=t) (C:=Bit)) by eauto.
+    erewrite (zipWith_unIdent (A:=t) (B:=t) (C:=Bit)) by eauto;
     rewrite (all_correct (n:=n)). cbn [combType_eqb].
     rewrite eqb_fold. reflexivity. }
   { (* Pair case *)
@@ -393,8 +393,8 @@ Proof.
 Qed.
 
 Lemma pairSel_mkpair_singleton {t} (x y : combType t) (sel : bool) :
-  pairSel [sel] (mkpair [x] [y]) = [if sel then y else x].
-Proof. destruct sel; reflexivity. Qed.
+  unIdent (pairSel [sel] (mkpair [x] [y])) = [if sel then y else x].
+Proof. Admitted.
 
 Lemma max_length_uniform_length {A} n (v : Vector.t (list A) n) len :
   n <> 0 -> ForallV (fun l => length l = len) v ->
@@ -520,33 +520,33 @@ Proof.
 Qed.
 
 Lemma pairSel_mkpair {t} (x y : seqType t) (sel : seqType Bit) :
-  pairSel sel (mkpair x y) = List.map
+  unIdent (pairSel sel (mkpair x y)) = List.map
                                (fun (xysel : combType t * combType t * combType Bit) =>
                                   let '(x,y,sel) := xysel in
                                   if sel then y else x)
                                (pad_combine (pad_combine x y) sel).
-Proof.
-  cbv [pairSel]. intros. rewrite unpair_mkpair_pad_combine.
-  rewrite !indexAt_unpeel with
-      (sellen :=length sel) (vlen := Nat.max (length x) (length y))
-      by (try congruence; cbn [ForallV]; ssplit; try reflexivity;
-          autorewrite with vsimpl; length_hammer).
-  autorewrite with vsimpl push_length.
-  cbn [Vector.map].
-  rewrite !(pad_combine_to_nth _ sel), List.map_map.
-  autorewrite with push_length.
-  eapply List.map_ext_in.
-  intro i; rewrite in_seq. intros.
-  repeat destruct_pair_let.
-  cbn [Bv2N N.succ_double N.double].
-  destr (i <? Nat.max (length x) (length y));
-    [ erewrite !map_nth_inbounds with (d2:=lastSignal (pad_combine x y))
-      by length_hammer; destruct_one_match; reflexivity | ].
-  rewrite !nth_overflow with (l:=List.map _ _) by length_hammer.
-  rewrite !nth_overflow with (l:=pad_combine _ _) by length_hammer.
-  rewrite !lastSignal_map by reflexivity.
-  destruct_one_match; reflexivity.
-Qed.
+Proof. Admitted.
+  (* cbv [pairSel]. intros. rewrite unpair_mkpair_pad_combine. *)
+  (* rewrite !indexAt_unpeel with *)
+  (*     (sellen :=length sel) (vlen := Nat.max (length x) (length y)) *)
+  (*     by (try congruence; cbn [ForallV]; ssplit; try reflexivity; *)
+  (*         autorewrite with vsimpl; length_hammer). *)
+  (* autorewrite with vsimpl push_length. *)
+  (* cbn [Vector.map]. *)
+  (* rewrite !(pad_combine_to_nth _ sel), List.map_map. *)
+  (* autorewrite with push_length. *)
+  (* eapply List.map_ext_in. *)
+  (* intro i; rewrite in_seq. intros. *)
+  (* repeat destruct_pair_let. *)
+  (* cbn [Bv2N N.succ_double N.double]. *)
+  (* destr (i <? Nat.max (length x) (length y)); *)
+  (*   [ erewrite !map_nth_inbounds with (d2:=lastSignal (pad_combine x y)) *)
+  (*     by length_hammer; destruct_one_match; reflexivity | ]. *)
+  (* rewrite !nth_overflow with (l:=List.map _ _) by length_hammer. *)
+  (* rewrite !nth_overflow with (l:=pad_combine _ _) by length_hammer. *)
+  (* rewrite !lastSignal_map by reflexivity. *)
+  (* destruct_one_match; reflexivity. *)
+(* Qed. *)
 
 Lemma peel_singleton {A n} (v : Vector.t (combType A) n) :
   peel [v] = map (fun x => [x]) v.
@@ -587,7 +587,8 @@ Proof. apply split_nth. Qed.
 
 Lemma muxPair_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
   unIdent (muxPair [sel] (([i0] : seqType _), ([i1] : seqType _))) = [if sel then i1 else i0].
-Proof. destruct sel; reflexivity. Qed.
+Proof. Admitted.
+(* destruct sel; reflexivity. Qed. *)
 
 Lemma mkpair_single {A B} (a : combType A) (b : seqType B):
   length b <> 0 ->
@@ -645,26 +646,26 @@ Proof.
 Qed.
 
 Lemma mux4_mkpair {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
-  mux4 (mkpair (mkpair (mkpair [i0] [i1]) [i2]) [i3]) [sel] =
+  unIdent (mux4 (mkpair (mkpair (mkpair [i0] [i1]) [i2]) [i3]) [sel]) =
   [if Vector.hd (Vector.tl sel)
    then if Vector.hd sel then i3 else i2
    else if Vector.hd sel then i1 else i0].
-Proof.
-  cbv in sel. constant_vector_simpl sel.
-  cbv [mux4 indexConst CombinationalSemantics].
-  autorewrite with vsimpl.
-  repeat
-    match goal with
-    | |- context [(@indexConstBoolList ?t ?sz ?v ?n)] =>
-      let x := constr:(@indexConstBoolList t sz v n) in
-      let y := (eval cbn in x) in
-      progress change x with y
-    | _ => rewrite pairAssoc_mkpair
-    | _ => rewrite pairSel_mkpair
-    | _ => destruct_one_match
-    | _ => reflexivity
-    end.
-Qed.
+Proof. Admitted.
+  (* cbv in sel. constant_vector_simpl sel. *)
+  (* cbv [mux4 indexConst CombinationalSemantics]. *)
+  (* autorewrite with vsimpl. *)
+  (* repeat *)
+  (*   match goal with *)
+  (*   | |- context [(@indexConstBoolList ?t ?sz ?v ?n)] => *)
+  (*     let x := constr:(@indexConstBoolList t sz v n) in *)
+  (*     let y := (eval cbn in x) in *)
+  (*     progress change x with y *)
+  (*   | _ => rewrite pairAssoc_mkpair *)
+  (*   | _ => rewrite pairSel_mkpair *)
+  (*   | _ => destruct_one_match *)
+  (*   | _ => reflexivity *)
+  (*   end. *)
+(* Qed. *)
 
 Lemma indexConst_singleton {A sz} (v : combType (Vec A sz)) (n : nat) :
   indexConst [v] n = [nth_default (defaultCombValue _) n v].

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -88,7 +88,7 @@ Section WithCava.
                        cava (signal A * (signal B * signal C)) :=
    let '((a, b), c) := i in
    ret (a, (b, c)).
- 
+
   (* Use a circuit to zip together two vectors. *)
   Definition zipWith {A B C : SignalType} {n : nat}
            (f : signal A * signal B -> cava (signal C))
@@ -103,8 +103,8 @@ Section WithCava.
   (* A list-based left monadic-fold. *)
   Fixpoint foldLM {m} `{Monad m} {A B : Type}
                   (f : B -> A -> m B)
-                  (input : list A) 
-                  (accum : B) 
+                  (input : list A)
+                  (accum : B)
                   : m B :=
     match input with
     | [] => ret accum
@@ -344,7 +344,7 @@ Section WithCava.
   (****************************************************************************)
 
   Definition swap {A B}
-                  (i : signal A * signal B) 
+                  (i : signal A * signal B)
                   : cava (signal B * signal A) :=
     let (a, b) := i in
     ret (b, a).
@@ -656,7 +656,8 @@ Section WithCava.
   Definition mux4 {t} (input : signal (Pair (Pair (Pair t t) t) t))
              (sel : signal (Vec Bit 2)) :=
     let x := pairAssoc input in
-    pairSel (indexConst sel 0) (pairSel (indexConst sel 1) x).
+    s <- pairSel (indexConst sel 1) x ;;
+    pairSel (indexConst sel 0) s.
 
   Section Sequential.
     Context {seqsemantics : CavaSeq semantics}.

--- a/silveroak-opentitan/aes/Acorn/Cipher.v
+++ b/silveroak-opentitan/aes/Acorn/Cipher.v
@@ -69,9 +69,9 @@ Section WithCava.
 
     (* Different rounds perform different operations on the state before adding
        the round key; select the appropriate wire based on add_round_key_in_sel *)
-    let add_round_key_in :=
+       add_round_key_in <-
         mux4 (mkpair (mkpair (mkpair mix_columns_out data) shift_rows_out) mix_columns_out)
-             add_round_key_in_sel in
+             add_round_key_in_sel ;;
 
     (* Intermediate decryption rounds need to mix the key columns *)
     mixed_round_key <- inv_mix_columns_key round_key ;;

--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -4,6 +4,17 @@ muxPair_correct_strong
     unIdent (muxPair sel (i0, i1)) =
     map (fun '(sel0, (i2, i3)) => if sel0 then i3 else i2)
       (pad_combine sel (pad_combine i0 i1))
+CombinationalProperties.muxPair_correct
+  : forall (t : SignalType) (i0 i1 : combType t) (sel : combType Bit),
+    unIdent (muxPair [sel] ([i0] : seqType t, [i1] : seqType t)) =
+    [if sel then i1 else i0]
+CombinationalProperties.mux4_mkpair
+  : forall (t : SignalType) (i0 i1 i2 i3 : combType t)
+      (sel : combType (Vec Bit 2)),
+    unIdent (mux4 (mkpair (mkpair (mkpair [i0] [i1]) [i2]) [i3]) [sel]) =
+    [if Vector.hd (Vector.tl sel)
+     then if Vector.hd sel then i3 else i2
+     else if Vector.hd sel then i1 else i0]
 mix_columns_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (aes_mix_columns [is_decrypt] [st]) =

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -4,6 +4,17 @@ muxPair_correct_strong
     unIdent (muxPair sel (i0, i1)) =
     map (fun '(sel0, (i2, i3)) => if sel0 then i3 else i2)
       (pad_combine sel (pad_combine i0 i1))
+CombinationalProperties.muxPair_correct
+  : forall (t : SignalType) (i0 i1 : combType t) (sel : combType Bit),
+    unIdent (muxPair [sel] ([i0] : seqType t, [i1] : seqType t)) =
+    [if sel then i1 else i0]
+CombinationalProperties.mux4_mkpair
+  : forall (t : SignalType) (i0 i1 i2 i3 : combType t)
+      (sel : combType (Vec Bit 2)),
+    unIdent (mux4 (mkpair (mkpair (mkpair [i0] [i1]) [i2]) [i3]) [sel]) =
+    [if Vector.hd (Vector.tl sel)
+     then if Vector.hd sel then i3 else i2
+     else if Vector.hd sel then i1 else i0]
 mix_columns_equiv
   : forall (is_decrypt : bool) (st : combType (Vec (Vec (Vec Bit 8) 4) 4)),
     unIdent (aes_mix_columns [is_decrypt] [st]) =


### PR DESCRIPTION
Unfortunately this solution would break some proofs. I've admitted broken proofs. The proof automation no longer works for the examples, I presume as I changed the type of pairSel to `cava _`  #552

cc @satnam6502  @jadephilipoom 