### PR TITLE
Add reset values to Circuits

### DIFF
--- a/cava/Cava/Acorn/Circuit.v
+++ b/cava/Cava/Acorn/Circuit.v
@@ -37,20 +37,20 @@ Section WithCava.
   | Compose : forall {i t o}, Circuit i t -> Circuit t o -> Circuit i o
   | First : forall {i o t}, Circuit i o -> Circuit (i * t) (o * t)
   | Second : forall {i o t}, Circuit i o -> Circuit (t * i) (t * o)
-  | LoopR :
+  | LoopInit :
       forall {i o : Type} {s : SignalType} (resetval : signal s),
         Circuit (i * signal s) (o * signal s) ->
         Circuit i o
-  | DelayR : forall {t} (resetval : signal t), Circuit (signal t) (signal t)
+  | DelayInit : forall {t} (resetval : signal t), Circuit (signal t) (signal t)
   .
 
   (* Loop with the default signal as its reset value *)
   Definition Loop {i o s}
     : Circuit (i * signal s) (o * signal s) -> Circuit i o :=
-    LoopR defaultSignal.
+    LoopInit defaultSignal.
   (* Delay with the default signal as its reset value *)
   Definition Delay {t} : Circuit (signal t) (signal t) :=
-    DelayR defaultSignal.
+    DelayInit defaultSignal.
 
 
   (* Internal state of the circuit (register values) *)
@@ -60,8 +60,8 @@ Section WithCava.
     | Compose f g => circuit_state f * circuit_state g
     | First f => circuit_state f
     | Second f => circuit_state f
-    | @LoopR i o s _ f => circuit_state f * signal s
-    | @DelayR t _ => signal t
+    | @LoopInit i o s _ f => circuit_state f * signal s
+    | @DelayInit t _ => signal t
     end.
 
   Fixpoint reset_state {i o} (c : Circuit i o) : circuit_state c :=
@@ -70,8 +70,8 @@ Section WithCava.
     | Compose f g => (reset_state f, reset_state g)
     | First f => reset_state f
     | Second f => reset_state f
-    | LoopR resetval f => (reset_state f, resetval)
-    | DelayR resetval => resetval
+    | LoopInit resetval f => (reset_state f, resetval)
+    | DelayInit resetval => resetval
     end.
 
   (* Run circuit for a single step *)
@@ -93,11 +93,11 @@ Section WithCava.
       fun cs input =>
         '(x, cs') <- interp f cs (snd input) ;;
         ret (fst input, x, cs')
-    | LoopR _ f =>
+    | LoopInit _ f =>
       fun cs input =>
         '(out, st, cs') <- interp f (fst cs) (input, snd cs) ;;
         ret (out, (cs',st))
-    | DelayR _ =>
+    | DelayInit _ =>
       fun cs input =>
         ret (cs, input)
     end.

--- a/cava/Cava/Acorn/Circuit.v
+++ b/cava/Cava/Acorn/Circuit.v
@@ -64,6 +64,7 @@ Section WithCava.
     | @DelayInit t _ => signal t
     end.
 
+  (* The state of the circuit after a reset *)
   Fixpoint reset_state {i o} (c : Circuit i o) : circuit_state c :=
     match c as c return circuit_state c with
     | Comb _ => tt

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -77,13 +77,12 @@ Instance CombinationalSemantics : Cava combType :=
 }.
 
 
-(* Run a circuit for many timesteps *)
-Definition multistep {i o} (c : Circuit i o) (resetvals : circuit_state c)
-           (input : list i) : list o :=
+(* Run a circuit for many timesteps, starting at the reset value *)
+Definition multistep {i o} (c : Circuit i o) (input : list i) : list o :=
   match input with
   | [] => []
   | i :: input =>
-    let '(o,st) := unIdent (interp c resetvals i) in
+    let '(o,st) := unIdent (interp c (reset_state c) i) in
     let '(acc, _) := fold_left_accumulate
                        (fun o_st i => unIdent (interp c (snd o_st) i))
                        input (o,st) in

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -344,11 +344,11 @@ Fixpoint newCircuitStateSignals {i o} (c : Circuit i o)
     gs <- newCircuitStateSignals g ;;
     ret (fs, gs)
   | First f | Second f => newCircuitStateSignals f
-  | @Loop _ _ i o s f =>
+  | @LoopR _ _ i o s _ f =>
     fs <- newCircuitStateSignals f ;;
     ss <- newSignal s ;;
     ret (fs, ss)
-  | @Delay _ _ t => newSignal t
+  | @DelayR _ _ t _ => newSignal t
   end.
 
 (* "Close the loop" by adding delays to connect the output and input states *)
@@ -361,15 +361,15 @@ Fixpoint linkCircuitStateSignals {i o} (c : Circuit i o)
       fs <- linkCircuitStateSignals f (fst in_state) (fst out_state) ;;
       linkCircuitStateSignals g (snd in_state) (snd out_state)
   | First f | Second f => linkCircuitStateSignals f
-  | @Loop _ _ i o s f =>
+  | @LoopR _ _ i o s resetval f =>
     fun in_state out_state =>
       fs <- linkCircuitStateSignals f (fst in_state) (fst out_state) ;;
       let ins := snd in_state in
       let outs := snd out_state in
-      addInstance (Netlist.Delay s (defaultNetSignal _) ins outs)
-  | @Delay _ _ t =>
+      addInstance (Netlist.Delay s resetval ins outs)
+  | @DelayR _ _ t resetval =>
     fun ins outs =>
-      addInstance (Netlist.Delay t (defaultNetSignal _) ins outs)
+      addInstance (Netlist.Delay t resetval ins outs)
   end.
 
 Definition interpCircuit {i o} (c : Circuit i o) (input : i)

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -344,11 +344,11 @@ Fixpoint newCircuitStateSignals {i o} (c : Circuit i o)
     gs <- newCircuitStateSignals g ;;
     ret (fs, gs)
   | First f | Second f => newCircuitStateSignals f
-  | @LoopR _ _ i o s _ f =>
+  | @LoopInit _ _ i o s _ f =>
     fs <- newCircuitStateSignals f ;;
     ss <- newSignal s ;;
     ret (fs, ss)
-  | @DelayR _ _ t _ => newSignal t
+  | @DelayInit _ _ t _ => newSignal t
   end.
 
 (* "Close the loop" by adding delays to connect the output and input states *)
@@ -361,13 +361,13 @@ Fixpoint linkCircuitStateSignals {i o} (c : Circuit i o)
       fs <- linkCircuitStateSignals f (fst in_state) (fst out_state) ;;
       linkCircuitStateSignals g (snd in_state) (snd out_state)
   | First f | Second f => linkCircuitStateSignals f
-  | @LoopR _ _ i o s resetval f =>
+  | @LoopInit _ _ i o s resetval f =>
     fun in_state out_state =>
       fs <- linkCircuitStateSignals f (fst in_state) (fst out_state) ;;
       let ins := snd in_state in
       let outs := snd out_state in
       addInstance (Netlist.Delay s resetval ins outs)
-  | @DelayR _ _ t resetval =>
+  | @DelayInit _ _ t resetval =>
     fun ins outs =>
       addInstance (Netlist.Delay t resetval ins outs)
   end.

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -112,25 +112,23 @@ Definition b250 := N2Bv_sized 8 250.
 Definition b251 := N2Bv_sized 8 251.
 
 Goal (multistep
-        (Comb addC) tt
+        (Comb addC)
         [(b14,b0); (b7,b14); (b3,b4); (b24,b250)]
       = [(b14,false);(b21,false);(b7,false);(b18,true)]).
 Proof. vm_compute. reflexivity. Qed.
 
 Goal (multistep
-        (Comb incrN) tt
+        (Comb incrN)
         [b14; b7; b3; b250] = [b15;b8;b4;b251]).
 Proof. vm_compute. reflexivity. Qed.
 
 Goal (multistep
         count_by
-        (tt, defaultCombValue _)
         [b14; b7; b3; b250] = [false;false;false;true]).
 Proof. vm_compute. reflexivity. Qed.
 
 Goal (multistep
         double_count_by
-        (tt, (defaultCombValue _), tt, defaultCombValue _)
         [b14; b7; b3; b250]
       = [b0;b0;b0;b1]).
 Proof. reflexivity. Qed.

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -100,11 +100,11 @@ Admitted.
 Local Opaque bvaddc.
 
 Lemma count_by_correct (input : list (combType (Vec Bit 8))) :
-  multistep count_by (tt, (defaultCombValue _)) input
+  multistep count_by input
   = map snd (count_by_spec input).
 Proof.
-  cbv [multistep count_by_spec count_by interp].
-  destruct input as [|input0 input]; [ reflexivity | ]. cbn [fst snd].
+  destruct input as [|input0 input]; [ reflexivity | ].
+  cbv [multistep count_by_spec count_by Loop interp].
   rewrite <-seq_shift, map_map. cbn [firstn].
   repeat destruct_pair_let. simpl_ident.
   repeat destruct_pair_let. simpl_ident.
@@ -169,5 +169,3 @@ Proof.
     autorewrite with push_firstn. cbn [fold_left].
     reflexivity. }
 Qed.
-
-


### PR DESCRIPTION
Progress on #568 

As an added bonus, this means we don't have to pass an initial state to `multistep` -- it just starts at the reset state, which can be constructed by inspecting the circuit structure.