### PR TITLE
Add enables to Circuit

### DIFF
--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -344,11 +344,11 @@ Fixpoint newCircuitStateSignals {i o} (c : Circuit i o)
     gs <- newCircuitStateSignals g ;;
     ret (fs, gs)
   | First f | Second f => newCircuitStateSignals f
-  | @LoopInit _ _ i o s _ f =>
+  | @LoopInitCE _ _ i o s _ _ f =>
     fs <- newCircuitStateSignals f ;;
     ss <- newSignal s ;;
     ret (fs, ss)
-  | @DelayInit _ _ t _ => newSignal t
+  | @DelayInitCE _ _ t _ _ => newSignal t
   end.
 
 (* "Close the loop" by adding delays to connect the output and input states *)
@@ -361,15 +361,15 @@ Fixpoint linkCircuitStateSignals {i o} (c : Circuit i o)
       fs <- linkCircuitStateSignals f (fst in_state) (fst out_state) ;;
       linkCircuitStateSignals g (snd in_state) (snd out_state)
   | First f | Second f => linkCircuitStateSignals f
-  | @LoopInit _ _ i o s resetval f =>
+  | @LoopInitCE _ _ i o s en resetval f =>
     fun in_state out_state =>
       fs <- linkCircuitStateSignals f (fst in_state) (fst out_state) ;;
       let ins := snd in_state in
       let outs := snd out_state in
-      addInstance (Netlist.Delay s resetval ins outs)
-  | @DelayInit _ _ t resetval =>
+      addInstance (DelayEnable s resetval en ins outs)
+  | @DelayInitCE _ _ t en resetval =>
     fun ins outs =>
-      addInstance (Netlist.Delay t resetval ins outs)
+      addInstance (DelayEnable t resetval en ins outs)
   end.
 
 Definition interpCircuit {i o} (c : Circuit i o) (input : i)


### PR DESCRIPTION
Resolves #568 

Now we have four options for both `Loop` and `Delay`:
- `LoopInitCE` and `DelayInitCE`, with both enables and reset values, which are the base constructors in terms of which the rest are defined
- `LoopInit` and `DelayInit`, which have reset values but not enables
- `LoopCE` and `DelayCE`, which have enables but default reset values
- `Loop` and `Delay`, which have no enables and default reset values