### PR TITLE
Move control circuit to new Circuit

### DIFF
--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -36,6 +36,7 @@ Require Import Cava.Acorn.Combinators.
 Require Import Cava.Acorn.NetlistGeneration.
 Require Import Cava.Acorn.XilinxAdder.
 Require Import Cava.Acorn.CavaPrelude.
+Require Import Cava.Acorn.Circuit.
 
 Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Lib.FullAdder.
@@ -44,6 +45,7 @@ Require Import Cava.Lib.UnsignedAdders.
 Recursive Extraction Library BitArithmetic.
 Recursive Extraction Library Cava.
 Recursive Extraction Library Acorn.
+Recursive Extraction Library Circuit.
 Recursive Extraction Library CombinationalMonad.
 Recursive Extraction Library Sequential.
 Recursive Extraction Library Combinators.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -51,6 +51,7 @@ library
                      CavaPrelude
                      Combinators
                      CombinationalMonad
+                     Circuit
                      Datatypes
                      FullAdder
                      HexString
@@ -82,7 +83,6 @@ library
                      BinNatDef
                      ByteVector
                      Byte
-                     Circuit
                      Compare_dec
                      Decimal
                      Functor

--- a/cava/Cava2SystemVerilog.hs
+++ b/cava/Cava2SystemVerilog.hs
@@ -175,7 +175,7 @@ showSignal signal
       SignalFst _ _ _ -> showSignal (simplifySignal signal)
       SignalSnd _ _ _ -> showSignal (simplifySignal signal)
       -- SignalPair should never occur but added here to aid debugging.
-      SignalPair _ _ a b -> "(" ++ showSignal a ++ ", " ++ showSignal b ++ ")"
+      SignalPair _ _ a b -> error $ "(" ++ show a ++ ", " ++ show b ++ ")"
       UnsignedAdd _ _ _ a b -> "(" ++ showSignal a ++ " + " ++ showSignal b ++ ")"
       UnsignedSubtract _ _ _ a b -> "(" ++ showSignal a ++ " - " ++ showSignal b ++ ")"
       UnsignedMultiply _ _ _ a b -> "(" ++ showSignal a ++ " * " ++ showSignal b ++ ")"
@@ -309,7 +309,6 @@ deriving instance Eq Signal
 deriving instance Show Signal
 deriving instance Show (Vector.Coq_t Signal)
 deriving instance Show BinNums.N
-deriving instance Show SignalType
 
 unsmashSignalInstance :: Instance -> State CavaState Instance
 unsmashSignalInstance = mapSignalsInInstanceM unsmashSignal
@@ -337,6 +336,10 @@ mapSignalsInInstanceM f inst
                        fi1 <- f i1
                        fo  <- f o
                        return (Or fi0 fi1 fo)
+      Nor i0 i1 o -> do fi0 <- f i0
+                        fi1 <- f i1
+                        fo  <- f o
+                        return (Nor fi0 fi1 fo)
       Xor i0 i1 o -> do fi0 <- f i0
                         fi1 <- f i1
                         fo  <- f o

--- a/cava/SystemVerilogUtils.hs
+++ b/cava/SystemVerilogUtils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StandaloneDeriving #-}
 {- Copyright 2021 The Project Oak Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,11 +24,14 @@ insertCommas [] = []
 insertCommas [x] = [x]
 insertCommas (x:y:xs) = (x ++ ", ") : insertCommas (y:xs)
 
+deriving instance Show SignalType
+
 vectorDeclaration' ::  SignalType -> Integer -> String
 vectorDeclaration' k s
   = case k of
       Bit -> "[" ++ show (s - 1) ++ ":0]"
       Vec k2 s2 -> "[" ++ show (s - 1) ++ ":0]" ++  vectorDeclaration' k2 s2
+      _ -> error $ show k
 
 vectorDeclaration :: String -> SignalType -> Integer -> String
 vectorDeclaration name k s

--- a/silveroak-opentitan/aes/Acorn/AESExtraction.v
+++ b/silveroak-opentitan/aes/Acorn/AESExtraction.v
@@ -15,14 +15,17 @@
 (****************************************************************************)
 
 Require Import AcornAes.Pkg.
+Require Import AcornAes.Cipher.
 Require Import AcornAes.MixColumnsCircuit.
 Require Import AcornAes.ShiftRowsCircuit.
 Require Import AcornAes.SubBytesCircuit.
 Require Import AcornAes.AddRoundKeyCircuit.
+Require Import AcornAes.CipherControlCircuit.
 Require Import AcornAes.MixColumnsNetlist.
 Require Import AcornAes.ShiftRowsNetlist.
 Require Import AcornAes.SubBytesNetlist.
 Require Import AcornAes.AddRoundKeyNetlist.
+Require Import AcornAes.CipherControlNetlist.
 Require Import Coq.extraction.Extraction.
 Require Import Coq.extraction.ExtrHaskellZInteger.
 Require Import Coq.extraction.ExtrHaskellString.
@@ -32,11 +35,14 @@ Require Import Coq.extraction.ExtrHaskellNatInteger.
 Extraction Language Haskell.
 
 Extraction Library Pkg.
+Extraction Library Cipher.
 Extraction Library MixColumnsCircuit.
 Extraction Library ShiftRowsCircuit.
 Extraction Library SubBytesCircuit.
 Extraction Library AddRoundKeyCircuit.
+Extraction Library CipherControlCircuit.
 Extraction Library MixColumnsNetlist.
 Extraction Library ShiftRowsNetlist.
 Extraction Library SubBytesNetlist.
 Extraction Library AddRoundKeyNetlist.
+Extraction Library CipherControlNetlist.

--- a/silveroak-opentitan/aes/Acorn/AESExtraction.v
+++ b/silveroak-opentitan/aes/Acorn/AESExtraction.v
@@ -16,6 +16,7 @@
 
 Require Import AcornAes.Pkg.
 Require Import AcornAes.Cipher.
+Require Import AcornAes.CipherNewLoop.
 Require Import AcornAes.MixColumnsCircuit.
 Require Import AcornAes.ShiftRowsCircuit.
 Require Import AcornAes.SubBytesCircuit.
@@ -36,6 +37,7 @@ Extraction Language Haskell.
 
 Extraction Library Pkg.
 Extraction Library Cipher.
+Extraction Library CipherNewLoop.
 Extraction Library MixColumnsCircuit.
 Extraction Library ShiftRowsCircuit.
 Extraction Library SubBytesCircuit.

--- a/silveroak-opentitan/aes/Acorn/AESSV.hs
+++ b/silveroak-opentitan/aes/Acorn/AESSV.hs
@@ -20,6 +20,7 @@ import MixColumnsNetlist
 import ShiftRowsNetlist
 import SubBytesNetlist
 import AddRoundKeyNetlist
+import CipherControlNetlist
 
 main :: IO ()
 main = do writeSystemVerilog aes_mix_columns_Netlist
@@ -31,3 +32,4 @@ main = do writeSystemVerilog aes_mix_columns_Netlist
           writeTestBench aes_sub_bytes_tb
           writeSystemVerilog aes_add_round_key_Netlist
           writeTestBench aes_add_round_key_tb
+          writeSystemVerilog aes_cipher_core_simplified_Netlist

--- a/silveroak-opentitan/aes/Acorn/AESSV.hs
+++ b/silveroak-opentitan/aes/Acorn/AESSV.hs
@@ -32,4 +32,4 @@ main = do writeSystemVerilog aes_mix_columns_Netlist
           writeTestBench aes_sub_bytes_tb
           writeSystemVerilog aes_add_round_key_Netlist
           writeTestBench aes_add_round_key_tb
-          writeSystemVerilog aes_cipher_core_simplified_Netlist
+          writeSystemVerilog key_expand_and_round_Netlist

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -25,6 +25,7 @@ Require Import ExtLib.Structures.Monads.
 Import MonadNotation.
 
 Require Import Cava.Cava.
+Require Import Cava.Acorn.Circuit.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Acorn.Combinators.
 Require Import AcornAes.Pkg.
@@ -32,8 +33,11 @@ Require Import AcornAes.SubBytesCircuit.
 Require Import AcornAes.AddRoundKeyCircuit.
 Require Import AcornAes.ShiftRowsCircuit.
 Require Import AcornAes.MixColumnsCircuit.
-Require Import AcornAes.Cipher.
+Require Import AcornAes.CipherNewLoop.
 Import Pkg.Notations.
+
+Require Import AcornAes.ShiftRowsNetlist.
+Require Import AcornAes.MixColumnsNetlist.
 
 Local Open Scope monad_scope.
 Local Open Scope vector_scope.
@@ -70,77 +74,59 @@ Section WithCava.
     ret (unpeel (Vector.tl (peel sum))).
 
   Local Infix "==?" := eqb (at level 40).
-  Local Infix "**" := Pair (at level 40, left associativity).
 
-  Let cipher_control_state : SignalType :=
-    Bit            (* idle *)
-    ** Bit         (* generating decryption key *)
-    ** round_index (* current round *)
-    ** Bit         (* in_ready_o *)
-    ** Bit         (* out_valid_o *)
-    ** state       (* state_o *)
-    ** Bit         (* out latch when not accepted *).
+  Let cipher_control_signals : Type :=
+    signal Bit (* is_decrypt *)
+    * signal Bit (* in_valid_i *)
+    * signal Bit (* out_ready_i *)
+    * signal key (* initial_key *)
+    * signal state (* initial_state *).
 
-  Let cipher_control_signals :=
-    Bit (* is_decrypt *)
-    ** Bit (* in_valid_i *)
-    ** Bit (* out_ready_i *)
-    ** key (* initial_key *)
-    ** state (* initial_state *).
+  (* aes_shift_rows' and aes_mix_columns' must be instantiated hierarchically
+     to prevent excessive code generation
+     *)
+  Definition aes_shift_rows' x y :=
+    instantiate aes_shift_rows_Interface (fun '(x,y) => aes_shift_rows x y) (x, y).
+  Definition aes_mix_columns' x y :=
+    instantiate aes_mix_columns_Interface (fun '(x,y) => aes_shift_rows x y) (x, y).
+  Definition aes_sbox_lut' x y :=
+    instantiate aes_sbox_lut_Interface (fun '(x,y) => aes_sbox_lut x y) (x, y).
+  Definition aes_sub_bytes' (is_decrypt : signal Bit) (b : signal state)
+    : cava (signal state) := state_map (aes_sbox_lut' is_decrypt) b.
 
-  Section Packing.
-    Fixpoint unpacked_left_type A: Type :=
-      match A with
-      | Pair a b => unpacked_left_type a * signal b
-      | x => signal x
-      end.
-
-    Fixpoint unpacked_signal {A}: signal A -> unpacked_left_type A :=
-      match A as A return signal A -> unpacked_left_type A with
-      | Pair a b => fun x =>
-        let '(y,z) := unpair x in
-        (unpacked_signal y, z)
-      | _ => fun x => x
-      end.
-
-    Fixpoint packed_signal A: unpacked_left_type A -> signal A :=
-      match A with
-      | Pair a b => fun '(x,y) =>
-        mkpair (packed_signal _ x) y
-      | _ => fun x => x
-      end.
-  End Packing.
-
-  Definition inv_mix_columns_key := aes_mix_columns (constant true).
+  Definition inv_mix_columns_key := aes_mix_columns' (constant true).
 
   (* Plug in our concrete components to the skeleton in Cipher.v *)
   Definition cipher := cipher
     (round_index:=round_index) (round_constant:=round_constant)
-    aes_sub_bytes aes_shift_rows aes_mix_columns aes_add_round_key
+    aes_sub_bytes' aes_shift_rows' aes_mix_columns' aes_add_round_key
     inv_mix_columns_key key_expand.
 
+  Definition cipher_control_output : Type :=
+      ( signal Bit (* in_ready_o *)
+      * signal Bit (* out_valid_o *)
+      * signal state (* state_o *)
+      ).
+
   (* Comparable to OpenTitan aes_cipher_core but with simplified signalling *)
-  Definition aes_cipher_core_simplified
-    (is_decrypt: signal Bit)
-    (in_valid_i out_ready_i: signal Bit)
-    (initial_key: signal key)
-    (initial_state: signal state)
-    : cava
-    ( signal Bit (* in_ready_o *)
-    * signal Bit (* out_valid_o *)
-    * signal state (* state_o *)
-    ) :=
-    st <- loopDelayS
+  Definition aes_cipher_core_simplified' : Circuit cipher_control_signals cipher_control_output
+    :=
+    Loop (Loop (Loop ( Loop (Loop (Loop (Loop (Comb
     (* state and key buffers are handled by `cipher_new` so we don't explicitly
     * register them here. There is an additional state buffer here for storing the output
     * until it is accepted via out_ready_i. *)
-      (fun '((inputs, st) : signal cipher_control_signals * signal cipher_control_state) =>
-
-        (* unpack inputs and state from Cava 'Pair's *)
-        let '(is_decrypt, in_valid_i, out_ready_i, initial_key, initial_state)
-          := unpacked_signal inputs in
-        let '(last_idle, last_gen_dec_key, last_round, _, _, last_buffered_state, last_output_latch)
-          := unpacked_signal st in
+      (fun input_and_state : cipher_control_signals *
+        signal Bit            (* idle *)
+        * signal Bit         (* generating decryption key *)
+        * signal round_index (* current round *)
+        * signal Bit         (* in_ready_o *)
+        * signal Bit         (* out_valid_o *)
+        * signal state       (* state_o *)
+        * signal Bit         (* out latch when not accepted *)
+        =>
+        let '(is_decrypt, in_valid_i, out_ready_i, initial_key, initial_state,
+             last_idle, last_gen_dec_key, last_round, _, _, last_buffered_state, last_output_latch)
+          := input_and_state in
 
         (* Are we still processing an input (or generating a decryption key) *)
         is_final_round <- last_round ==? round_final ;;
@@ -170,29 +156,31 @@ Section WithCava.
         initial_rcon <- initial_rcon_selector is_decrypt ;;
 
         (* we only need to grab the state at the last round *)
-        st <- cipher round_final round_0 is_decrypt initial_rcon initial_key
-                    initial_state round ;;
+        (* st <- cipher round_final round_0 is_decrypt initial_rcon initial_key *)
+        (*             initial_state round ;; *)
+        let st := initial_state in
         buffered_state <- muxPair producing_output (st, last_buffered_state) ;;
 
         out_valid_o <- or2 (last_output_latch, producing_output) ;;
         inv_out_ready_i <- inv out_ready_i ;;
         output_latch <- and2 (out_valid_o, inv_out_ready_i) ;;
 
-        ret (packed_signal cipher_control_state
-          ( idle
+        ret
+          (
+            (becoming_idle
+          , out_valid_o
+          , buffered_state )
+
+          , idle
           , generating_decryption_key
           , round
           , becoming_idle
           , out_valid_o
           , buffered_state
           , output_latch
-          ))
-      )
-      (packed_signal cipher_control_signals
-        (is_decrypt, in_valid_i, out_ready_i, initial_key, initial_state)) ;;
 
-    let '(_, _, _, in_ready_o, out_valid_o, state_o, _) := unpacked_signal st in
-    ret (in_ready_o, out_valid_o, state_o).
+          )
+      )))))))).
 
 End WithCava.
 

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -38,6 +38,7 @@ Import Pkg.Notations.
 
 Require Import AcornAes.ShiftRowsNetlist.
 Require Import AcornAes.MixColumnsNetlist.
+Require Import AcornAes.SubBytesNetlist.
 
 Local Open Scope monad_scope.
 Local Open Scope vector_scope.
@@ -166,11 +167,12 @@ Section WithCava.
         output_latch <- and2 (out_valid_o, inv_out_ready_i) ;;
 
         ret
-          (
-            (becoming_idle
+          (* outputs *)
+          ( (becoming_idle
           , out_valid_o
           , buffered_state )
 
+          (* state *)
           , idle
           , generating_decryption_key
           , round
@@ -178,7 +180,6 @@ Section WithCava.
           , out_valid_o
           , buffered_state
           , output_latch
-
           )
       )))))))).
 

--- a/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
@@ -1,0 +1,105 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Coq.Vectors.Vector.
+Import ListNotations VectorNotations.
+Require Import ExtLib.Structures.Monads.
+Import MonadNotation.
+
+Require Import Cava.Cava.
+Require Import Cava.Acorn.Acorn.
+Require Import AcornAes.CipherControlCircuit.
+Require Import AcornAes.SubBytesCircuit.
+Require Import AcornAes.MixColumnsCircuit.
+Require Import AcornAes.ShiftRowsCircuit.
+Require Import AcornAes.AddRoundKeyCircuit.
+Require Import AcornAes.Pkg.
+Import Pkg.Notations.
+
+Require Import AcornAes.ShiftRowsNetlist.
+Require Import AcornAes.MixColumnsNetlist.
+
+Definition cipher_state : SignalType := Pair (Pair key round_constant) state.
+
+Definition aes_shift_rows' := instantiate aes_shift_rows_Interface (fun '(x,y) => aes_shift_rows x y).
+Definition aes_mix_columns' := instantiate aes_mix_columns_Interface (fun '(x,y) => aes_shift_rows x y).
+
+Definition key_expand_and_round
+           (is_decrypt : Signal Bit)
+           (round_key : Signal key)
+           (rcon : Signal round_constant)
+           (data : Signal state)
+           (add_round_key_in_sel : Signal (Vec Bit 2))
+           (round_key_sel : Signal Bit)
+           (round_i : Signal round_index)
+  : cava (Signal state) :=
+  sub_bytes_out <- aes_sub_bytes' is_decrypt data ;;
+  shift_rows_out <- aes_shift_rows' (is_decrypt, sub_bytes_out) ;;
+  mix_columns_out <- aes_mix_columns' (is_decrypt, shift_rows_out) ;;
+
+  (* Different rounds perform different operations on the state before adding
+     the round key; select the appropriate wire based on add_round_key_in_sel *)
+  let add_round_key_in :=
+      mux4Tuple (mix_columns_out, data, shift_rows_out, mix_columns_out)
+           add_round_key_in_sel in
+  add_round_key_in <- localSignal add_round_key_in ;;
+
+  (* Intermediate decryption rounds need to mix the key columns *)
+  mixed_round_key <- inv_mix_columns_key round_key ;;
+
+  key_to_add <- muxPair round_key_sel (round_key, mixed_round_key) ;;
+  out <- aes_add_round_key key_to_add add_round_key_in ;;
+
+  (* Key expansion *)
+  '(round_key, rcon) <- key_expand is_decrypt round_i (round_key, rcon) ;;
+
+  ret shift_rows_out.
+
+Definition key_expand_and_round_Interface :=
+  combinationalInterface "key_expand_and_round"
+  [ mkPort "is_decrypt" Bit
+  ; mkPort "key" key
+  ; mkPort "rcon" round_constant
+  ; mkPort "data" state
+  ; mkPort "add_round_key_in_sel" (Vec Bit 2)
+  ; mkPort "round_key_sel" Bit
+  ; mkPort "round_i" (Vec Bit 4) ]
+  [ mkPort "state_o" state ]
+  [].
+
+Definition key_expand_and_round_Netlist
+  := makeNetlist key_expand_and_round_Interface
+  (fun '(a, b, c, d, e, f, g ) => key_expand_and_round a b c d e f g).
+
+Definition aes_cipher_core_simplified_Interface :=
+  combinationalInterface "aes_cipher_core_simplified"
+  [ mkPort "op_i" Bit
+  ; mkPort "in_valid_i" Bit
+  ; mkPort "out_ready_i" Bit
+  ; mkPort "key_init_i" key
+  ; mkPort "state_init_i" state ]
+  [ mkPort "in_ready_o" Bit
+  ; mkPort "out_valid_o" Bit
+  ; mkPort "state_o" state ]
+  [].
+
+(* Definition aes_cipher_core_simplified_Netlist *)
+(*   := makeNetlist aes_cipher_core_simplified_Interface *)
+(*   (fun '(op_i, in_valid_i, out_ready_i, key_init_i, state_init_i) => *)
+(*     aes_cipher_core_simplified key_expand op_i in_valid_i out_ready_i key_init_i state_init_i). *)
+

--- a/silveroak-opentitan/aes/Acorn/CipherNewLoop.v
+++ b/silveroak-opentitan/aes/Acorn/CipherNewLoop.v
@@ -71,7 +71,7 @@ Section WithCava.
     (* Different rounds perform different operations on the state before adding
        the round key; select the appropriate wire based on add_round_key_in_sel *)
     let add_round_key_in :=
-        mux4 (mkpair (mkpair (mkpair mix_columns_out data) shift_rows_out) mix_columns_out)
+        mux4Tuple (mix_columns_out, data, shift_rows_out, mix_columns_out)
              add_round_key_in_sel in
 
     (* Intermediate decryption rounds need to mix the key columns *)


### PR DESCRIPTION
- Uses instantiated versions of `aes_shift_rows`,`aes_mix_columns` etc, this is necessary to prevent excessive netlist generation (and non termination when generating SystemVerilog)