### PR TITLE
aes_cipher_core netlist fixes

### DIFF
--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -366,10 +366,10 @@ Fixpoint linkCircuitStateSignals {i o} (c : Circuit i o)
       fs <- linkCircuitStateSignals f (fst in_state) (fst out_state) ;;
       let ins := snd in_state in
       let outs := snd out_state in
-      addInstance (DelayEnable s resetval en ins outs)
+      addInstance (DelayEnable s resetval en outs ins)
   | @DelayInitCE _ _ t en resetval =>
     fun ins outs =>
-      addInstance (DelayEnable t resetval en ins outs)
+      addInstance (DelayEnable t resetval en outs ins)
   end.
 
 Definition interpCircuit {i o} (c : Circuit i o) (input : i)

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -72,7 +72,7 @@ Section WithCava.
     unpeel (Vector.map constant (nat_to_bitvec_sized _ 1)).
 
   Definition inc_round (current: signal round_index): cava (signal round_index) :=
-    let sum := (@unsignedAdd _ _ 4 4 (current, round_1)) in
+    sum <- localSignal (@unsignedAdd _ _ 4 4 (current, round_1)) ;;
     ret (unpeel (Vector.tl (peel sum))).
 
   Local Infix "==?" := eqb (at level 40).

--- a/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
@@ -59,7 +59,8 @@ Definition key_expand_and_round_Netlist
   (fun '(a, b, c, d, e, f, g ) => key_expand_and_round a (b, c, d) e f g).
 
 Definition aes_cipher_core_simplified_Interface :=
-  combinationalInterface "aes_cipher_core_simplified"
+  sequentialInterface "aes_cipher_core_simplified"
+  "clk_i" PositiveEdge "rst_ni" NegativeEdge
   [ mkPort "op_i" Bit
   ; mkPort "in_valid_i" Bit
   ; mkPort "out_ready_i" Bit
@@ -73,5 +74,4 @@ Definition aes_cipher_core_simplified_Interface :=
 Definition aes_cipher_core_simplified_Netlist :=
   let aes := aes_cipher_core_simplified key_expand in
   makeCircuitNetlist aes_cipher_core_simplified_Interface aes.
-
 


### PR DESCRIPTION
A few small quick fixes
- Fix state delays for circuit (assignments were reversed)
- Add localSignal for addition (generated system verilog was creating an invalid index)
- Provide correct (OpenTitan expected) sequential interface for aes_cipher_core