### PR TITLE
Key expansion loop

### DIFF
--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -43,6 +43,7 @@ Local Open Scope type_scope.
 
 Section WithCava.
   Context {signal} {semantics: Cava signal}.
+  Existing Instance monad. (* make sure cava Monad instance takes precedence *)
 
   (****************************************************************************)
   (* Lava-style circuit combinators.                                          *)

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -39,8 +39,10 @@ End Length.
 (* The push_length autorewrite database simplifies goals including [length] *)
 Hint Rewrite @nil_length @cons_length @seq_length @repeat_length @rev_length
      @map_length @firstn_length @skipn_length @app_length @combine_length
-     @tl_length
+     @tl_length @removelast_firstn_len
      using solve [eauto] : push_length.
+Hint Rewrite @removelast_firstn_len using solve [eauto] : push_length.
+
 Create HintDb length discriminated.
 Ltac length_hammer :=
   autorewrite with push_length; eauto with length; lia.
@@ -116,14 +118,73 @@ Section Misc.
     cbn [tl app]. reflexivity.
   Qed.
 
+  Lemma eta_list_cons_snoc {A} (l : list A) (d : A) :
+    2 < length l ->
+    l = hd d l :: (removelast (tl l)) ++ [last l d].
+  Proof.
+    intros.
+    destruct l; cbn [length] in *; [ Lia.lia | ].
+    destruct l using rev_ind; cbn [length] in *; [ Lia.lia | ].
+    cbn [hd tl]. rewrite !app_comm_cons, last_last.
+    rewrite removelast_last. reflexivity.
+  Qed.
+
+  Lemma removelast_tl {A} (l : list A) : removelast (tl l) = tl (removelast l).
+  Proof.
+    destruct l; [ reflexivity | ]. cbn [tl].
+    destruct l using rev_ind; [ reflexivity | ].
+    rewrite app_comm_cons, !removelast_last. reflexivity.
+  Qed.
+End Misc.
+Hint Rewrite @seq_snoc using solve [eauto] : pull_snoc.
+
+Section Rev.
+  Lemma last_rev {A} l (d : A) : last (rev l) d = hd d l.
+  Proof. destruct l; cbn [rev hd]; auto using last_last. Qed.
+
+  Lemma hd_rev {A} l (d : A) : hd d (rev l) = last l d.
+  Proof.
+    rewrite <-(rev_involutive l). rewrite (rev_involutive (rev l)).
+    rewrite last_rev. reflexivity.
+  Qed.
+
+  Lemma tl_rev {A} (l : list A) : tl (rev l) = rev (removelast l).
+  Proof.
+    destruct l using rev_ind; [ reflexivity | ].
+    rewrite rev_unit, removelast_last. reflexivity.
+  Qed.
+  Lemma removelast_rev {A} (l : list A) : removelast (rev l) = rev (tl l).
+  Proof.
+    rewrite <-(rev_involutive l). rewrite (rev_involutive (rev l)).
+    rewrite tl_rev, rev_involutive. reflexivity.
+  Qed.
+End Rev.
+Hint Rewrite @map_rev @last_rev @hd_rev @tl_rev @removelast_rev using solve [eauto] : pull_rev.
+
+Section Forall2.
   Lemma Forall2_length_eq {A B} (R : A -> B -> Prop) ls1 ls2 :
     Forall2 R ls1 ls2 -> length ls1 = length ls2.
   Proof.
     revert ls2; induction ls1; destruct ls2; auto;
       inversion 1; subst; cbn [length]; auto.
   Qed.
-End Misc.
-Hint Rewrite @seq_snoc using solve [eauto] : pull_snoc.
+
+  Lemma Forall2_eq_map_r {A B} (f : A -> B) ls1 ls2 :
+    Forall2 (fun a b => a = f b) ls1 ls2 ->
+    ls1 = map f ls2.
+  Proof.
+    revert ls2; induction ls1; destruct ls2; auto;
+      inversion 1; subst; cbn [map]; f_equal; eauto.
+  Qed.
+
+  Lemma Forall2_eq_map_l {A B} (f : A -> B) ls1 ls2 :
+    Forall2 (fun b a => a = f b) ls1 ls2 ->
+    ls2 = map f ls1.
+  Proof.
+    revert ls2; induction ls1; destruct ls2; auto;
+      inversion 1; subst; cbn [map]; f_equal; eauto.
+  Qed.
+End Forall2.
 Hint Resolve Forall2_length_eq : length.
 
 (* Definition and proofs of [extend], which pads a list to a specified length *)
@@ -684,6 +745,17 @@ Section Folds.
     cbn [fold_left]. eauto.
   Qed.
 
+  Lemma fold_left_preserves_relation_In {A B C}
+        (R : B -> C -> Prop) (f : B -> A -> B) (g : C -> A -> C) :
+    forall ls b c,
+      R b c ->
+      (forall b c a, R b c -> In a ls -> R (f b a) (g c a)) ->
+      R (fold_left f ls b) (fold_left g ls c).
+  Proof.
+    induction ls; intros; [ eassumption | ].
+    cbn [fold_left In] in *. apply IHls; eauto.
+  Qed.
+
   Lemma fold_left_preserves_relation_seq {B C}
         (R : nat -> B -> C -> Prop) (f : B -> nat -> B) (g : C -> nat -> C) :
     forall len start b c,
@@ -774,6 +846,17 @@ Section Folds.
   Proof.
     intros ? ? IimpliesP. apply IimpliesP.
     apply fold_left_preserves_relation; eauto.
+  Qed.
+
+  Lemma fold_left_double_invariant_In {A B C} (I P : B -> C -> Prop)
+        (f : B -> A -> B) (g : C -> A -> C) (ls : list A) b c :
+    I b c -> (* invariant holds at start *)
+    (forall b c a, I b c -> In a ls -> I (f b a) (g c a)) -> (* invariant holds through loop body *)
+    (forall b c, I b c -> P b c) -> (* invariant implies postcondition *)
+    P (fold_left f ls b) (fold_left g ls c).
+  Proof.
+    intros ? ? IimpliesP. apply IimpliesP.
+    apply fold_left_preserves_relation_In; eauto.
   Qed.
 
   (* Similar to fold_left_double_invariant, except the invariant can depend on
@@ -1077,6 +1160,38 @@ Section FoldLeftAccumulate.
     reflexivity.
   Qed.
 
+
+  Lemma fold_left_accumulate_double_invariant_In {A B C}
+        (I : B -> C -> Prop) (P : (list B * B) -> (list C * C) -> Prop)
+        (f1 : B -> A -> B) (f2 : C -> A -> C)
+        (ls : list A) b d :
+    I b d -> (* invariant holds at start *)
+    (forall b d a, I b d -> In a ls -> I (f1 b a) (f2 d a)) -> (* invariant holds through loop body *)
+    (* invariant implies postcondition *)
+    (forall b d acc1 acc2,
+        I b d ->
+        Forall2 I acc1 acc2 ->
+        P (acc1, b) (acc2, d)) ->
+    P (fold_left_accumulate f1 ls b)
+      (fold_left_accumulate f2 ls d).
+  Proof.
+    intros ? ? IimpliesP. cbv [fold_left_accumulate fold_left_accumulate'].
+    eapply fold_left_double_invariant_In
+      with (I0 := fun '(acc1, a') '(acc2, b') =>
+                    Forall2 I acc1 acc2
+                    /\ I a' b');
+      intros;
+      repeat match goal with
+             | x : _ * _ |- _ => destruct x
+             | H : _ /\ _ |- _ => destruct H
+             | |- _ /\ _ => split; try length_hammer
+             | |- last _ _ = _ => apply last_last
+             end.
+    { cbn [app]; repeat constructor; auto. }
+    { apply Forall2_app; auto. }
+    { apply IimpliesP; auto. }
+  Qed.
+
   Lemma fold_left_accumulate_double_invariant_seq {A B}
         (I : nat -> A -> B -> Prop) (P : list A * A -> list B * B -> Prop)
         (f : A -> nat -> A) (g : B -> nat -> B) start len a b :
@@ -1144,21 +1259,7 @@ Section FoldLeftAccumulate.
     P (fold_left_accumulate f1 ls b)
       (fold_left_accumulate f2 ls d).
   Proof.
-    intros ? ? IimpliesP. cbv [fold_left_accumulate fold_left_accumulate'].
-    eapply fold_left_double_invariant
-      with (I0 := fun '(acc1, a') '(acc2, b') =>
-                    Forall2 I acc1 acc2
-                    /\ I a' b');
-      intros;
-      repeat match goal with
-             | x : _ * _ |- _ => destruct x
-             | H : _ /\ _ |- _ => destruct H
-             | |- _ /\ _ => split; try length_hammer
-             | |- last _ _ = _ => apply last_last
-             end.
-    { cbn [app]; repeat constructor; auto. }
-    { apply Forall2_app; auto. }
-    { apply IimpliesP; auto. }
+    intros. eapply fold_left_accumulate_double_invariant_In; eauto.
   Qed.
 
 End FoldLeftAccumulate.

--- a/silveroak-opentitan/aes/Acorn/AESSV.hs
+++ b/silveroak-opentitan/aes/Acorn/AESSV.hs
@@ -32,5 +32,5 @@ main = do writeSystemVerilog aes_mix_columns_Netlist
           writeTestBench aes_sub_bytes_tb
           writeSystemVerilog aes_add_round_key_Netlist
           writeTestBench aes_add_round_key_tb
-          writeSystemVerilog key_expand_and_round_Netlist
+          writeSystemVerilog cipher_round_Netlist
           writeSystemVerilog aes_cipher_core_simplified_Netlist

--- a/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
@@ -35,28 +35,25 @@ Import Pkg.Notations.
 Require Import AcornAes.ShiftRowsNetlist.
 Require Import AcornAes.MixColumnsNetlist.
 
-Definition cipher_state : SignalType := Pair (Pair key round_constant) state.
-
-Definition key_expand_and_round := CipherNewLoop.key_expand_and_round
-  (round_index:=round_index) (round_constant:=round_constant)
+Definition cipher_round := CipherNewLoop.cipher_round
+  (round_index:=round_index)
   aes_sub_bytes' aes_shift_rows' aes_mix_columns' aes_add_round_key
-  inv_mix_columns_key key_expand.
+  inv_mix_columns_key.
 
-Definition key_expand_and_round_Interface :=
-  combinationalInterface "key_expand_and_round"
+Definition cipher_round_Interface :=
+  combinationalInterface "cipher_round"
   [ mkPort "is_decrypt" Bit
   ; mkPort "key" key
-  ; mkPort "rcon" round_constant
-  ; mkPort "data" state
   ; mkPort "add_round_key_in_sel" (Vec Bit 2)
   ; mkPort "round_key_sel" Bit
-  ; mkPort "round_i" (Vec Bit 4) ]
-  [ mkPort "key_o" key; mkPort "round_o" round_constant; mkPort "state_o" state ]
+  ; mkPort "round_i" (Vec Bit 4)
+  ; mkPort "data" state ]
+  [ mkPort "state_o" state ]
   [].
 
-Definition key_expand_and_round_Netlist
-  := makeNetlist key_expand_and_round_Interface
-  (fun '(a, b, c, d, e, f, g ) => key_expand_and_round a (b, c, d) e f g).
+Definition cipher_round_Netlist
+  := makeNetlist cipher_round_Interface
+  (fun '(a, b, c, d, e, f ) => cipher_round a b c d e f).
 
 Definition aes_cipher_core_simplified_Interface :=
   combinationalInterface "aes_cipher_core_simplified"

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalenceNew.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalenceNew.v
@@ -42,9 +42,6 @@ Require Import Cava.Acorn.Multistep.
 
 Require Import AesSpec.Cipher.
 Require Import AesSpec.CipherProperties.
-Require Import AesSpec.ExpandAllKeys.
-Require Import AesSpec.InterleavedCipher.
-Require Import AesSpec.InterleavedInverseCipher.
 Require Import AcornAes.CipherNewLoop.
 
 Existing Instance Combinational.CombinationalSemantics.
@@ -54,18 +51,13 @@ Section WithSubroutines.
   Local Notation state := (Vector.t (Vector.t byte 4) 4) (only parsing).
   Local Notation key := (Vector.t (Vector.t byte 4) 4) (only parsing).
   Local Notation round_index := (Vector.t bool 4) (only parsing).
-  Local Notation round_constant := byte (only parsing).
   Context (sub_bytes:     bool -> state -> ident state)
           (shift_rows:    bool -> state -> ident state)
           (mix_columns:   bool -> state -> ident state)
-          (add_round_key : key -> state -> ident state)
-          (key_expand : bool -> round_index -> key * round_constant ->
-                        ident (key * round_constant)).
+          (add_round_key : key -> state -> ident state).
   Context (sub_bytes_spec shift_rows_spec mix_columns_spec inv_sub_bytes_spec
                           inv_shift_rows_spec inv_mix_columns_spec : state -> state)
-          (add_round_key_spec : state -> key -> state)
-          (key_expand_spec inv_key_expand_spec :
-             nat -> key * round_constant -> key * round_constant).
+          (add_round_key_spec : state -> key -> state).
   Context
     (sub_bytes_correct : forall (is_decrypt : bool) (st : state),
         unIdent (sub_bytes is_decrypt st)
@@ -77,46 +69,25 @@ Section WithSubroutines.
         unIdent (mix_columns is_decrypt st)
         = if is_decrypt then inv_mix_columns_spec st else mix_columns_spec st)
     (add_round_key_correct :
-       forall k (st : state), unIdent (add_round_key k st) = add_round_key_spec st k)
-    (key_expand_correct :
-       forall (is_decrypt : bool) (round_i : round_index) (k : key) (rcon : round_constant),
-         unIdent (key_expand is_decrypt round_i (k,rcon))
-         = let spec := if is_decrypt then inv_key_expand_spec else key_expand_spec in
-           let i := N.to_nat (Bv2N round_i) in
-           (spec i (k, rcon))).
+       forall k (st : state), unIdent (add_round_key k st) = add_round_key_spec st k).
 
-  Let add_round_key_spec' : state -> key * round_constant -> state :=
-    (fun st k => add_round_key_spec st (fst k)).
-  Let inv_mix_columns_key_spec : key * round_constant -> key * round_constant :=
-    (fun '(k,rcon) => (inv_mix_columns_spec k, rcon)).
-  Let fwd_round_spec : key * round_constant * state -> nat -> key * round_constant * state :=
-    cipher_round_interleaved
-      add_round_key_spec' sub_bytes_spec shift_rows_spec mix_columns_spec
-      key_expand_spec.
-  Let inv_round_spec : key * round_constant * state -> nat -> key * round_constant * state :=
-    equivalent_inverse_cipher_round_interleaved
-      add_round_key_spec' inv_sub_bytes_spec inv_shift_rows_spec
-      inv_mix_columns_spec inv_key_expand_spec
-      inv_mix_columns_key_spec.
-  Let round_spec (is_decrypt : bool) (key_rcon_data : key * round_constant * state) (i : nat)
-    : key * round_constant * state :=
-    if is_decrypt then inv_round_spec key_rcon_data i else fwd_round_spec key_rcon_data i.
-  Let last_round_spec (is_decrypt : bool) (key_rcon_data : key * round_constant * state) (i : nat)
-    : key * round_constant * state :=
-    if is_decrypt
-    then
-      (inv_key_expand_spec i (fst key_rcon_data),
-       add_round_key_spec
-         (inv_shift_rows_spec (inv_sub_bytes_spec (snd key_rcon_data)))
-         (fst (fst key_rcon_data)))
-    else
-      (key_expand_spec i (fst key_rcon_data),
-       add_round_key_spec
-         (shift_rows_spec (sub_bytes_spec (snd key_rcon_data)))
-         (fst (fst key_rcon_data))).
+  (* Formula for each round based on index *)
+  Let round_spec (Nr : nat) (is_decrypt : bool) (k : key) (st : state) (i : nat) : state :=
+    if i =? 0
+    then add_round_key_spec st k
+    else if is_decrypt
+         then if i =? Nr
+              then add_round_key_spec (inv_shift_rows_spec (inv_sub_bytes_spec st)) k
+              else add_round_key_spec
+                     (inv_mix_columns_spec (inv_shift_rows_spec (inv_sub_bytes_spec st)))
+                     (inv_mix_columns_spec k)
+         else if i =? Nr
+              then add_round_key_spec (shift_rows_spec (sub_bytes_spec st)) k
+              else add_round_key_spec
+                     (mix_columns_spec (shift_rows_spec (sub_bytes_spec st))) k.
 
   Hint Rewrite sub_bytes_correct shift_rows_correct mix_columns_correct add_round_key_correct
-       key_expand_correct : to_spec.
+       : to_spec.
 
   Local Ltac simplify_step :=
     first [ destruct_pair_let
@@ -127,10 +98,8 @@ Section WithSubroutines.
           | progress cbn [fst snd map] ].
   Local Ltac simplify := repeat simplify_step.
 
-  (* key_expand_and_round is equivalent to interleaved cipher rounds *)
-  Lemma key_expand_and_round_equiv
-        (is_decrypt : bool)
-        (key_rcon_data : key * round_constant * state)
+  Lemma cipher_round_equiv
+        (is_decrypt : bool) (k : key) (data : state)
         add_round_key_in_sel round_key_sel
         (i Nr : nat) :
     Nr <> 0 -> i < 2 ^ 4 ->
@@ -141,34 +110,24 @@ Section WithSubroutines.
                      then if Nat.eqb i 0 then false
                           else if Nat.eqb i Nr then false else true
                      else false) ->
-    unIdent (key_expand_and_round
+    unIdent (cipher_round
                (key:=Vec (Vec (Vec Bit 8) 4) 4)
-               (round_constant:=Vec Bit 8)
                (state:=Vec (Vec (Vec Bit 8) 4) 4)
                (round_index:=Vec Bit 4)
-               sub_bytes shift_rows mix_columns add_round_key
-               (mix_columns true) key_expand
-               is_decrypt key_rcon_data add_round_key_in_sel round_key_sel
-               (nat_to_bitvec_sized _ i))
-    = if Nat.eqb i Nr
-      then last_round_spec is_decrypt key_rcon_data i
-      else round_spec is_decrypt key_rcon_data i.
+               sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
+               is_decrypt k add_round_key_in_sel round_key_sel
+               (nat_to_bitvec_sized _ i) data)
+    = round_spec Nr is_decrypt k data i.
   Proof.
-    cbv zeta; intros. subst_lets. subst.
-    destruct key_rcon_data as [[round_key rcon] data].
-    cbv [key_expand_and_round cipher_round_interleaved mcompose
-                              equivalent_inverse_cipher_round_interleaved ].
-    simplify.
+    cbv zeta; intros. subst_lets. subst. destruct_products.
+    cbv [cipher_round mcompose]. simplify.
     repeat (destruct_one_match || destruct_one_match_hyp);
-      try Lia.lia; try congruence.
-    all:rewrite <-surjective_pairing.
-    all:reflexivity.
+      try Lia.lia; try congruence; reflexivity.
   Qed.
 
   Lemma cipher_step_equiv
         (Nr : nat) (is_decrypt is_first_round : bool)
-        (num_regular_rounds : round_index)
-        (key_rcon_data : key * round_constant * state)
+        (num_regular_rounds : round_index) (k : key) (data : state)
         (i : nat) :
     (* Nr must be at least two and small enough to fit in round_index size *)
     1 < Nr < 2 ^ 4 -> i <= Nr ->
@@ -177,32 +136,29 @@ Section WithSubroutines.
     unIdent
       (cipher_step
          (key:=Vec (Vec (Vec Bit 8) 4) 4)
-         (round_constant:=Vec Bit 8)
          (state:=Vec (Vec (Vec Bit 8) 4) 4)
          (round_index:=Vec Bit 4)
          sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-         key_expand is_decrypt is_first_round num_regular_rounds
-         key_rcon_data (nat_to_bitvec_sized _ i))
-    = if i =? Nr
-      then last_round_spec is_decrypt key_rcon_data i
-      else round_spec is_decrypt key_rcon_data i.
+         is_decrypt is_first_round num_regular_rounds
+         k (nat_to_bitvec_sized _ i) data)
+    = round_spec Nr is_decrypt k data i.
   Proof.
     cbv zeta; intro Hall_keys; intros. subst.
-    cbv [cipher_step]. simplify.
+    cbv [cipher_step]. simplify. destruct_products.
 
     (* simplify boolean comparisons *)
     cbn [nor2 and2 CombinationalSemantics].
     simplify.
 
-    apply key_expand_and_round_equiv with (Nr:=Nr);
+    apply cipher_round_equiv with (Nr:=Nr);
       try Lia.lia; repeat destruct_one_match;
         boolsimpl; reflexivity.
   Qed.
 
   Lemma cipher_loop_step
         (Nr : nat) (num_regular_rounds round0 : round_index)
-        (is_decrypt : bool) (init_cipher_state : key * round_constant * state)
-        (round_i : round_index) (i : nat) :
+        (is_decrypt : bool) (init_key : key) (init_state : state)
+        (round_key : key) (round_i : round_index) (i : nat) :
     (* Nr must be at least two and small enough to fit in round_index size *)
     1 < Nr < 2 ^ 4 ->
     0 <= i <= Nr ->
@@ -211,84 +167,74 @@ Section WithSubroutines.
     round0 = nat_to_bitvec_sized _ 0 ->
     let loop := cipher_loop
                   (key:=Vec (Vec (Vec Bit 8) 4) 4)
-                  (round_constant:=Vec Bit 8)
                   (state:=Vec (Vec (Vec Bit 8) 4) 4)
                   (round_index:=Vec Bit 4)
-                  sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-                  key_expand in
-    forall current_cipher_state : circuit_state loop,
-      let key := snd current_cipher_state in
-      let rcon := snd (fst current_cipher_state) in
-      let state := snd (fst (fst current_cipher_state)) in
+                  sub_bytes shift_rows mix_columns add_round_key (mix_columns true) in
+    forall current_state : circuit_state loop,
       unIdent
-        (interp loop current_cipher_state
+        (interp loop current_state
                 (is_decrypt, num_regular_rounds, round0, round_i,
-                 init_cipher_state))
-      = let st := if i =? 0 then init_cipher_state else (key,rcon,state) in
-        let out := (if i =? Nr
-                    then last_round_spec is_decrypt st i
-                    else round_spec is_decrypt st i) in
-        (out, (tt, snd out, snd (fst out), fst (fst out))).
+                 init_key, init_state, round_key))
+      = let st := if i =? 0 then init_state else snd (current_state) in
+        let st' := round_spec Nr is_decrypt round_key st i in
+        (st', (tt, st')).
   Proof.
     cbv zeta; intros.
     subst round0 num_regular_rounds round_i.
     cbv [cipher_loop Loop] in *. cbn [interp circuit_state] in *.
-    destruct_products. repeat destruct_pair_let. cbn [fst snd].
-    simpl_ident. rewrite !eqb_nat_to_bitvec_sized by Lia.lia.
+    destruct_products. simplify.
     rewrite cipher_step_equiv with (Nr:=Nr)
       by (try Lia.lia; destruct i; reflexivity).
-    (* too many pair-lets to simplify them all straightaway; expose pairs first *)
-    destruct_inner_pair_let; cbn [unIdent].
-    destruct_inner_pair_let; cbn [unIdent].
     simplify.
     repeat destruct_one_match; cbn [fst snd].
-    all:rewrite <-!surjective_pairing.
     all:try Lia.lia.
     all:try reflexivity.
     all:exfalso; congruence.
   Qed.
 
-  (* Model the expected trace of the cipher loop using the interleaved cipher
-     definition *)
+  (* Model the expected trace of the cipher loop *)
   Definition cipher_trace_with_keys
-             (Nr : nat) (is_decrypt : bool) (first_key : key) (init_rcon : round_constant)
-             (input : state) : list (key * round_constant * state) :=
+             (Nr : nat) (is_decrypt : bool)
+             (init_state : state) (round_keys : list key) : list state :=
     (* Run all rounds except the last *)
     let '(acc, state) :=
         fold_left_accumulate
-          (fun st i =>
-             if i =? Nr
-             then last_round_spec is_decrypt st i
-             else round_spec is_decrypt st i)
-          (List.seq 0 (S Nr)) (first_key, init_rcon, input) in
+          (fun st '(i,k) =>
+             round_spec Nr is_decrypt k st i)
+          (combine (List.seq 0 (S Nr)) round_keys)
+          init_state in
     tl acc.
 
   Lemma cipher_loop_equiv
         (Nr : nat) (is_decrypt : bool)
-        (init_rcon : round_constant) (init_key : key) (init_state : state)
-        (cipher_input : list _) init_cipher_state_ignored :
+        init_key_ignored
+        (init_state : state) init_state_ignored
+        (round_keys : list key) (cipher_input : list _) :
     (* Nr must be at least two and small enough to fit in round_index size *)
     1 < Nr < 2 ^ 4 ->
-    let init_cipher_state := (init_key, init_rcon, init_state) in
-    length init_cipher_state_ignored = Nr ->
+    length init_key_ignored = S Nr ->
+    length init_state_ignored = Nr ->
+    length round_keys = S Nr ->
     cipher_input = combine
-                     (map
-                        (fun i =>
-                           (is_decrypt, nat_to_bitvec_sized _ Nr,
-                            nat_to_bitvec_sized _ 0, nat_to_bitvec_sized _ i))
-                        (seq 0 (S Nr)))
-                     (init_cipher_state :: init_cipher_state_ignored) ->
+                     (combine
+                        (map
+                           (fun i =>
+                              (is_decrypt, nat_to_bitvec_sized _ Nr,
+                               nat_to_bitvec_sized _ 0, nat_to_bitvec_sized _ i))
+                           (seq 0 (S Nr)))
+                        init_key_ignored)
+                     (init_state :: init_state_ignored) ->
     let loop := cipher_loop
                   (key:=Vec (Vec (Vec Bit 8) 4) 4)
-                  (round_constant:=Vec Bit 8)
                   (state:=Vec (Vec (Vec Bit 8) 4) 4)
                   (round_index:=Vec Bit 4)
-                  sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-                  key_expand in
-    multistep loop cipher_input
-    = cipher_trace_with_keys Nr is_decrypt init_key init_rcon init_state.
+                  sub_bytes shift_rows mix_columns add_round_key (mix_columns true) in
+    multistep loop (combine cipher_input round_keys)
+    = cipher_trace_with_keys Nr is_decrypt init_state round_keys.
   Proof.
     cbv zeta; intros. subst cipher_input.
+    destruct round_keys; cbn [length] in *; [ length_hammer | ].
+    destruct init_key_ignored; cbn [length] in *; [ length_hammer | ].
     cbv [multistep cipher_trace_with_keys].
     cbn [seq map combine].
     rewrite fold_left_accumulate_cons_full.
@@ -304,24 +250,29 @@ Section WithSubroutines.
     (* Use loop invariant *)
     rewrite fold_left_accumulate_to_seq
       with (default := (defaultCombValue _, defaultCombValue _, defaultCombValue _,
-                        defaultCombValue _, (defaultCombValue _, defaultCombValue _,
-                                             defaultCombValue _))).
+                        defaultCombValue _, defaultCombValue _, defaultCombValue _,
+                        defaultCombValue _)).
+    rewrite fold_left_accumulate_to_seq
+      with (default:=(0,defaultCombValue (Vec (Vec (Vec Bit 8) 4) 4))).
     autorewrite with push_length natsimpl.
-    rewrite <-seq_shift, fold_left_accumulate_map.
     factor_out_loops.
     eapply fold_left_accumulate_double_invariant_seq
-      with (I:=fun i st1 st2 => (st1 = (st2, (tt, snd st2, snd (fst st2), fst (fst st2))))).
+      with (I:=fun i st1 st2 => (st1 = (st2, (tt, st2)))).
     { (* invariant holds at start *)
       reflexivity. }
     { (* invariant holds through body *)
       intros i x y; intros; subst x. cbn [fst snd].
-      rewrite map_map. autorewrite with push_nth.
+      rewrite <-!seq_shift, !map_map.
+      rewrite !combine_map_l.
+      erewrite map_nth_inbounds with (d2:=(0,init_state,init_state,init_state)) by length_hammer.
+      erewrite map_nth_inbounds with (d2:=(0,init_state)) by length_hammer.
+      cbn [combType] in *.
+      autorewrite with push_nth natsimpl. cbn [fst snd].
       erewrite cipher_loop_step with (Nr:=Nr) (i:=S i)
         by (reflexivity || Lia.lia).
-      cbn zeta delta [fst snd]. repeat destruct_pair_let.
+      cbn [fst snd]. repeat destruct_pair_let.
       cbn [fst snd]. change (S i =? 0) with false. cbn match.
-      destruct_products. cbn [fst snd].
-      destr (i =? Nr); reflexivity. }
+      destruct_products. reflexivity. }
     { (* invariant implies postcondition *)
       intros *. intros Heq Hnth; intros.
       rewrite Heq in *. cbn [fst snd].
@@ -348,159 +299,111 @@ Section WithSubroutines.
       reflexivity. }
   Qed.
 
+  Lemma fold_round_spec_equiv (Nr : nat) (is_decrypt : bool)
+        init_key init_state middle_keys last_key :
+    0 < Nr ->
+    length middle_keys = Nr - 1 ->
+    fold_left (fun (st : t (t byte 4) 4) '(i, k) => round_spec Nr is_decrypt k st i)
+              (combine (seq 1 Nr) (middle_keys ++ [last_key]))
+              (round_spec Nr is_decrypt init_key init_state 0) =
+    if is_decrypt
+    then
+      Cipher.equivalent_inverse_cipher
+        _ _ add_round_key_spec inv_sub_bytes_spec inv_shift_rows_spec
+        inv_mix_columns_spec init_key last_key
+        (map inv_mix_columns_spec middle_keys) init_state
+    else
+      Cipher.cipher _ _ add_round_key_spec sub_bytes_spec shift_rows_spec
+                    mix_columns_spec init_key last_key middle_keys init_state.
+  Proof.
+    intros. rewrite <-seq_shift, combine_map_l.
+    rewrite fold_left_map. destruct Nr; [ Lia.lia | ].
+    autorewrite with pull_snoc.
+    rewrite combine_append by length_hammer.
+    cbn [combine]. autorewrite with pull_snoc natsimpl.
+    cbn [fst snd].
+    cbv [equivalent_inverse_cipher Cipher.cipher].
+    rewrite fold_left_to_seq with (default:=(0,init_key)).
+    rewrite !fold_left_to_seq with (default:=init_key).
+    autorewrite with push_length natsimpl.
+    replace (length middle_keys) with Nr by Lia.lia.
+    destruct is_decrypt.
+    { cbv [round_spec]. repeat destruct_one_match; try Lia.lia; [ ].
+      factor_out_loops.
+      eapply fold_left_double_invariant_seq with
+          (I:=fun _ st1 st2 => st1 = st2);
+        [ reflexivity | | congruence ].
+      intros; subst.
+      autorewrite with push_nth natsimpl. cbn [fst snd].
+      rewrite map_nth_inbounds with (d2:=init_key) by length_hammer.
+      repeat destruct_one_match; try Lia.lia. reflexivity. }
+    { cbv [round_spec]. repeat destruct_one_match; try Lia.lia; [ ].
+      factor_out_loops.
+      eapply fold_left_double_invariant_seq with
+          (I:=fun _ st1 st2 => st1 = st2);
+        [ reflexivity | | congruence ].
+      intros; subst.
+      autorewrite with push_nth natsimpl. cbn [fst snd].
+      repeat destruct_one_match; try Lia.lia. reflexivity. }
+  Qed.
+
   Lemma cipher_equiv
-        (Nr : nat)
-        init_cipher_state_ignored
-        (init_rcon : round_constant) (init_key : key) (init_state : state)
+        (key_expand : Circuit _ _)
+        (Nr : nat) init_key_input init_state_ignored
+        (is_decrypt : bool)
+        (init_key : key) (init_state : state)
         (last_key : key) (middle_keys : list key)
-        (cipher_input : list _) :
-    (* precomputed keys match key expansion *)
-    let all_keys_and_rcons := all_keys key_expand_spec Nr (init_key, init_rcon) in
-    let all_keys := List.map fst all_keys_and_rcons in
-    all_keys = (init_key :: middle_keys ++ [last_key])%list ->
-    (* Nr must be at least two and small enough to fit in round_index size *)
+        (cipher_input : list _) :(* Nr must be at least two and small enough to fit in round_index size *)
     1 < Nr < 2 ^ 4 ->
-    let init_cipher_state := (init_key, init_rcon, init_state) in
-    length init_cipher_state_ignored = Nr ->
+    length init_key_input = S Nr ->
+    length init_state_ignored = Nr ->
+    length middle_keys = Nr - 1 ->
     cipher_input = combine
-                     (map
-                        (fun i =>
-                           (false, nat_to_bitvec_sized _ Nr,
-                            nat_to_bitvec_sized _ 0, nat_to_bitvec_sized _ i))
-                        (seq 0 (S Nr)))
-                     (init_cipher_state :: init_cipher_state_ignored) ->
+                     (combine
+                        (map
+                           (fun i =>
+                              (is_decrypt, nat_to_bitvec_sized _ Nr,
+                               nat_to_bitvec_sized _ 0, nat_to_bitvec_sized _ i))
+                           (seq 0 (S Nr)))
+                        init_key_input)
+                     (init_state :: init_state_ignored) ->
+    (* precomputed keys match key expansion *)
+    multistep key_expand cipher_input = init_key :: middle_keys ++ [last_key] ->
     let cipher := cipher
                     (key:=Vec (Vec (Vec Bit 8) 4) 4)
-                    (round_constant:=Vec Bit 8)
                     (state:=Vec (Vec (Vec Bit 8) 4) 4)
                     (round_index:=Vec Bit 4)
                     sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
                     key_expand in
     forall d,
       nth Nr (multistep cipher cipher_input) d
-      = AesSpec.Cipher.cipher
-          _ _ add_round_key_spec sub_bytes_spec shift_rows_spec mix_columns_spec
-          init_key last_key middle_keys init_state.
+      = if is_decrypt
+        then
+          Cipher.equivalent_inverse_cipher
+            _ _ add_round_key_spec inv_sub_bytes_spec inv_shift_rows_spec
+            inv_mix_columns_spec init_key last_key
+            (map inv_mix_columns_spec middle_keys) init_state
+        else
+          Cipher.cipher
+            _ _ add_round_key_spec sub_bytes_spec shift_rows_spec
+            mix_columns_spec init_key last_key middle_keys init_state.
   Proof.
-    cbv zeta; intro Hall_keys; intros. subst cipher_input.
-    cbv [cipher]. rewrite multistep_compose, multistep_comb.
-    erewrite map_ext with (g:=snd) by (intros; destruct_products; reflexivity).
-    erewrite cipher_loop_equiv with (Nr:=Nr)
-      by (eassumption||reflexivity).
+    cbv zeta; intros. subst cipher_input.
+    cbv [cipher]. autorewrite with push_multistep.
+    rewrite !map_map.
+    rewrite !ListUtils.map_id_ext by reflexivity.
+    erewrite cipher_loop_equiv with (Nr:=Nr) (init_state_ignored:=init_state_ignored)
+      by length_hammer.
+    match goal with Hkexp : multistep key_expand _ = _ |- _ =>
+                    cbv [combType Bvector.Bvector] in Hkexp |- *;
+                      rewrite Hkexp; clear Hkexp end.
     cbv [cipher_trace_with_keys]. simplify.
 
-    (* simplify selection of last element *)
-    erewrite map_nth_inbounds
-      with (d2:=defaultCombValue
-                  (Pair (Pair (Vec (Vec (Vec Bit 8) 4) 4) (Vec Bit 8))
-                        (Vec (Vec (Vec Bit 8) 4) 4)))
-      by length_hammer.
-    autorewrite with push_nth. rewrite nth_tl, nth_last by length_hammer.
-    rewrite fold_left_accumulate_last.
+    cbn [seq combine]. rewrite fold_left_accumulate_cons.
+    cbn [tl]. rewrite nth_fold_left_accumulate by length_hammer.
+    rewrite !firstn_all2 by length_hammer.
 
-    (* Get all states from key expansion *)
-    map_inversion Hall_keys; subst.
-    match goal with H : @eq (list (_ * _)) _ (_ :: _ ++ [_])%list |- _ =>
-                    rename H into Hall_keys end.
-
-    (* representation change; use full key-expansion state (key * round_constant) *)
-    erewrite cipher_change_key_rep with (projkey:=@fst key round_constant)
-      by (reflexivity || eauto).
-
-    erewrite <-cipher_interleaved_equiv by eassumption.
-    cbv [cipher_interleaved]. repeat destruct_pair_let.
-
-    (* process last round on LHS *)
-    autorewrite with pull_snoc.
-    destruct_one_match; try Lia.lia; [ ].
-
-    (* remove the last-round case from loop body *)
-    erewrite ListUtils.fold_left_ext_In with (f:= fun _ _ => if _ =? _ then _ else _)
-      by (intros *; rewrite in_seq; intros; repeat destruct_one_match; try Lia.lia;
-          reflexivity).
-
-    reflexivity.
-  Qed.
-
-  Lemma inv_mix_columns_key_spec_map keys :
-    map fst (map inv_mix_columns_key_spec keys) = map inv_mix_columns_spec (map fst keys).
-  Proof.
-    rewrite !map_map; apply map_ext.
-    intros; subst_lets. cbv beta.
-    repeat destruct_pair_let; reflexivity.
-  Qed.
-
-  Lemma inverse_cipher_equiv
-        (Nr : nat) init_cipher_state_ignored
-        (init_rcon : round_constant) (init_key : key) (init_state : state)
-        (last_key : key) (middle_keys : list key)
-        (cipher_input : list _) :
-    (* precomputed keys match key expansion *)
-    let all_keys_and_rcons := all_keys inv_key_expand_spec Nr (init_key, init_rcon) in
-    let all_keys := List.map fst all_keys_and_rcons in
-    all_keys = (init_key :: middle_keys ++ [last_key])%list ->
-    (* Nr must be at least two and small enough to fit in round_index size *)
-    1 < Nr < 2 ^ 4 ->
-    let init_cipher_state := (init_key, init_rcon, init_state) in
-    length init_cipher_state_ignored = Nr ->
-    cipher_input = combine
-                     (map
-                        (fun i =>
-                           (true, nat_to_bitvec_sized _ Nr,
-                            nat_to_bitvec_sized _ 0, nat_to_bitvec_sized _ i))
-                        (seq 0 (S Nr)))
-                     (init_cipher_state :: init_cipher_state_ignored) ->
-    let cipher := cipher
-                    (key:=Vec (Vec (Vec Bit 8) 4) 4)
-                    (round_constant:=Vec Bit 8)
-                    (state:=Vec (Vec (Vec Bit 8) 4) 4)
-                    (round_index:=Vec Bit 4)
-                    sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-                    key_expand in
-    forall d,
-      nth Nr (multistep cipher cipher_input) d
-      = Cipher.equivalent_inverse_cipher
-         _ _ add_round_key_spec inv_sub_bytes_spec inv_shift_rows_spec inv_mix_columns_spec
-         init_key last_key (map inv_mix_columns_spec middle_keys) init_state.
-  Proof.
-    cbv zeta; intro Hall_keys; intros. subst cipher_input.
-    cbv [cipher]. rewrite multistep_compose, multistep_comb.
-    erewrite map_ext with (g:=snd) by (intros; destruct_products; reflexivity).
-    erewrite cipher_loop_equiv with (Nr:=Nr) by (eassumption||reflexivity).
-    cbv [cipher_trace_with_keys]. simplify.
-
-    (* simplify selection of last element *)
-    erewrite map_nth_inbounds
-      with (d2:=defaultCombValue
-                  (Pair (Pair (Vec (Vec (Vec Bit 8) 4) 4) (Vec Bit 8))
-                        (Vec (Vec (Vec Bit 8) 4) 4)))
-      by length_hammer.
-    autorewrite with push_nth. rewrite nth_tl, nth_last by length_hammer.
-    rewrite fold_left_accumulate_last.
-
-    (* Get all states from key expansion *)
-    map_inversion Hall_keys; subst.
-    match goal with H : @eq (list (_ * _)) _ (_ :: _ ++ [_])%list |- _ =>
-                    rename H into Hall_keys end.
-
-    (* representation change; use full key-expansion state (key * round_constant) *)
-    erewrite equivalent_inverse_cipher_change_key_rep
-      with (projkey:=@fst key round_constant)
-           (middle_keys_alt:=List.map inv_mix_columns_key_spec _)
-      by (reflexivity || apply inv_mix_columns_key_spec_map).
-
-    erewrite <-equivalent_inverse_cipher_interleaved_equiv by eassumption.
-    cbv [equivalent_inverse_cipher_interleaved]. repeat destruct_pair_let.
-
-    (* process last round on LHS *)
-    autorewrite with pull_snoc.
-    destruct_one_match; try Lia.lia; [ ].
-
-    (* remove the last-round case from loop body *)
-    erewrite ListUtils.fold_left_ext_In with (f:= fun _ _ => if _ =? _ then _ else _)
-      by (intros *; rewrite in_seq; intros; repeat destruct_one_match; try Lia.lia;
-          reflexivity).
-
+    erewrite <-fold_round_spec_equiv with (Nr:=Nr) by length_hammer.
     reflexivity.
   Qed.
 End WithSubroutines.

--- a/silveroak-opentitan/aes/Acorn/CipherNewLoop.v
+++ b/silveroak-opentitan/aes/Acorn/CipherNewLoop.v
@@ -28,25 +28,23 @@ Require Import Cava.Acorn.CavaPrelude.
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.Circuit.
 Require Import Cava.Acorn.Combinators.
+Import Circuit.Notations.
 
 Local Open Scope monad_scope.
 
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
-  Context {key round_constant state round_index : SignalType}.
+  Context {key state round_index : SignalType}.
 
   Context (sub_bytes:     signal Bit -> signal state -> cava (signal state))
           (shift_rows:    signal Bit -> signal state -> cava (signal state))
           (mix_columns:   signal Bit -> signal state -> cava (signal state))
           (add_round_key: signal key -> signal state -> cava (signal state))
           (inv_mix_columns_key : signal key -> cava (signal key)).
-  Context (key_expand : signal Bit -> signal round_index ->
-                        (signal key  * signal round_constant) ->
-                        cava (signal key * signal round_constant)).
   Local Infix "==?" := eqb (at level 40).
 
   (* State of the AES cipher (key, round constant, AES state vector) *)
-  Let cipher_state : Type := signal key * signal round_constant * signal state.
+  Let cipher_state : Type := signal key * signal state.
   (* The non-state signals that each round of the cipher loop needs access to *)
   Let cipher_signals : Type :=
     signal Bit (* op_i/is_decrypt : true for decryption, false for encryption *)
@@ -55,14 +53,14 @@ Section WithCava.
       * signal round_index (* current round_index *)
       * cipher_state (* initial state, ignored for all rounds except first *).
 
-  Definition key_expand_and_round
+  Definition cipher_round
              (is_decrypt : signal Bit)
-             (key_rcon_data : cipher_state)
+             (key_data : cipher_state)
              (add_round_key_in_sel : signal (Vec Bit 2))
              (round_key_sel : signal Bit)
              (round_i : signal round_index)
-    : cava (cipher_state) :=
-    let '(round_key, rcon, data) := key_rcon_data in
+    : cava (signal state) :=
+    let '(round_key, data) := key_data in
     shift_rows_out <- (sub_bytes is_decrypt >=> shift_rows is_decrypt) data ;;
     mix_columns_out <- mix_columns is_decrypt shift_rows_out ;;
 
@@ -78,19 +76,16 @@ Section WithCava.
     key_to_add <- muxPair round_key_sel (round_key, mixed_round_key) ;;
     out <- add_round_key key_to_add add_round_key_in ;;
 
-    (* Key expansion *)
-    '(round_key, rcon) <- key_expand is_decrypt round_i (round_key, rcon) ;;
-
-    ret (round_key, rcon, out).
+    ret out.
 
   Definition cipher_step
              (is_decrypt : signal Bit) (* called op_i in OpenTitan *)
              (is_first_round : signal Bit)
              (num_rounds_regular : signal round_index)
-             (key_rcon_data : cipher_state)
+             (key_data : cipher_state)
              (round_i : signal round_index)
-    : cava (cipher_state) :=
-    let '(round_key, rcon, data) := key_rcon_data in
+    : cava (signal state) :=
+    let '(round_key, data) := key_data in
     is_final_round <- round_i ==? num_rounds_regular;;
     (* add_round_key_in_sel :
        1 if round_i = 0, 2 if round_i = num_rounds_regular, 0 otherwise *)
@@ -98,33 +93,31 @@ Section WithCava.
     is_middle_round <- nor2 (is_first_round, is_final_round) ;;
     (* round_key_sel : 1 for a decryption middle round, 0 otherwise *)
     round_key_sel <- and2 (is_middle_round, is_decrypt) ;;
-    key_expand_and_round is_decrypt key_rcon_data
-                         add_round_key_in_sel round_key_sel round_i.
+    cipher_round is_decrypt key_data
+                 add_round_key_in_sel round_key_sel round_i.
 
   Definition cipher_loop
-    : Circuit cipher_signals cipher_state :=
+    : Circuit (cipher_signals * signal key) (signal state) :=
     Loop
-      (Loop
-         (Loop
-            (Comb
-               (fun input_and_state :
-                    cipher_signals * signal key * signal round_constant * signal state  =>
-                  let '(input, fk, fr, fv) := input_and_state in
-                  (* extract signals from the input tuple *)
-                  let '(is_decrypt, num_rounds_regular,
-                        round_0, idx, initial_state) := input in
-                  let '(ik, ir, iv) := initial_state in
-                  is_first_round <- idx ==? round_0 ;;
-                  k <- muxPair is_first_round (fk, ik) ;;
-                  r <- muxPair is_first_round (fr, ir) ;;
-                  v <- muxPair is_first_round (fv, iv) ;;
-                  '(k',r',v') <- cipher_step is_decrypt is_first_round
-                                            num_rounds_regular (k,r,v) idx ;;
-                  let out := (k',r',v') in
-                  ret (out,k',r',v'))))).
+      (Comb
+         (fun input_and_state :
+              cipher_signals * signal key * signal state  =>
+            let '(input, fk, fv) := input_and_state in
+            (* extract signals from the input tuple *)
+            let '(is_decrypt, num_rounds_regular,
+                  round_0, idx, initial_state) := input in
+            let '(ik, iv) := initial_state in
+            is_first_round <- idx ==? round_0 ;;
+            k <- muxPair is_first_round (fk, ik) ;;
+            v <- muxPair is_first_round (fv, iv) ;;
+            v' <- cipher_step is_decrypt is_first_round
+                             num_rounds_regular (k,v) idx ;;
+            ret (v',v'))).
 
   Definition cipher
+             (key_expand : Circuit cipher_signals (signal key))
     : Circuit cipher_signals (signal state) :=
-    Compose cipher_loop
-            (Comb (fun '(_,out) => ret out)).
+    (Comb fork2)
+      >==> Second key_expand
+      >==> cipher_loop.
 End WithCava.


### PR DESCRIPTION
Resolves #560 
Resolves #414 

Makes `key_expand` a sequential `Circuit` instead of a loop, with the round constant as part of its internal state. This actually simplified the top-level lemma statements quite a bit and means we no longer need to use the "interleaved" version of the spec as an intermediate step.