### PR TITLE
Make enables a true input to loops

### DIFF
--- a/cava/Cava/Acorn/Circuit.v
+++ b/cava/Cava/Acorn/Circuit.v
@@ -30,20 +30,18 @@ Require Import Cava.Acorn.Combinators.
 Section WithCava.
   Context `{semantics:Cava}.
 
-  (* TODO: change loop here to a loop with enable *)
-  (* TODO: maybe make loop have separate in/out types to reduce state info *)
   Inductive Circuit : Type -> Type -> Type :=
   | Comb : forall {i o}, (i -> cava o) -> Circuit i o
   | Compose : forall {i t o}, Circuit i t -> Circuit t o -> Circuit i o
   | First : forall {i o t}, Circuit i o -> Circuit (i * t) (o * t)
   | Second : forall {i o t}, Circuit i o -> Circuit (t * i) (t * o)
   | LoopInitCE :
-      forall {i o : Type} {s : SignalType} (en : signal Bit) (resetval : signal s),
+      forall {i o : Type} {s : SignalType} (resetval : signal s),
         Circuit (i * signal s) (o * signal s) ->
-        Circuit i o
+        Circuit (i * signal Bit) o
   | DelayInitCE :
-      forall {t} (en : signal Bit) (resetval : signal t),
-        Circuit (signal t) (signal t)
+      forall {t} (resetval : signal t),
+        Circuit (signal t * signal Bit) (signal t)
   .
 
   (* Internal state of the circuit (register values) *)
@@ -53,8 +51,8 @@ Section WithCava.
     | Compose f g => circuit_state f * circuit_state g
     | First f => circuit_state f
     | Second f => circuit_state f
-    | @LoopInitCE i o s _ _ f => circuit_state f * signal s
-    | @DelayInitCE t _ _ => signal t
+    | @LoopInitCE i o s _ f => circuit_state f * signal s
+    | @DelayInitCE t _ => signal t
     end.
 
   (* The state of the circuit after a reset *)
@@ -64,67 +62,37 @@ Section WithCava.
     | Compose f g => (reset_state f, reset_state g)
     | First f => reset_state f
     | Second f => reset_state f
-    | LoopInitCE _ resetval f => (reset_state f, resetval)
-    | DelayInitCE _ resetval => resetval
-    end.
-
-  (* Run circuit for a single step *)
-  Fixpoint interp {i o} (c : Circuit i o)
-    : circuit_state c -> i -> cava (o * circuit_state c) :=
-    match c in Circuit i o return circuit_state c -> i
-                                  -> cava (o * circuit_state c) with
-    | Comb f => fun _ i => x <- f i ;; ret (x, tt)
-    | Compose f g =>
-      fun cs input =>
-        '(x, cs1) <- interp f (fst cs) input ;;
-        '(y, cs2) <- interp g (snd cs) x ;;
-        ret (y, (cs1, cs2))
-    | First f =>
-      fun cs input =>
-        '(x, cs') <- interp f cs (fst input) ;;
-        ret (x, snd input, cs')
-    | Second f =>
-      fun cs input =>
-        '(x, cs') <- interp f cs (snd input) ;;
-        ret (fst input, x, cs')
-    | LoopInitCE en _ f =>
-      fun '(cs,st) input =>
-        '(out, st', cs') <- interp f cs (input, st) ;;
-        (* select the updated state only if the loop is enabled *)
-         let new_state := indexAt (unpeel [st;st']) (unpeel [en]) in
-        ret (out, (cs',new_state))
-    | DelayInitCE en _ =>
-      fun st input =>
-        (* select the updated state only if the delay is enabled *)
-        let new_state := indexAt (unpeel [st;input]) (unpeel [en]) in
-        ret (st, new_state)
+    | LoopInitCE resetval f => (reset_state f, resetval)
+    | DelayInitCE resetval => resetval
     end.
 
   (* Loop with no enable; set enable to always be true *)
   Definition LoopInit {i o s} (resetval : signal s)
-    : Circuit (i * signal s) (o * signal s) -> Circuit i o :=
-    LoopInitCE (constant true) resetval.
+             (body : Circuit (i * signal s) (o * signal s))
+    : Circuit i o :=
+    Compose (Comb (fun i => ret (i, constant true))) (LoopInitCE resetval body).
   (* Delay with no enable; set enable to always be true *)
   Definition DelayInit {t} (resetval : signal t)
     : Circuit (signal t) (signal t) :=
-    DelayInitCE (constant true) resetval.
+    Compose (Comb (fun i => ret (i, constant true))) (DelayInitCE resetval).
 
   (* Loop with the default signal as its reset value *)
-  Definition LoopCE {i o s} (en : signal Bit)
-    : Circuit (i * signal s) (o * signal s) -> Circuit i o :=
-    LoopInitCE en defaultSignal.
+  Definition LoopCE {i o s}
+    : Circuit (i * signal s) (o * signal s) -> Circuit (i * signal Bit) o :=
+    LoopInitCE defaultSignal.
   (* Delay with the default signal as its reset value *)
-  Definition DelayCE {t} (en : signal Bit)
-    : Circuit (signal t) (signal t) :=
-    DelayInitCE en defaultSignal.
+  Definition DelayCE {t}
+    : Circuit (signal t * signal Bit) (signal t) :=
+    DelayInitCE defaultSignal.
 
   (* Loop with the default signal as its reset value and no enable *)
   Definition Loop {i o s}
-    : Circuit (i * signal s) (o * signal s) -> Circuit i o :=
-    LoopInitCE (constant true) defaultSignal.
+             (body : Circuit (i * signal s) (o * signal s))
+    : Circuit i o :=
+    Compose (Comb (fun i => ret (i, constant true))) (LoopInitCE defaultSignal body).
   (* Delay with the default signal as its reset value and no enable *)
   Definition Delay {t} : Circuit (signal t) (signal t) :=
-    DelayInitCE (constant true) defaultSignal.
+    Compose (Comb (fun i => ret (i, constant true))) (DelayInitCE defaultSignal).
 End WithCava.
 
 Module Notations.

--- a/cava/Cava/Acorn/Multistep.v
+++ b/cava/Cava/Acorn/Multistep.v
@@ -30,9 +30,9 @@ Definition multistep {i o} (c : Circuit i o) (input : list i) : list o :=
   match input with
   | [] => []
   | i :: input =>
-    let '(o,st) := unIdent (interp c (reset_state c) i) in
+    let '(o,st) := step c (reset_state c) i in
     let '(acc, _) := fold_left_accumulate
-                       (fun o_st i => unIdent (interp c (snd o_st) i))
+                       (fun o_st => step c (snd o_st))
                        input (o,st) in
     map fst acc
   end.
@@ -45,7 +45,7 @@ Proof.
   repeat destruct_pair_let; simpl_ident.
   destruct input as [|i1 input]; [ cbn; repeat destruct_pair_let; reflexivity | ].
   rewrite !fold_left_accumulate_cons_full.
-  cbn [fst snd map interp reset_state circuit_state].
+  cbn [fst snd map step reset_state circuit_state].
   repeat first [ destruct_pair_let | progress simpl_ident ].
   rewrite <-!surjective_pairing.
   rewrite fold_left_accumulate_map.
@@ -73,7 +73,7 @@ Proof.
   clear.
   cbv [multistep]. destruct input as [|i0 input]; [ reflexivity | ].
   repeat destruct_pair_let; simpl_ident.
-  cbn [fst snd map interp reset_state circuit_state].
+  cbn [fst snd map step reset_state circuit_state].
   simpl_ident. rewrite fold_left_accumulate_to_map.
   cbn [map fst]. rewrite map_map. cbn [fst].
   reflexivity.
@@ -87,7 +87,7 @@ Proof.
   clear.
   cbv [multistep]. destruct input as [|i0 input]; [ reflexivity | ].
   repeat destruct_pair_let; simpl_ident.
-  cbn [fst snd map interp reset_state circuit_state].
+  cbn [fst snd map step reset_state circuit_state].
   simpl_ident. repeat destruct_pair_let; simpl_ident.
   rewrite fold_left_accumulate_map.
   rewrite !fold_left_accumulate_to_seq with (default:=i0).
@@ -122,7 +122,7 @@ Proof.
   clear.
   cbv [multistep]. destruct input as [|i0 input]; [ reflexivity | ].
   repeat destruct_pair_let; simpl_ident.
-  cbn [fst snd map interp reset_state circuit_state].
+  cbn [fst snd map step reset_state circuit_state].
   simpl_ident. repeat destruct_pair_let; simpl_ident.
   rewrite fold_left_accumulate_map.
   rewrite !fold_left_accumulate_to_seq with (default:=i0).
@@ -157,4 +157,3 @@ Proof.
   destruct input; repeat destruct_pair_let; length_hammer.
 Qed.
 Hint Rewrite @multistep_length using solve [eauto] : push_length.
-

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalenceNew.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalenceNew.v
@@ -193,17 +193,16 @@ Section WithSubroutines.
                   (round_index:=Vec Bit 4)
                   sub_bytes shift_rows mix_columns add_round_key (mix_columns true) in
     forall current_state : circuit_state loop,
-      unIdent
-        (interp loop current_state
-                (is_decrypt, num_regular_rounds, round0, round_i,
-                 init_key, init_state, round_key))
-      = let st := if i =? 0 then init_state else snd (current_state) in
+      step loop current_state
+           (is_decrypt, num_regular_rounds, round0, round_i,
+            init_key, init_state, round_key)
+      = let st := if i =? 0 then init_state else snd (snd (current_state)) in
         let st' := round_spec Nr is_decrypt round_key st i in
-        (st', (tt, st')).
+        (st', (tt, (tt, st'))).
   Proof.
     cbv zeta; intros.
     subst round0 num_regular_rounds round_i.
-    cbv [cipher_loop Loop] in *. cbn [interp circuit_state] in *.
+    cbv [cipher_loop Loop] in *. cbn [step circuit_state] in *.
     destruct_products. simplify.
     rewrite cipher_step_equiv with (Nr:=Nr)
       by (try Lia.lia; destruct i; reflexivity).
@@ -274,7 +273,7 @@ Section WithSubroutines.
     autorewrite with push_length natsimpl.
     factor_out_loops.
     eapply fold_left_accumulate_double_invariant_seq
-      with (I:=fun i st1 st2 => (st1 = (st2, (tt, st2)))).
+      with (I:=fun i st1 st2 => (st1 = (st2, (tt, (tt, st2))))).
     { (* invariant holds at start *)
       reflexivity. }
     { (* invariant holds through body *)

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -105,7 +105,7 @@ Lemma count_by_correct (input : list (combType (Vec Bit 8))) :
   = map snd (count_by_spec input).
 Proof.
   destruct input as [|input0 input]; [ reflexivity | ].
-  cbv [multistep count_by_spec count_by Loop interp].
+  cbv [multistep count_by_spec count_by Loop step].
   rewrite <-seq_shift, map_map. cbn [firstn].
   repeat destruct_pair_let. simpl_ident.
   repeat destruct_pair_let. simpl_ident.
@@ -117,10 +117,10 @@ Proof.
 
   pose (statet := combType (Vec Bit 8)).
   pose (outt := combType Bit).
-  pose (to_out_and_state:=fun (x : statet * outt) => (snd x, (tt, fst x))).
+  pose (to_out_and_state:=fun (x : statet * outt) => (snd x, (tt, (tt, fst x)))).
   (* Important: min_state should go *inside fold_left to avoid this complicated state type *)
   eapply fold_left_invariant_seq
-      with (I:=fun i (acc_st : list (outt * (unit * statet)) * (outt * (unit * statet))) =>
+      with (I:=fun i (acc_st : list (outt * (unit * (unit * statet))) * (outt * (unit * (unit * statet)))) =>
                  acc_st = (map to_out_and_state (count_by_spec (firstn (S i) (input0 :: input))),
                            to_out_and_state (bvsumc (firstn (S i) (input0 :: input))))).
   { (* invariant holds at start *)


### PR DESCRIPTION
I realized that I made a mistake in #572 -- the way I encoded enables meant that the enable could only be a constant value, since it was part of the construction of the loop and not part of the input to the circuit. This PR fixes the issue by making enables true inputs.

Unfortunately, to make this work, I had to get rid of the cute trick where I used the same `interp` singe-step interpretation function to produce both the netlist and Coq semantics. Now we have two functions, `interpCircuit : forall i o, Circuit i o -> state CavaState o`, which creates the netlist for a `Circuit` (including constructing all the new signals and adding delays) and `step : forall i o (c : Circuit i o), circuit_state c -> i -> o * circuit_state c`, which is the single-step semantics for the identity-monad interpretation.