### PR TITLE
Port CountBy to Circuit, update DoubleCountBy

### DIFF
--- a/cava/Cava/Acorn/AcornNew.v
+++ b/cava/Cava/Acorn/AcornNew.v
@@ -1,0 +1,24 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Export Cava.Signal.
+Require Export Cava.Acorn.CavaClass.
+Require Export Cava.Acorn.CavaPrelude.
+Require Export Cava.Acorn.Circuit.
+Require Export Cava.Acorn.Combinational.
+Require Export Cava.Acorn.Combinators.
+Require Export Cava.Acorn.NetlistGeneration.
+Require Export Cava.Acorn.Multistep.

--- a/cava/Cava/Acorn/CombinationalPropertiesNew.v
+++ b/cava/Cava/Acorn/CombinationalPropertiesNew.v
@@ -184,3 +184,8 @@ Lemma indexConst_eq {A sz} (v : combType (Vec A sz)) (n : nat) :
   indexConst v n = nth_default (defaultCombValue _) n v.
 Proof. reflexivity. Qed.
 Hint Rewrite @indexConst_eq using solve [eauto] : simpl_ident.
+
+Lemma fork2Correct {A} (i : combType A) :
+ unIdent (fork2 i) = (i, i).
+Proof. reflexivity. Qed.
+Hint Rewrite @fork2Correct using solve [eauto] : simpl_ident.

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -29,6 +29,7 @@ Require Import Cava.Cava.
 Require Import Cava.Signal.
 Require Import Cava.VectorUtils.
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Acorn.CombinationalMonad.
 Require Import Cava.Acorn.Sequential.
 Require Import Cava.Acorn.CavaClass.
@@ -47,8 +48,10 @@ Recursive Extraction Library Cava.
 Recursive Extraction Library Acorn.
 Recursive Extraction Library Circuit.
 Recursive Extraction Library CombinationalMonad.
+Recursive Extraction Library Combinational.
 Recursive Extraction Library Sequential.
 Recursive Extraction Library Combinators.
+Recursive Extraction Library Multistep.
 Recursive Extraction Library NetlistGeneration.
 
 Recursive Extraction Library Netlist.

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -682,12 +682,28 @@ Section FirstnSkipn.
     destruct lb; cbn [skipn combine]; [ rewrite combine_nil; reflexivity | ].
     rewrite IHn. reflexivity.
   Qed.
+
+  Lemma firstn_map {A B} (f : A -> B) n ls :
+    firstn n (map f ls) = map f (firstn n ls).
+  Proof.
+    revert ls; induction n; [ reflexivity | ].
+    destruct ls; [ reflexivity | ].
+    cbn [map firstn]. rewrite IHn; reflexivity.
+  Qed.
+
+  Lemma firstn_seq n start len :
+    firstn n (seq start len) = seq start (Nat.min n len).
+  Proof.
+    revert start len; induction n; [ reflexivity | ].
+    destruct len; [ reflexivity | ].
+    cbn [Nat.min seq firstn]. rewrite IHn; reflexivity.
+  Qed.
 End FirstnSkipn.
 Hint Rewrite @skipn_app @skipn_skipn @skipn_repeat @skipn_cons @skipn_O
      @skipn_nil @skipn_all @skipn_combine
      using solve [eauto] : push_skipn.
 Hint Rewrite @firstn_nil @firstn_cons @firstn_all @firstn_app @firstn_O
-     @firstn_firstn @combine_firstn
+     @firstn_firstn @combine_firstn @firstn_map @firstn_seq
      using solve [eauto] : push_firstn.
 
 (* Proofs about fold_right and fold_left *)

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -1160,6 +1160,34 @@ Section FoldLeftAccumulate.
     reflexivity.
   Qed.
 
+  Lemma fold_left_accumulate_invariant_seq {A B}
+        (I : nat -> B -> list B -> Prop) (P : (list B * B) -> Prop)
+        (f : B -> A -> B) (ls : list A) b :
+    I 0 b [b] -> (* invariant holds at start *)
+  (* invariant holds through loop *)
+  (forall t st acc d,
+      I t st acc ->
+      0 <= t < length ls ->
+      let out := f st (nth t ls d) in
+      I (S t) out (acc ++ [out])) ->
+    (* invariant implies postcondition *)
+    (forall st acc,
+        I (length ls) st acc ->
+        P (acc, st)) ->
+    P (fold_left_accumulate f ls b).
+  Proof.
+    intros ? ? IimpliesP. cbv [fold_left_accumulate fold_left_accumulate'].
+    destruct ls as[|default ls]; [ cbn; solve [auto] | ].
+    erewrite fold_left_to_seq with (default0:=default).
+    eapply fold_left_invariant_seq
+          with (I0 := fun i '(acc,st) =>
+                        I i st acc).
+    { cbn. eauto. }
+    { intros ? [? ?]; intros.
+      cbn [Nat.add] in *; auto. }
+    { intros [? ?]; cbn [length Nat.add]; intros.
+      auto. }
+  Qed.
 
   Lemma fold_left_accumulate_double_invariant_In {A B C}
         (I : B -> C -> Prop) (P : (list B * B) -> (list C * C) -> Prop)

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -51,6 +51,7 @@ library
                      CavaPrelude
                      Combinators
                      CombinationalMonad
+                     Combinational
                      Circuit
                      Datatypes
                      FullAdder
@@ -60,6 +61,7 @@ library
                      ListUtils
                      Logic
                      Monad
+                     Multistep
                      Netlist
                      NetlistGeneration
                      Nat

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -23,12 +23,12 @@ Export MonadNotation.
 
 Require Import Cava.Cava.
 Require Import Cava.Tactics.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.UnsignedAdders.
 
 (******************************************************************************)
 (* countBy                                                                    *)
-(******************************************************************************) 
+(******************************************************************************)
 
 (*
 
@@ -48,11 +48,10 @@ bit-growth i.e. it computes (a + b) mod 256.
 *)
 
 Section WithCava.
-  Context {signal} {combsemantics: Cava signal}
-          {semantics: CavaSeq combsemantics}.
+  Context {signal} {semantics: Cava signal}.
 
-  Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
-    := loopDelayS addN.
+  Definition countBy : Circuit (signal (Vec Bit 8)) (signal (Vec Bit 8))
+    := Loop (Comb (addN >=> fork2)).
 
 End WithCava.
 
@@ -68,7 +67,7 @@ Definition b250 := N2Bv_sized 8 250.
 
 Local Open Scope list_scope.
 
-Example countBy_ex1: sequential (countBy [b14; b7; b3; b250]) = [b14; b21; b24; b18].
+Example countBy_ex1: multistep countBy [b14; b7; b3; b250] = [b14; b21; b24; b18].
 Proof. reflexivity. Qed.
 
 Definition countBy_Interface
@@ -78,13 +77,13 @@ Definition countBy_Interface
      [mkPort "o" (Vec Bit 8)]
      [].
 
-Definition countBy_Netlist := makeNetlist countBy_Interface countBy.
+Definition countBy_Netlist := makeCircuitNetlist countBy_Interface countBy.
 
 Definition countBy_tb_inputs
   := [b14; b7; b3; b250].
 
-Definition countBy_tb_expected_inputs := sequential (countBy countBy_tb_inputs).
+Definition countBy_tb_expected_outputs := multistep countBy countBy_tb_inputs.
 
 Definition countBy_tb
   := testBench "countBy_tb" countBy_Interface
-     countBy_tb_inputs countBy_tb_expected_inputs.
+     countBy_tb_inputs countBy_tb_expected_outputs.

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -25,12 +25,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.CavaClass.
-Require Import Cava.Acorn.CavaPrelude.
-Require Import Cava.Acorn.Circuit.
-Require Import Cava.Acorn.Combinational.
-Require Import Cava.Acorn.Combinators.
-Require Import Cava.Acorn.Multistep.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.UnsignedAdders.
 Import Circuit.Notations.
 

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -129,4 +129,21 @@ Goal (multistep
       = [b0;b0;b0;b1]).
 Proof. reflexivity. Qed.
 
-(* TODO: netlist generation  -- define a recursive function on Circuit that wires up the netlist *)
+Definition double_count_by_interface
+  := sequentialInterface "double_count_by"
+     "clk" PositiveEdge "rst" PositiveEdge
+     [mkPort "i" (Vec Bit 8)]
+     [mkPort "o" (Vec Bit 8)]
+     [].
+
+Definition double_count_by_Netlist :=
+  makeCircuitNetlist double_count_by_interface double_count_by.
+
+Definition double_count_by_tb_inputs := [b14; b7; b3; b250].
+
+Definition double_count_by_tb_expected_outputs :=
+  multistep double_count_by double_count_by_tb_inputs.
+
+Definition double_count_by_tb
+  := testBench "double_count_by_tb" double_count_by_interface
+     double_count_by_tb_inputs double_count_by_tb_expected_outputs.

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -14,25 +14,23 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
+Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.NArith.
 Require Import Coq.Lists.List.
 Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 Local Open Scope list_scope.
 
+Require Import coqutil.Tactics.Tactics.
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
 Require Import Cava.ListUtils.
 Require Import Cava.Tactics.
-Require Import Cava.Acorn.CavaClass.
-Require Import Cava.Acorn.Circuit.
-Require Import Cava.Acorn.Identity.
-Require Import Cava.Acorn.Combinational.
-Require Import Cava.Acorn.Combinators.
-Require Import Cava.Acorn.Multistep.
+Require Import Cava.Acorn.AcornNew.
+Require Import Cava.Acorn.IdentityNew.
+Require Import Cava.Acorn.CombinationalPropertiesNew.
 Require Import Cava.Lib.UnsignedAdders.
 
 Require Import DoubleCountBy.DoubleCountBy.
@@ -40,17 +38,15 @@ Require Import DoubleCountBy.DoubleCountBy.
 Existing Instance CombinationalSemantics.
 
 (* redefine simpl_ident to simplify the new semantics class *)
-Ltac simpl_ident ::=
-  repeat (first
-            [ progress autorewrite with simpl_ident
-            | progress cbn[fst snd bind ret Monad_ident monad
-                               CombinationalSemantics unIdent] ]).
-
 Definition bvadd {n} (a b : Vector.t bool n) : Vector.t bool n :=
   N2Bv_sized n (Bv2N b + Bv2N a).
 
 Definition bvsum {n} (l : list (Vector.t bool n)) : Vector.t bool n :=
   fold_left bvadd l (N2Bv_sized n 0).
+
+Definition boolsum {n} (l : list bool) : Vector.t bool n :=
+  fold_left (fun acc (c : bool) => if c then N2Bv_sized n (Bv2N acc + 1) else acc)
+            l (N2Bv_sized n 0).
 
 Definition bvaddc {n} (a b : Vector.t bool n) : Vector.t bool n * bool :=
   let sum := (Bv2N b + Bv2N a)%N in
@@ -58,13 +54,13 @@ Definition bvaddc {n} (a b : Vector.t bool n) : Vector.t bool n * bool :=
   (N2Bv_sized n sum, carry).
 
 Definition bvsumc {n} (l : list (Vector.t bool n)) : Vector.t bool n * bool :=
-  fold_left (fun '(acc,_) => bvaddc acc) l (N2Bv_sized n 0, false).
+  fold_left (fun acc_c => bvaddc (fst acc_c)) l (N2Bv_sized n 0, false).
 
 Definition count_by_spec (i : list (Vector.t bool 8)) : list (Vector.t bool 8 * bool) :=
   map (fun t => bvsumc (firstn t i)) (seq 1 (length i)).
 
-Definition double_count_by_spec (i : list (Vector.t bool 8)) : list (Vector.t bool 8 * bool) :=
-  map (fun t => bvsumc (firstn t i)) (seq 1 (length i)).
+Definition double_count_by_spec (i : list (Vector.t bool 8)) : list (Vector.t bool 8) :=
+  map (fun t => boolsum (firstn t (map snd (count_by_spec i)))) (seq 1 (length i)).
 
 Lemma addN_correct {n} (x y : combType (Vec Bit n)) :
   unIdent (addN (x, y)) = bvadd x y.
@@ -100,73 +96,121 @@ Lemma bvaddc_comm {n} (a b : Vector.t bool n) : bvaddc a b = bvaddc b a.
 Admitted.
 Local Opaque bvaddc.
 
-Lemma count_by_correct (input : list (combType (Vec Bit 8))) :
-  multistep count_by input
-  = map snd (count_by_spec input).
+Lemma count_by_step (input st : combType (Vec Bit 8)) :
+  step count_by (tt, (tt, st)) input
+  = (snd (bvaddc input st), (tt, (tt, fst (bvaddc input st)))).
 Proof.
-  destruct input as [|input0 input]; [ reflexivity | ].
-  cbv [multistep count_by_spec count_by Loop step].
-  rewrite <-seq_shift, map_map. cbn [firstn].
-  repeat destruct_pair_let. simpl_ident.
-  repeat destruct_pair_let. simpl_ident.
-  erewrite fold_left_accumulate_ext_In.
-  2:{ intros; repeat destruct_pair_let; simpl_ident.
-      instantiate_app_by_reflexivity. }
-  rewrite fold_left_accumulate_to_seq with (default:=defaultCombValue _).
-  cbv [fold_left_accumulate fold_left_accumulate']. cbn [app].
+  intros; cbv [count_by Loop step].
+  repeat first [ destruct_pair_let | progress simpl_ident].
+  reflexivity.
+Qed.
 
-  pose (statet := combType (Vec Bit 8)).
-  pose (outt := combType Bit).
-  pose (to_out_and_state:=fun (x : statet * outt) => (snd x, (tt, (tt, fst x)))).
-  (* Important: min_state should go *inside fold_left to avoid this complicated state type *)
-  eapply fold_left_invariant_seq
-      with (I:=fun i (acc_st : list (outt * (unit * (unit * statet))) * (outt * (unit * (unit * statet)))) =>
-                 acc_st = (map to_out_and_state (count_by_spec (firstn (S i) (input0 :: input))),
-                           to_out_and_state (bvsumc (firstn (S i) (input0 :: input))))).
+Lemma bvsumc_snoc {n} xs (x : t bool n) :
+  bvsumc (xs ++ [x]) = bvaddc x (fst (bvsumc xs)).
+Proof.
+  cbv [bvsumc].
+  autorewrite with pull_snoc.
+  apply bvaddc_comm.
+Qed.
+
+Lemma boolsum_snoc {n} xs (x : bool) :
+  boolsum (xs ++ [x]) = if x then N2Bv_sized n (Bv2N (n:=n) (boolsum xs) + 1) else boolsum xs.
+Proof.
+  cbv [boolsum]. autorewrite with pull_snoc.
+  reflexivity.
+Qed.
+
+Lemma count_by_correct (input : list (combType (Vec Bit 8))) :
+  multistep count_by input = map snd (count_by_spec input).
+Proof.
+  intros; cbv [count_by].
+  eapply (multistep_Loop_invariant (s:=Vec Bit 8)) with
+      (I:=fun t st _ acc =>
+            st = fst (bvsumc (firstn t input))
+            /\ acc = map snd (count_by_spec (firstn t input))).
   { (* invariant holds at start *)
-    subst_lets. cbn - [bvaddc].
-    rewrite bvaddc_comm. reflexivity. }
-  { (* invariant holds through loop *)
-    intros. Tactics.destruct_products. subst_lets.
-    logical_simplify. cbn [fst snd].
-    cbv [bvsumc]. cbn [fold_left].
-    autorewrite with push_firstn push_length.
-    rewrite !Min.min_l by (cbn [combType] in *; Lia.lia).
-    cbn [seq map].
-    rewrite <-!seq_shift, !map_map. cbn [fold_left].
-    erewrite !firstn_succ_snoc with (d:=defaultCombValue _) by length_hammer.
-    autorewrite with pull_snoc. repeat destruct_pair_let.
-    f_equal; [ | rewrite bvaddc_comm; reflexivity ].
-
-    cbv [count_by_spec bvsumc].
-    autorewrite with push_length natsimpl.
-    rewrite PeanoNat.Nat.add_1_r.
-    rewrite <-seq_shift, !map_map.
-    rewrite seq_snoc. cbn [seq].
-    rewrite <-!app_comm_cons. cbn [map].
-    autorewrite with pull_snoc push_firstn.
-    cbn [fold_left].
-    apply f_equal.
-    apply f_equal2.
-    { rewrite <-seq_shift, !map_map.
-      apply map_ext_in; intros *.
-      rewrite in_seq. intros.
-      cbn [combType] in *.
-      autorewrite with push_firstn push_length natsimpl listsimpl.
-      reflexivity. }
-    { cbn [combType] in *.
-      autorewrite with push_length push_firstn natsimpl.
-      autorewrite with pull_snoc. repeat destruct_pair_let.
-      cbn [fst snd]. rewrite bvaddc_comm. reflexivity. }
-  }
-  { (* invariant implies postcondition *)
-    intros. Tactics.destruct_products. logical_simplify.
-    subst_lets. cbn [fst snd map seq].
-    cbv [bvsumc]. cbn [fold_left].
-    autorewrite with push_length natsimpl.
-    cbn [map seq firstn fold_left fst snd].
-    f_equal. rewrite <-!seq_shift, !map_map.
-    apply map_ext; intros. cbn [fst snd].
-    autorewrite with push_firstn. cbn [fold_left].
+    split; reflexivity. }
+  { (* invariant holds through body *)
+    cbv zeta. intros ? ? ? ? d; intros; logical_simplify; subst.
+    cbv [step count_by_spec].
+    repeat first [ destruct_pair_let | progress simpl_ident].
+    rewrite firstn_succ_snoc with (d0:=d) by length_hammer.
+    autorewrite with push_length natsimpl pull_snoc.
+    rewrite Nat.add_1_r. autorewrite with pull_snoc.
+    rewrite firstn_succ_snoc with (d0:=d) by length_hammer.
+    cbv [combType] in *. rewrite !bvsumc_snoc.
+    autorewrite with push_nth push_firstn push_length natsimpl listsimpl.
+    ssplit; [ reflexivity | ].
+    f_equal; [ ]. apply f_equal.
+    apply map_ext_in; intros.
+    match goal with H : _ |- _ => apply in_seq in H end.
+    autorewrite with push_length natsimpl push_firstn push_list_fold listsimpl.
     reflexivity. }
+  { (* invariant implies postcondition *)
+    intros; logical_simplify; subst.
+    rewrite firstn_all; reflexivity. }
+Qed.
+
+Lemma count_by_spec_nth t input d :
+  t < length input ->
+  nth t (count_by_spec input) d = bvaddc (nth t input (fst d)) (fst (bvsumc (firstn t input))).
+Proof.
+  cbv [count_by_spec]. intros.
+  rewrite map_nth_inbounds with (d2:=0) by length_hammer.
+  autorewrite with push_nth. cbn [Nat.add].
+  rewrite firstn_succ_snoc with (d0:=fst d) by length_hammer.
+  rewrite bvsumc_snoc. reflexivity.
+Qed.
+
+Lemma count_by_spec_length input : length (count_by_spec input) = length input.
+Proof. cbv [count_by_spec]; length_hammer. Qed.
+Hint Rewrite @count_by_spec_length using solve [eauto] : push_length.
+
+Lemma firstn_count_by_spec t input :
+  firstn t (count_by_spec input) = count_by_spec (firstn t input).
+Proof.
+  cbv [count_by_spec]. intros.
+  autorewrite with push_firstn push_length natsimpl.
+  apply map_ext_in; intros.
+  match goal with H : _ |- _ => apply in_seq in H end.
+  autorewrite with push_firstn natsimpl.
+  reflexivity.
+Qed.
+Hint Rewrite @firstn_count_by_spec using solve [eauto] : push_firstn.
+
+Lemma double_count_by_correct (input : list (combType (Vec Bit 8))) :
+  multistep double_count_by input = double_count_by_spec input.
+Proof.
+  intros; cbv [double_count_by].
+  let f := lazymatch goal with |- context [Loop ?body] => body end in
+  eapply multistep_Loop_invariant
+    with (body:=f)
+         (I:= fun t st body_st acc =>
+                body_st = (tt, (tt, fst (bvsumc (firstn t input))), tt)
+                /\ st = boolsum (firstn t (map snd (count_by_spec input)))
+                /\ acc = double_count_by_spec (firstn t input)).
+  { (* invariant holds at start *)
+    ssplit; reflexivity. }
+  { (* invariant holds through body *)
+    cbv zeta. intros ? ? ? ? d; intros; logical_simplify; subst.
+    cbn [step]. cbv [double_count_by_spec].
+    repeat first [ destruct_pair_let | progress simpl_ident].
+    autorewrite with push_length natsimpl pull_snoc.
+    rewrite !count_by_step. cbn [fst snd].
+    cbv [combType] in *.
+    rewrite firstn_succ_snoc with (d0:=d) by length_hammer.
+    rewrite !firstn_succ_snoc with (d0:=false) by length_hammer.
+    cbv [combType] in *. rewrite !bvsumc_snoc, !boolsum_snoc.
+    rewrite !map_nth_inbounds with (d2:=(d,false)) by length_hammer.
+    rewrite !count_by_spec_nth by length_hammer.
+    ssplit; [ reflexivity .. | ].
+    autorewrite with push_nth push_firstn push_length natsimpl listsimpl.
+    f_equal; [ ].
+    apply map_ext_in; intros.
+    match goal with H : _ |- _ => apply in_seq in H end.
+    autorewrite with push_firstn push_length natsimpl listsimpl.
+    reflexivity. }
+  { (* invariant implies postcondition *)
+    intros; logical_simplify; subst.
+    rewrite firstn_all; reflexivity. }
 Qed.

--- a/tests/TestsExtraction.v
+++ b/tests/TestsExtraction.v
@@ -27,6 +27,7 @@ Require Import Tests.MuxTests.
 Require Import Tests.TestMultiply.
 Require Import Tests.Delay.
 Require Import Tests.CountBy.CountBy.
+Require Import Tests.DoubleCountBy.DoubleCountBy.
 Require Import Tests.AccumulatingAdderEnable.AccumulatingAdderEnable.
 Require Import Tests.Array.
 
@@ -36,4 +37,5 @@ Extraction Library TestMultiply.
 Extraction Library Delay.
 Extraction Library AccumulatingAdderEnable.
 Extraction Library CountBy.
+Extraction Library DoubleCountBy.
 Extraction Library Array.

--- a/tests/TestsSV.hs
+++ b/tests/TestsSV.hs
@@ -23,6 +23,7 @@ import MuxTests
 import TestMultiply
 import Delay
 import CountBy
+import DoubleCountBy
 import Array
 
 main :: IO ()
@@ -42,8 +43,9 @@ main = do writeSystemVerilog mux2_1Netlist
           -- writeTestBench pipelinedNAND_tb
           writeSystemVerilog countBy_Netlist
           writeTestBench countBy_tb
+          writeSystemVerilog double_count_by_Netlist
+          writeTestBench double_count_by_tb
           writeSystemVerilog accumulatingAdderEnable_Netlist
-          writeSystemVerilog accumulatingAdderEnable2_Netlist
           writeSystemVerilog arrayTest_Netlist
           writeTestBench arrayTest_tb
           writeSystemVerilog multiDimArrayTest_Netlist


### PR DESCRIPTION
Progress on #565

- Add some loop invariant lemmas for `multistep`
- Port `tests/CountBy` to `Circuit`
- Update `tests/DoubleCountBy` with netlist generation and a proof for the double counter