### PR TITLE
Port remaining tests and examples

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -29,7 +29,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.UnsignedAdders.
 
 Existing Instance CombinationalSemantics.
@@ -78,17 +78,17 @@ Local Open Scope string_scope.
 Local Open Scope vector_scope.
 
 Definition v0_v1 := [v0; v1].
-Definition v0_plus_v1 : list (Bvector 8) := combinational (adderTree 0 [v0_v1]%list).
+Definition v0_plus_v1 : list (Bvector 8) := unIdent (adderTree 0 [v0_v1]%list).
 
-Example sum_vo_v1 : combinational (adderTree2 [v0_v1]%list) = [N2Bv_sized 8 21]%list.
+Example sum_vo_v1 : unIdent (adderTree2 [v0_v1]%list) = [N2Bv_sized 8 21]%list.
 Proof. reflexivity. Qed.
 
 
 
 Definition v0_3 := [v0; v1; v2; v3].
-Definition sum_v0_3 : list (Bvector 8) := combinational (adderTree4 [v0_3]%list).
+Definition sum_v0_3 : list (Bvector 8) := unIdent (adderTree4 [v0_3]%list).
 
-Example sum_v0_v1_v2_v3 : combinational (adderTree4 [v0_3]%list) = [N2Bv_sized 8 30]%list.
+Example sum_v0_v1_v2_v3 : unIdent (adderTree4 [v0_3]%list) = [N2Bv_sized 8 30]%list.
 Proof. reflexivity. Qed.
 
 Definition adder_tree_Interface name nrInputs bitSize
@@ -112,8 +112,7 @@ Definition adder_tree4_8_tb_inputs
      ].
 
 Definition adder_tree4_8_tb_expected_outputs
-  := map (fun i => List.hd (Vector.const false _) (combinational (adderTree4 [i]%list)))
-         adder_tree4_8_tb_inputs.
+  := multistep (Comb adderTree4) adder_tree4_8_tb_inputs.
 
 Definition adder_tree4_8_tb :=
   testBench "adder_tree4_8_tb" adder_tree4_8Interface
@@ -141,8 +140,7 @@ Definition adder_tree64_8_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_8_tb_expected_outputs
-  := map (fun i => List.hd (Vector.const false _)
-                        (combinational (adderTree 5 [i]%list))) adder_tree64_8_tb_inputs.
+  := multistep (Comb (adderTree 5)) adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "adder_tree64_8_tb" adder_tree64_8Interface
@@ -161,8 +159,7 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := map (fun i => List.hd (Vector.const false _)
-                        (combinational (adderTree 5 [i]%list))) adder_tree64_128_tb_inputs.
+  := multistep (Comb (adderTree 5)) adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "adder_tree64_128_tb" adder_tree64_128Interface

--- a/acorn-examples/Examples.v
+++ b/acorn-examples/Examples.v
@@ -17,19 +17,19 @@
 (* Experiments with the primitives that form the core of Cava. *)
 
 Require Import Coq.Lists.List.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Import ListNotations.
 
 (* Experiments with the primitive Cava gates. *)
 
-Example inv_false : combinational (inv [false]) = [true].
+Example inv_false : unIdent (inv false) = true.
 Proof. reflexivity. Qed.
 
-Example inv_true  : combinational (inv [true]) = [false].
+Example inv_true  : unIdent (inv true) = false.
 Proof. reflexivity. Qed.
 
-Example and_00 : combinational (and2 ([false], [false])) = [false].
+Example and_00 : unIdent (and2 (false, false)) = false.
 Proof. reflexivity. Qed.
 
-Example and_11 : combinational (and2 ([true], [true])) = [true].
+Example and_11 : unIdent (and2 (true, true)) = true.
 Proof. reflexivity. Qed.

--- a/acorn-examples/FullAdderExample.v
+++ b/acorn-examples/FullAdderExample.v
@@ -21,9 +21,11 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.FullAdder.
 Require Import Cava.Acorn.XilinxAdder.
+
+Existing Instance CavaCombinationalNet.
 
 Section WithCava.
   Context {signal} `{Cava signal}.
@@ -32,7 +34,7 @@ Section WithCava.
   (* Build a full-adder that takes a flat-tuple for netlist generation.       *)
   (****************************************************************************)
 
-  Definition fullAdderTop '(cin, a, b) := fullAdder (cin, (a, b)).  
+  Definition fullAdderTop '(cin, a, b) := fullAdder (cin, (a, b)).
 
 End WithCava.
 
@@ -46,7 +48,7 @@ Definition halfAdderNetlist := makeNetlist halfAdderInterface halfAdder.
 
 (* A proof that the half-adder is correct. *)
 Lemma halfAdder_behaviour : forall (a : bool) (b : bool),
-                            combinational (halfAdder ([a], [b])) = ([xorb a b], [a && b]).
+                            unIdent (halfAdder (a, b)) = (xorb a b, a && b).
 
 Proof.
   auto.
@@ -71,11 +73,8 @@ Definition fullAdder_tb_inputs :=
    (true,  true,  true)
 ].
 
-Definition fullAdder_tb_expected_outputs
-  := map (fun '(i0,i1,i2) =>
-            let '(r1, r2) := combinational (fullAdderTop ([i0],[i1],[i2])%list) in
-            (List.hd (defaultCombValue _) r1, List.hd (defaultCombValue _) r2))
-         fullAdder_tb_inputs.
+Definition fullAdder_tb_expected_outputs :=
+  multistep (Comb fullAdderTop) fullAdder_tb_inputs.
 
 Definition fullAdder_tb
   := testBench "fullAdder_tb" fullAdderInterface
@@ -83,12 +82,11 @@ Definition fullAdder_tb
 
 (* A proof that the the full-adder is correct. *)
 Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
-                            combinational (fullAdderTop ([cin], [a], [b]))
-                              = ([xorb cin (xorb a b)],
-                                 [(a && b) || (b && cin) || (a && cin)]).
+                            unIdent (fullAdderTop (cin, a, b))
+                              = (xorb cin (xorb a b),
+                                 (a && b) || (b && cin) || (a && cin)).
 Proof.
   intros.
-  unfold combinational.
   unfold fst.
   simpl.
   case a, b, cin.
@@ -97,11 +95,10 @@ Qed.
 
 (* Prove the generic full adder is equivalent to Xilinx fast adder. *)
 Lemma generic_vs_xilinx_adder : forall (a : bool) (b : bool) (cin : bool),
-                                combinational (fullAdderTop ([cin], [a], [b])) =
-                                combinational (xilinxFullAdder ([cin], ([a], [b]))).
+                                unIdent (fullAdderTop (cin, a, b)) =
+                                unIdent (xilinxFullAdder (cin, (a, b))).
 Proof.
-  intros.
-  unfold combinational. simpl.
+  intros. simpl.
   case a, b, cin.
   all : reflexivity.
 Qed.

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -20,9 +20,9 @@ Require Import Coq.NArith.NArith.
 Require Import Coq.Vectors.Vector.
 Require Import coqutil.Tactics.Tactics.
 Require Import ExtLib.Structures.Monad.
-Require Import Cava.Acorn.Acorn.
-Require Import Cava.Acorn.CombinationalProperties.
-Require Import Cava.Acorn.Identity.
+Require Import Cava.Acorn.AcornNew.
+Require Import Cava.Acorn.CombinationalPropertiesNew.
+Require Import Cava.Acorn.IdentityNew.
 Require Import Cava.BitArithmetic.
 Require Import Cava.NatUtils.
 Require Import Cava.Tactics.
@@ -103,125 +103,69 @@ Section Proofs.
   Existing Instance CombinationalSemantics.
 
   Lemma half_adder_correct (x y : combType Bit) :
-    combinational (half_adder ([x],[y]))
-    = ([xorb x y], [andb x y]).
+    unIdent (half_adder (x,y)) = (xorb x y, andb x y).
   Proof.
-    cbv [half_adder combinational and2 xor2 CombinationalSemantics].
-    cbv [lift2]. rewrite pad_combine_eq by reflexivity.
-    repeat destruct_pair_let. simpl_ident.
-    reflexivity.
+    cbv [half_adder and2 xor2 CombinationalSemantics].
+    simpl_ident. reflexivity.
   Qed.
   Hint Rewrite half_adder_correct using solve [eauto] : simpl_ident.
 
   Lemma incr4_correct (input : combType (Vec Bit 4)) :
-    combinational (incr4 [input]) = [N2Bv_sized 4 (Bv2N input + 1)].
+    unIdent (incr4 input) = N2Bv_sized 4 (Bv2N input + 1).
   Proof.
-    cbv [incr4 combinational]. simpl_ident. boolsimpl.
+    cbv [incr4]. simpl_ident. boolsimpl.
     cbn [unpeel indexConst CombinationalSemantics].
     cbn [combType] in input. constant_bitvec_cases input.
     all:reflexivity.
   Qed.
 
   Lemma half_subtractor_correct (x y : combType Bit) :
-    combinational (half_subtractor ([x],[y]))
-    = ([xorb x y], [andb (negb x) y]).
+    unIdent (half_subtractor (x,y)) = (xorb x y, andb (negb x) y).
   Proof.
-    cbv [half_subtractor combinational and2 xor2 CombinationalSemantics].
-    cbv [lift2]. rewrite pad_combine_eq by reflexivity.
-    repeat destruct_pair_let. simpl_ident.
-    reflexivity.
+    cbv [half_subtractor and2 xor2 CombinationalSemantics].
+    simpl_ident; reflexivity.
   Qed.
   Hint Rewrite half_subtractor_correct using solve [eauto] : simpl_ident.
 
   Lemma decr4_correct (input : combType (Vec Bit 4)) :
-    combinational (decr4 [input]) = [N2Bv_sized 4 (if (Bv2N input =? 0)%N then 15
-                                                   else Bv2N input - 1)].
+    unIdent (decr4 input) = N2Bv_sized 4 (if (Bv2N input =? 0)%N then 15
+                                          else Bv2N input - 1).
   Proof.
-    cbv [decr4 combinational]. simpl_ident. boolsimpl.
-    cbn [unpeel indexConst CombinationalSemantics].
+    cbv [decr4]. simpl_ident. boolsimpl.
     cbn [combType] in input. constant_bitvec_cases input.
     all:reflexivity.
   Qed.
 
   Lemma incr'_correct {sz} carry (input : combType (Vec Bit sz)) :
-    combinational (incr' [carry] [input])
-    = [N2Bv_sized _ (Bv2N input + if carry then 1 else 0)%N].
+    unIdent (incr' carry input)
+    = N2Bv_sized _ (Bv2N input + if carry then 1 else 0)%N.
   Proof.
-    cbv [combinational].
     revert carry input; induction sz; intros; [ cbn; f_equal; solve [apply nil_eq] | ].
-    cbn [incr']. simpl_ident. cbn [unpeel peel CombinationalSemantics].
+    cbn [incr']. simpl_ident.
     rewrite (eta input). autorewrite with vsimpl. repeat destruct_pair_let.
-    cbn [unIdent combType]. rewrite (peelVecList_cons_cons (A:=Bit)).
-    autorewrite with vsimpl. rewrite half_adder_correct. cbn [fst snd].
-    (* Prove sz=0 case immediately to get sz <> 0 precondition *)
-    destruct (PeanoNat.Nat.eq_dec sz 0);
-      [ subst; eapply case0 with (v:=Vector.tl input);
-        cbn; repeat destruct_one_match; reflexivity | ].
-    rewrite unpeel_peel by auto.
-    rewrite IHsz; clear IHsz.
-    erewrite (unpeelVecList_cons_singleton (A:=Bit))
-      by lazymatch goal with
-         | |- unpeelVecList (peelVecList _) = _ => rewrite unpeel_peel by auto; reflexivity
-         | |- forall l, InV l (peelVecList _) -> length l = _ =>
-           intros * Hin; apply peelVecList_length in Hin;
-             cbn [length] in *; solve [auto]
-         | _ => solve [auto]
-         end.
-    destruct carry, (Vector.hd input);
-      boolsimpl; rewrite ?N.add_0_r, ?N2Bv_sized_Bv2N;
-        try reflexivity; [ | ].
-    (* TODO(jadep) : improve this proof *)
-    { f_equal. apply Bv2N_inj; autorewrite with push_Bv2N.
-      compute_expr (N.of_nat 1). rewrite !Bv2N_N2Bv_sized_modulo.
-      rewrite !N.double_spec, !N.succ_double_spec.
-      rewrite Nat2N.inj_succ. rewrite N.pow_succ_r by lia.
-      rewrite N.mod_mul_r by (try apply N.pow_nonzero; lia).
-      lazymatch goal with
-      | |- context [(2 * ?n + 1 + 1)%N] =>
-        replace (2 * n + 1 + 1)%N with ((n + 1) * 2)%N by lia
-      end.
-      rewrite N.div_mul, N.mod_mul by lia.
-      lia. }
-    { f_equal. autorewrite with push_Bv2N.
-      rewrite N.double_succ_double.
-      autorewrite with push_N2Bv_sized.
-      rewrite N2Bv_sized_Bv2N.
-      reflexivity. }
+    rewrite IHsz. rewrite Bv2N_cons.
+    destruct carry, (hd input); boolsimpl;
+      rewrite ?N.add_0_r, ?N.double_succ_double, ?N.succ_double_succ;
+      rewrite ?N2Bv_sized_double, ?N2Bv_sized_succ_double;
+      reflexivity.
   Qed.
 
   Lemma incr_correct {sz} (input : combType (Vec Bit sz)) :
-    combinational (incr [input]) = [N2Bv_sized _ (Bv2N input + 1)].
+    unIdent (incr input) = N2Bv_sized _ (Bv2N input + 1).
   Proof. cbv [incr]. simpl_ident. apply incr'_correct. Qed.
 
   Lemma decr'_correct {sz} borrow (input : combType (Vec Bit sz)) :
-    combinational (decr' [borrow] [input])
-    = [N2Bv_sized _ (if borrow
-                     then if (Bv2N input =? 0)%N
-                          then N.ones (N.of_nat sz)
-                          else N.pred (Bv2N input)
-                     else Bv2N input)].
+    unIdent (decr' borrow input)
+    = N2Bv_sized _ (if borrow
+                    then if (Bv2N input =? 0)%N
+                         then N.ones (N.of_nat sz)
+                         else N.pred (Bv2N input)
+                    else Bv2N input).
   Proof.
-    cbv [combinational].
     revert borrow input; induction sz; intros; [ cbn; f_equal; solve [apply nil_eq] | ].
-    cbn [decr']. simpl_ident. cbn [unpeel peel CombinationalSemantics].
+    cbn [decr']. simpl_ident.
     rewrite (eta input). autorewrite with vsimpl. repeat destruct_pair_let.
-    cbn [unIdent combType]. rewrite (peelVecList_cons_cons (A:=Bit)).
-    autorewrite with vsimpl. rewrite half_subtractor_correct. cbn [fst snd].
-    (* Prove sz=0 case immediately to get sz <> 0 precondition *)
-    destruct (PeanoNat.Nat.eq_dec sz 0);
-      [ subst; eapply case0 with (v:=Vector.tl input);
-        cbn; repeat destruct_one_match; repeat destruct_one_match_hyp;
-        try reflexivity; congruence | ].
-    rewrite unpeel_peel by auto.
-    rewrite IHsz; clear IHsz. autorewrite with push_Bv2N.
-    erewrite (unpeelVecList_cons_singleton (A:=Bit))
-      by lazymatch goal with
-         | |- unpeelVecList (peelVecList _) = _ => rewrite unpeel_peel by auto; reflexivity
-         | |- forall l, InV l (peelVecList _) -> length l = _ =>
-           intros * Hin; apply peelVecList_length in Hin;
-             cbn [length] in *; solve [auto]
-         | _ => solve [auto]
-         end.
+    rewrite IHsz. rewrite Bv2N_cons.
     destruct borrow, (Vector.hd input); boolsimpl;
       autorewrite with push_Bv2N push_N2Bv_sized;
       rewrite ?N.sub_0_r, ?N2Bv_sized_Bv2N;
@@ -248,15 +192,12 @@ Section Proofs.
   Qed.
 
   Lemma decr_correct {sz} (input : combType (Vec Bit sz)) :
-    combinational (decr [input])
-    = [N2Bv_sized _ ( if (Bv2N input =? 0)%N
-                      then 2 ^ (N.of_nat sz) - 1
-                      else Bv2N input - 1)%N].
+    unIdent (decr input)
+    = N2Bv_sized _ ( if (Bv2N input =? 0)%N
+                     then 2 ^ (N.of_nat sz) - 1
+                     else Bv2N input - 1)%N.
   Proof.
-    cbv [decr]. unfold one. unfold constant. simpl.
-  Admitted.
-  (* rewrite decr'_correct.
+    cbv [decr]. rewrite decr'_correct.
     rewrite N.ones_equiv, !N.pred_sub. reflexivity.
-  Qed. *)
-  
+  Qed.
 End Proofs.

--- a/acorn-examples/NandGate.v
+++ b/acorn-examples/NandGate.v
@@ -24,15 +24,15 @@ Export MonadNotation.
 Open Scope monad_scope.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.
 Local Open Scope string_scope.
+Existing Instance CavaCombinationalNet.
 
 Section WithCava.
-  Context {signal} {combsemantics : Cava signal}
-          {seqsemantics: CavaSeq combsemantics}.
+  Context `{semantics:Cava}.
 
   (* NAND gate example. First, let's define an overloaded NAND gate
      description. *)
@@ -56,22 +56,22 @@ Definition nand2Netlist := makeNetlist nand2Interface nand2_gate.
 
 (* A proof that the NAND gate implementation is correct. *)
 Lemma nand2_behaviour : forall (a : bool) (b : bool),
-                        combinational (nand2_gate ([a], [b])) = [negb (a && b)].
+                        unIdent (nand2_gate (a, b)) = negb (a && b).
 Proof.
   auto.
 Qed.
 
 (* An exhuastive proof by analyzing all four cases. *)
-Example nand_00 : combinational (nand2_gate ([false], [false])) = [true].
+Example nand_00 : unIdent (nand2_gate (false, false)) = true.
 Proof. reflexivity. Qed.
 
-Example nand_01 : combinational (nand2_gate ([false], [true])) = [true].
+Example nand_01 : unIdent (nand2_gate (false, true)) = true.
 Proof. reflexivity. Qed.
 
-Example nand_10 : combinational (nand2_gate ([true], [false])) = [true].
+Example nand_10 : unIdent (nand2_gate (true, false)) = true.
 Proof. reflexivity. Qed.
 
-Example nand_11 : combinational (nand2_gate ([true], [true])) = [false].
+Example nand_11 : unIdent (nand2_gate (true, true)) = false.
 Proof. reflexivity. Qed.
 
 (* Test bench tables for generated SystemVerilog simulation test bench *)
@@ -80,7 +80,7 @@ Definition nand_tb_inputs : list (bool * bool) :=
 
 (* Compute expected outputs. *)
 Definition nand_tb_expected_outputs : list bool :=
-  map (fun '(i0,i1) => List.hd false (combinational (nand2_gate ([i0], [i1])%list))) nand_tb_inputs.
+  multistep (Comb nand2_gate) nand_tb_inputs.
 
 Definition nand2_tb :=
   testBench "nand2_tb" nand2Interface nand_tb_inputs nand_tb_expected_outputs.

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -23,7 +23,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.UnsignedAdders.
 
 (******************************************************************************)
@@ -46,11 +46,11 @@ Definition bv5_30 := N2Bv_sized 5 30.
 (******************************************************************************)
 
 (* Check 0 + 0 = 0 *)
-Example add0_0 : combinational (addN ([bv4_0], [bv4_0])) = [bv4_0].
+Example add0_0 : unIdent (addN ([bv4_0], [bv4_0])) = [bv4_0].
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 0 *)
-Example add15_1 : combinational (addN ([bv4_15], [bv4_1])) = [bv4_0].
+Example add15_1 : unIdent (addN ([bv4_15], [bv4_1])) = [bv4_0].
 Proof. reflexivity. Qed.
 
 Section WithCava.
@@ -81,19 +81,19 @@ Section WithCava.
 End WithCava.
 
 (* Check 0 + 0 = 0 *)
-Example add5_0_0 : combinational (adderGrowth ([bv4_0], [bv4_0])) = [bv5_0].
+Example add5_0_0 : unIdent (adderGrowth ([bv4_0], [bv4_0])) = [bv5_0].
 Proof. reflexivity. Qed.
 
 (* Check 1 + 2 = 3 *)
-Example add5_1_2 : combinational (adderGrowth ([bv4_1], [bv4_2])) = [bv5_3].
+Example add5_1_2 : unIdent (adderGrowth ([bv4_1], [bv4_2])) = [bv5_3].
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 16 *)
-Example add5_15_1 : combinational (adderGrowth ([bv4_15], [bv4_1])) = [bv5_16].
+Example add5_15_1 : unIdent (adderGrowth ([bv4_15], [bv4_1])) = [bv5_16].
 Proof. reflexivity. Qed.
 
 (* Check 15 + 15 = 30 *)
-Example add5_15_15 : combinational (adderGrowth ([bv4_15], [bv4_15])) = [bv5_30].
+Example add5_15_15 : unIdent (adderGrowth ([bv4_15], [bv4_15])) = [bv5_30].
 Proof. reflexivity. Qed.
 
 (******************************************************************************)
@@ -101,6 +101,7 @@ Proof. reflexivity. Qed.
 (******************************************************************************)
 
 Local Open Scope nat_scope.
+Existing Instance CavaCombinationalNet.
 
 Definition adder4Interface
   := combinationalInterface "adder4"
@@ -117,7 +118,7 @@ Definition adder4_tb_inputs
 Definition adder4_tb_inputs' := fromListOfTuples [Vec Bit 4; Vec Bit 4] adder4_tb_inputs.  
 
 Definition adder4_tb_expected_outputs
-  := combinational (unsignedAddCircuit adder4_tb_inputs').
+  := unIdent (unsignedAddCircuit adder4_tb_inputs').
 
 Definition adder4_tb
   := testBench "adder4_tb" adder4Interface
@@ -144,7 +145,7 @@ Definition adder8_3input_tb_inputs :=
 
 Definition adder8_3input_tb_expected_outputs :=
   map (fun '(i0,i1,i2) => List.hd (defaultCombValue _)
-                               (combinational (add3InputTuple 8 8 8 ([i0],[i1],[i2])%list)))
+                               (unIdent (add3InputTuple 8 8 8 ([i0],[i1],[i2])%list)))
       adder8_3input_tb_inputs.
 
 Definition adder8_3input_tb :=

--- a/cava/Cava/Lib/FullAdder.v
+++ b/cava/Cava/Lib/FullAdder.v
@@ -23,10 +23,10 @@ Open Scope monad_scope.
 Open Scope type_scope.
 
 Require Import Cava.ListUtils.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 
 Section WithCava.
-  Context {signal} `{Cava signal}.
+  Context `{semantics:Cava}.
 
   (****************************************************************************)
   (* Build a half-adder                                                       *)
@@ -40,7 +40,7 @@ Section WithCava.
   (****************************************************************************)
   (* Build a full-adder                                                       *)
   (****************************************************************************)
-  
+
   Definition fullAdder '(cin, (a, b))
                        : cava (signal Bit * signal Bit) :=
     '(abl, abh) <- halfAdder (a, b) ;;
@@ -49,25 +49,24 @@ Section WithCava.
     ret (abcl, cout).
 
  End WithCava.
- 
+
 Section Combinational.
 
   (* A proof that the half-adder is correct. *)
   Lemma halfAdder_behaviour :
     forall (a : bool) (b : bool),
-      unIdent (halfAdder ([a], [b])) = ([xorb a b], [a && b]).
+      unIdent (halfAdder (a, b)) = (xorb a b, a && b).
   Proof.
     auto.
   Qed.
 
   (* A proof that the the full-adder is correct. *)
   Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
-                              combinational (fullAdder ([cin], ([a], [b])))
-                                = ([xorb cin (xorb a b)],
-                                  [(a && b) || (b && cin) || (a && cin)]).
+                              unIdent (fullAdder (cin, (a, b)))
+                                = (xorb cin (xorb a b),
+                                  (a && b) || (b && cin) || (a && cin)).
   Proof.
     intros.
-    unfold combinational.
     unfold fst.
     simpl.
     case a, b, cin.

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -25,7 +25,7 @@ Open Scope monad_scope.
 Open Scope type_scope.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.FullAdder.
 
 Local Open Scope vector_scope.

--- a/cava/Cava/NatUtils.v
+++ b/cava/Cava/NatUtils.v
@@ -79,6 +79,11 @@ Module N.
     rewrite !N.double_spec, !N.succ_double_spec. reflexivity.
   Qed.
 
+  Lemma succ_double_succ n : (N.succ_double n + 1 = N.double (n + 1))%N.
+  Proof.
+    rewrite !N.double_spec, !N.succ_double_spec. lia.
+  Qed.
+
   Lemma succ_double_double_neq n m : N.succ_double n <> N.double m.
   Proof.
     rewrite N.double_spec, N.succ_double_spec. nia.

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -21,8 +21,9 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.UnsignedAdders.
+Import Circuit.Notations.
 
 (******************************************************************************)
 (* Add with delay                                                             *)
@@ -64,11 +65,10 @@ s   :  0 0 14  7 17 1
 *)
 
 Section WithCava.
-  Context {signal} {combsemantics: Cava signal}
-          {semantics: CavaSeq combsemantics}.
+  Context {signal} {semantics: Cava signal}.
 
-  Definition addWithDelay : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
-    := loopDelayS (addN >=> delay).
+  Definition addWithDelay : Circuit (signal (Vec Bit 8)) (signal (Vec Bit 8))
+    := Loop (Comb addN >==> Delay >==> Comb fork2).
 
 End WithCava.
 
@@ -78,11 +78,11 @@ Local Notation "'#' l" := (map (fun i => N2Bv_sized 8 (N.of_nat i)) l)
 
 Local Open Scope list_scope.
 
-Example addWithDelay_ex1: sequential (addWithDelay (# [0;1;2;3;4;5;6;7;8])) = # [0;0;1;2;4;6;9;12;16;20].
+Example addWithDelay_ex1: multistep addWithDelay (# [0;1;2;3;4;5;6;7;8]) = # [0;0;1;2;4;6;9;12;16].
 Proof. reflexivity. Qed.
 
-Example addWithDelay_ex2: sequential (addWithDelay (# [1;1;1;1;1;1;1;1;1])) = # [0;1;1;2;2;3;3;4;4;5].
+Example addWithDelay_ex2: multistep addWithDelay (# [1;1;1;1;1;1;1;1;1]) = # [0;1;1;2;2;3;3;4;4].
 Proof. reflexivity. Qed.
 
-Example addWithDelay_ex3: sequential (addWithDelay (# [14; 7; 3; 250])) = # [0; 14; 7; 17; 1].
+Example addWithDelay_ex3: multistep addWithDelay (# [14; 7; 3; 250]) = # [0; 14; 7; 17].
 Proof. reflexivity. Qed.

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -27,10 +27,11 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Cava.
 Require Import Cava.ListUtils.
 Require Import Cava.Tactics.
-Require Import Cava.Acorn.Acorn.
-Require Import Cava.Acorn.Identity.
-Require Import Cava.Acorn.SequentialProperties.
+Require Import Cava.Acorn.AcornNew.
+Require Import Cava.Acorn.IdentityNew.
+Require Import Cava.Acorn.CombinationalPropertiesNew.
 Require Import Cava.Lib.UnsignedAdders.
+Import Circuit.Notations.
 
 Require Import Tests.AddWithDelay.AddWithDelay.
 Local Open Scope nat_scope.
@@ -53,22 +54,23 @@ Definition addWithDelaySpecF
       bvadd (input (S t')) (out t')
     end.
 
-Definition addNSpec {n} (a b : seqType (Vec Bit n)) :=
-  map2 bvadd a b.
-
-Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (semantics:=CombinationalSemantics) (a, b)) = addNSpec a b.
+Lemma addNCorrect n (a b : combType (Vec Bit n)) :
+  unIdent (addN (a, b)) = bvadd a b.
 Admitted.
-Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
+Hint Rewrite addNCorrect using solve [eauto] : simpl_ident.
 
 Lemma addWithDelayStepCorrect :
-  forall (i : Bvector 8) (s : Bvector 8),
-    sequential ((addN >=> delay >=> fork2) ([i], [s]))
-    = ([bvzero; bvadd i s], [bvzero; bvadd i s]).
+  forall (i s : Bvector 8) (st : circuit_state _),
+    step (Comb addN >==> Delay >==> Comb fork2)
+         st
+         (i, s)
+    = (snd (snd (fst st)), snd (snd (fst st)),
+       (tt, (tt, bvadd i s), tt)).
 Proof.
-  intros. seqsimpl. reflexivity.
+  intros. cbv [mcompose step Delay].
+  repeat first [ destruct_pair_let | progress simpl_ident ].
+  reflexivity.
 Qed.
-Hint Rewrite addWithDelayStepCorrect using solve [eauto] : seqsimpl.
 
 Lemma Bv2N_bvzero n : Bv2N (@bvzero n) = 0%N.
 Proof.
@@ -86,33 +88,42 @@ Proof.
 Qed.
 
 Lemma addWithDelayCorrect (i : list (Bvector 8)) :
-  sequential (addWithDelay i) = map (fun t => addWithDelaySpecF (fun n => nth n i bvzero) t)
-                                    (seq 0 (if length i =? 0 then 0 else S (length i))).
+  multistep addWithDelay i = map (fun t => addWithDelaySpecF (fun n => nth n i bvzero) t)
+                                 (seq 0 (length i)).
 Proof.
   intros; cbv [addWithDelay].
-  eapply (loopDelayS_invariant_alt (B:=Vec Bit 8))
-    with (I:=fun t acc =>
-               0 < t /\
-               acc = map (fun t => addWithDelaySpecF
-                                  (fun n => nth n i bvzero) t)
-                         (seq 0  (S t))).
+  eapply multistep_Loop_invariant
+    with (body:=(Comb addN >==> Delay >==> Comb fork2))
+         (I := fun t st body_st acc =>
+                 st = match t with
+                      | 0 => bvzero
+                      | S t => addWithDelaySpecF (fun n => nth n i bvzero) t
+                      end
+                 /\ body_st = (tt, (tt, addWithDelaySpecF (fun n => nth n i bvzero) t), tt)
+                 /\ acc = map (fun t => addWithDelaySpecF
+                                      (fun n => nth n i bvzero) t)
+                             (seq 0 t)).
   { (* invariant is satisfied at start *)
-    destruct i; [ reflexivity | ]. split; [ lia | ].
-    seqsimpl. autorewrite with natsimpl.
-    cbn [nth map seq addWithDelaySpecF].
-    change (Signal.defaultCombValue (Vec Bit 8)) with (@bvzero 8).
-    cbv [addNSpec map2]. rewrite bvadd_bvzero_l; reflexivity. }
+    ssplit; reflexivity. }
   { (* invariant holds through loop *)
-    cbv zeta; intros *; intros [? ?].
-    intros;  subst; seqsimpl. split; [ lia | ].
-    autorewrite with pull_snoc.
-    rewrite !overlap_snoc_cons by length_hammer.
-    destruct t; [ lia | ].
-    autorewrite with push_nth push_length natsimpl push_length pull_snoc.
-    cbn [addWithDelaySpecF]. rewrite <-!app_assoc. cbn [app].
-    cbn [addNSpec map2]. reflexivity. }
+    cbv zeta; intros; logical_simplify. subst.
+    cbn [step mcompose Delay fst snd].
+    repeat first [ destruct_pair_let | progress simpl_ident ].
+    destruct t.
+    { destruct i; cbn [length] in *; [length_hammer | ].
+      ssplit; try reflexivity; [ ].
+      cbn [nth]. rewrite bvadd_bvzero_l.
+      reflexivity. }
+    { (* change default to bvzero *)
+      match goal with |- context [nth _ _ ?x] =>
+                      is_var x;
+                      rewrite nth_inbounds_change_default
+                        with (d1:=x) (d2:=bvzero)
+                        by length_hammer
+      end.
+      ssplit; try reflexivity; [ ].
+      autorewrite with pull_snoc natsimpl. reflexivity. } }
   { (* invariant implies postcondition *)
-    intros *; intros [? ?]; subst.
-    destruct i; autorewrite with push_length in *; [ lia | ].
+    intros; logical_simplify; subst.
     reflexivity. }
 Qed.

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -24,16 +24,17 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.AcornNew.
 Require Import Cava.Lib.UnsignedAdders.
 Require Import Coq.Vectors.Vector.
 Require Import Cava.VectorUtils.
 Require Import Coq.Bool.Bvector.
 
 From Coq Require Import Bool.Bvector.
+Existing Instance CavaCombinationalNet.
 
 Section WithCava.
-  Context `{CavaSeq}.
+  Context `{Cava}.
 
   Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : signal (Vec Bit n) :=
     unpeel (Vector.map constant lut).
@@ -78,9 +79,9 @@ Definition multiDimArrayTest_Netlist := makeNetlist multiDimArrayTest_Interface 
 Definition arrayTest_tb_inputs := List.repeat (nat_to_bitvec_sized 8 0) 2.
 
 Definition arrayTest_tb_expected_outputs
-  := sequential (arrayTest arrayTest_tb_inputs).
+  := multistep (Comb arrayTest) arrayTest_tb_inputs.
 Definition multiDimArrayTest_tb_expected_outputs
-  := sequential (multiDimArrayTest arrayTest_tb_inputs).
+  := multistep (Comb multiDimArrayTest) arrayTest_tb_inputs.
 
 Definition arrayTest_tb
   := testBench "arrayTest_tb" arrayTest_Interface

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -34,7 +34,7 @@ From Coq Require Import Bool.Bvector.
 (******************************************************************************)
 
 Section WithCava.
-  Context `{CavaSeq}.
+  Context `{Cava}.
 
   Definition delayByte : Circuit (signal (Vec Bit 8)) (signal (Vec Bit 8)) :=
     Delay.


### PR DESCRIPTION
Resolves #565 

There might still be some small cleanup to do, but all the proofs and large examples are now ported to `Circuit`. Once #589 is merged, we're clear to start #567.