### PR TITLE
Remove pairs from SignalType

### DIFF
--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -52,9 +52,6 @@ Class Cava (signal : SignalType -> Type) := {
          signal Bit * signal Bit * signal Bit * signal Bit * signal Bit * signal Bit -> cava (signal Bit); (* 6-input LUT *)
   xorcy : signal Bit * signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
   muxcy : signal Bit -> signal  Bit -> signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
-  (* Converting to/from pairs *)
-  mkpair : forall {t1 t2 : SignalType}, signal t1 -> signal t2 -> signal (Pair t1 t2);
-  unpair : forall {t1 t2 : SignalType}, signal (Pair t1 t2) -> signal t1 * signal t2;
   (* Converting to/from Vector.t *)
   peel : forall {t : SignalType} {s : nat}, signal (Vec t s) -> Vector.t (signal t) s;
   unpeel : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> signal (Vec t s);

--- a/cava/Cava/Acorn/CavaPrelude.v
+++ b/cava/Cava/Acorn/CavaPrelude.v
@@ -48,11 +48,4 @@ Section WithCava.
     let (a, b) := ab in
     localSignal (indexAt (unpeel [a; b]) (unpeel [sel])).
 
-  (* A variant of muxPair that works over a Cava pair. *)
-  Definition pairSel {A : SignalType}
-                     (sel : signal Bit)
-                     (ab : signal (Pair A A)) : signal A :=
-  let (a, b) := unpair ab in
-  indexAt (unpeel [a; b]) (unpeel [sel]).
-
 End WithCava.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -61,8 +61,6 @@ Instance CombinationalSemantics : Cava combType :=
     lut6 := fun f '(a,b,c,d,e,g) => ret (f a b c d e g);
     xorcy := fun '(x,y) => ret (xorb x y);
     muxcy := fun sel x y => ret (if sel then x else y);
-    unpair _ _ v := v;
-    mkpair _ _ v1 v2 := (v1, v2);
     peel _ _ v := v;
     unpeel _ _ v := v;
     indexAt t sz isz := fun v sel => nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v;

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -44,9 +44,6 @@ Section DecidableEquality.
     | Void => fun _ _ => true
     | Bit => fun x y => Bool.eqb x y
     | Vec A n => fun x y => Vector.eqb _ combType_eqb x y
-    | Pair A B => fun x y =>
-                   (combType_eqb (fst x) (fst y) &&
-                    combType_eqb (snd x) (snd y))%bool
     | ExternalType s => fun x y => true
     end.
 
@@ -62,11 +59,7 @@ Section DecidableEquality.
              | _ => tauto
              | _ => solve [eauto using VectorEq.eqb_eq]
              | |- _ <-> _ => split; congruence
-             end; [ ].
-    (* only the pair case should be remaining *)
-    rewrite Bool.andb_true_iff, IHt1, IHt2.
-    split; [ destruct 1 | inversion 1; split ];
-      intros; subst; eauto.
+             end.
   Qed.
 End DecidableEquality.
 
@@ -107,7 +100,7 @@ Lemma eqb_correct {t} (x y : combType t) :
 Proof.
   revert x y.
   induction t;
-    cbn [eqb and2 xnor2 one unpair
+    cbn [eqb and2 xnor2 one
              CombinationalSemantics] in *;
     intros; simpl_ident; repeat destruct_pair_let;
     (* handle easy cases first *)
@@ -122,11 +115,6 @@ Proof.
     simpl_ident. cbn [combType_eqb].
     rewrite eqb_fold. apply f_equal.
     auto using map2_ext. }
-  { (* Pair case *)
-    simpl_ident. cbn [split]. repeat destruct_pair_let.
-    cbn [fst snd]. rewrite IHt1, IHt2.
-    cbn [combType_eqb].
-    reflexivity. }
 Qed.
 
 Lemma eqb_eq {t} (x y : combType t) :
@@ -171,7 +159,7 @@ Proof. destruct sel; reflexivity. Qed.
 Hint Rewrite @indexAt2_correct using solve [eauto] : simpl_ident.
 
 Lemma mux4_correct {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
-  mux4Tuple (i0,i1,i2,i3) sel =
+  mux4 (i0,i1,i2,i3) sel =
   if Vector.hd (Vector.tl sel)
   then if Vector.hd sel then i3 else i2
   else if Vector.hd sel then i1 else i0.

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -51,30 +51,7 @@ Section WithCava.
 
   (* Operations over the first or second element of a pair of inputs. *)
 
-  (* Apply a circuit f to the first element of a pair. *)
-  Definition fsT {A B C : SignalType}
-                 (f: signal A -> cava (signal C))
-                 (i: signal (Pair A B)) :
-                 cava (signal (Pair C B)) :=
-    let (a, b) := unpair i in
-    c <- f a ;;
-    ret (mkpair c b).
-
-  (* Apply a circuit f to the second element of a pair. *)
-  Definition snD {A B C : SignalType}
-                 (f: signal B -> cava (signal C))
-                 (i: signal (Pair A B)) :
-                 cava (signal (Pair A C)) :=
-    let (a, b) := unpair i in
-    c <- f b ;;
-    ret (mkpair a c).
-
-  (* A fork that returns a Pair SignalType. *)
-  Definition fork2S {A : SignalType}
-                    (i: signal A) : cava (signal (Pair A A)) :=
-    ret (mkpair i i).
-
-   (* pairLeft takes an input with shape (a, (b, c)) and re-organizes
+  (* pairLeft takes an input with shape (a, (b, c)) and re-organizes
       it as ((a, b), c) *)
    Definition pairLeft {A B C : SignalType}
                        (i : signal A * (signal B * signal C)) :
@@ -89,7 +66,7 @@ Section WithCava.
                        cava (signal A * (signal B * signal C)) :=
    let '((a, b), c) := i in
    ret (a, (b, c)).
- 
+
   (* Use a circuit to zip together two vectors. *)
   Definition zipWith {A B C : SignalType} {n : nat}
            (f : signal A * signal B -> cava (signal C))
@@ -104,8 +81,8 @@ Section WithCava.
   (* A list-based left monadic-fold. *)
   Fixpoint foldLM {m} `{Monad m} {A B : Type}
                   (f : B -> A -> m B)
-                  (input : list A) 
-                  (accum : B) 
+                  (input : list A)
+                  (accum : B)
                   : m B :=
     match input with
     | [] => ret accum
@@ -637,30 +614,12 @@ Section WithCava.
     | Void => fun _ _ => ret one
     | Bit => fun x y => xnor2 (x, y)
     | ExternalType s => fun x y => ret one
-    | Pair a b => fun x y : signal (Pair a b) =>
-                   let '(x1,x2) := unpair x in
-                   let '(y1, y2) := unpair y in
-                   eq1 <- eqb x1 y1 ;;
-                   eq2 <- eqb x2 y2 ;;
-                   and2 (eq1, eq2)
     | Vec a n => fun x y : signal (Vec a n) =>
                   eq_results <- zipWith (fun '(a, b) => eqb a b) x y ;;
                   all eq_results
     end.
 
-  Definition pairAssoc {A B C} (x : signal (Pair (Pair A B) C))
-    : signal (Pair A (Pair B C)) :=
-    let '(ab, c) := unpair x in
-    let '(a, b) := unpair ab in
-    mkpair a (mkpair b c).
-
-  Definition mux4 {t} (input : signal (Pair (Pair (Pair t t) t) t))
-             (sel : signal (Vec Bit 2)) :=
-    let x := pairAssoc input in
-    pairSel (indexConst sel 0) (pairSel (indexConst sel 1) x).
-
-  (* TODO: rename to mux4 once pairs are eliminated *)
-  Definition mux4Tuple {t} (input : signal t * signal t * signal t * signal t)
+  Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
              (sel : signal (Vec Bit 2)) : signal t :=
     let '(i0,i1,i2,i3) := input in
     indexAt (unpeel [i0;i1;i2;i3]%vector) sel.

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -190,12 +190,6 @@ Definition muxcyNet (s ci di : Signal Bit) : state CavaState (Signal Bit) :=
   addInstance (Component "MUXCY" [] [("O", USignal o); ("S", USignal s); ("CI", USignal ci); ("DI", USignal di)]) ;;
   ret o.
 
-Definition unpairNet {t1 t2 : SignalType} (v : Signal (Pair t1 t2)) : Signal t1 * Signal t2 :=
-  (SignalFst v, SignalSnd v).
-
-Definition mkpairNet {t1 t2 : SignalType} (v1 : Signal t1) (v2 : Signal t2) : Signal (Pair t1 t2) :=
-  SignalPair v1 v2.
-
 Definition peelNet {t : SignalType} {s : nat} (v : Signal (Vec t s)) : Vector.t (Signal t) s :=
   Vector.map (IndexConst v) (vseq 0 s).
 
@@ -217,7 +211,6 @@ Fixpoint combToSignal (t : SignalType) (v : combType t) : Signal t :=
                | true => Vcc
                end
   | Vec vt s, v => VecLit (Vector.map (combToSignal vt) v)
-  | Pair ta tb, (a, b) => SignalPair (combToSignal ta a) (combToSignal tb b)
   | ExternalType typ, _ => UninterpretedSignal typ
   end.
 
@@ -264,8 +257,6 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     lut6 := lut6Net;
     xorcy := xorcyNet;
     muxcy := muxcyNet;
-    mkpair := @mkpairNet;
-    unpair := @unpairNet;
     peel := @peelNet;
     unpeel := @unpeelNet;
     indexAt k sz isz := IndexAt;

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -27,7 +27,6 @@ Inductive SignalType :=
   | Void : SignalType                              (* An empty type *)
   | Bit : SignalType                               (* A single wire *)
   | Vec : SignalType -> nat -> SignalType              (* Vectors, possibly nested *)
-  | Pair : SignalType -> SignalType -> SignalType    (* A pair of signals *)
   | ExternalType : string -> SignalType.            (* An uninterpreted type *)
 
 (******************************************************************************)
@@ -39,7 +38,6 @@ Fixpoint combType (t: SignalType) : Type :=
   | Void => unit
   | Bit => bool
   | Vec vt sz => Vector.t (combType vt) sz
-  | Pair lt rt => combType lt * combType rt
   | ExternalType _ => unit (* No semantics for combinational interpretation. *)
   end.
 
@@ -48,7 +46,6 @@ Fixpoint defaultCombValue (t: SignalType) : combType t :=
   | Void => tt
   | Bit => false
   | Vec t2 sz => Vector.const (defaultCombValue t2) sz
-  | Pair t1 t2 => (defaultCombValue t1, defaultCombValue t2)
   | ExternalType _ => tt
   end.
 
@@ -187,14 +184,11 @@ Inductive Signal : SignalType -> Type :=
   | NamedVector: forall t s, string -> Signal (Vec t s)
   | LocalVec: forall t s, N -> Signal (Vec t s)
   | VecLit: forall {t s}, Vector.t (Signal t) s -> Signal (Vec t s)
-  | SignalPair : forall {t1 t2}, Signal t1 -> Signal t2 -> Signal (Pair t1 t2)
   (* Dynamic index *)
   | IndexAt:  forall {t sz isz}, Signal (Vec t sz) ->
               Signal (Vec Bit isz) -> Signal t
   (* Static indexing *)
   | IndexConst: forall {t sz}, Signal (Vec t sz) -> nat -> Signal t
-  | SignalFst : forall {t1 t2}, Signal (Pair t1 t2) -> Signal t1
-  | SignalSnd : forall {t1 t2}, Signal (Pair t1 t2) -> Signal t2
   (* Static slice *)
   | Slice: forall {t sz} (start len: nat), Signal (Vec t sz) ->
                                            Signal (Vec t len)
@@ -219,7 +213,6 @@ Fixpoint defaultNetSignal (t: SignalType) : Signal t :=
   | Void => UndefinedSignal
   | Bit => Gnd
   | Vec vt s => VecLit (Vector.const (defaultNetSignal vt) s)
-  | Pair lt rt => SignalPair (defaultNetSignal lt) (defaultNetSignal rt)
   | ExternalType s => UninterpretedSignal "default-defaultSignal"
   end.
 

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -66,8 +66,8 @@ Section WithCava.
     (* Different rounds perform different operations on the state before adding
        the round key; select the appropriate wire based on add_round_key_in_sel *)
     let add_round_key_in :=
-        mux4Tuple (mix_columns_out, data, shift_rows_out, mix_columns_out)
-                  add_round_key_in_sel in
+        mux4 (mix_columns_out, data, shift_rows_out, mix_columns_out)
+             add_round_key_in_sel in
 
     (* Intermediate decryption rounds need to mix the key columns *)
     mixed_round_key <- inv_mix_columns_key round_key ;;

--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -3,5 +3,9 @@ mix_single_column_equiv
   : forall (is_decrypt : bool) (col : t (t bool 8) 4),
     unIdent (aes_mix_single_column is_decrypt col) =
     (if is_decrypt
-     then Vector.map byte_to_bitvec (MixColumns.inv_mix_single_column (Vector.map bitvec_to_byte col))
-     else Vector.map byte_to_bitvec (MixColumns.mix_single_column (Vector.map bitvec_to_byte col)))
+     then
+      Vector.map byte_to_bitvec
+        (MixColumns.inv_mix_single_column (Vector.map bitvec_to_byte col))
+     else
+      Vector.map byte_to_bitvec
+        (MixColumns.mix_single_column (Vector.map bitvec_to_byte col)))

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -3,5 +3,9 @@ mix_single_column_equiv
   : forall (is_decrypt : bool) (col : t (t bool 8) 4),
     unIdent (aes_mix_single_column is_decrypt col) =
     (if is_decrypt
-     then Vector.map byte_to_bitvec (MixColumns.inv_mix_single_column (Vector.map bitvec_to_byte col))
-     else Vector.map byte_to_bitvec (MixColumns.mix_single_column (Vector.map bitvec_to_byte col)))
+     then
+      Vector.map byte_to_bitvec
+        (MixColumns.inv_mix_single_column (Vector.map bitvec_to_byte col))
+     else
+      Vector.map byte_to_bitvec
+        (MixColumns.mix_single_column (Vector.map bitvec_to_byte col)))


### PR DESCRIPTION
Resolves #416 
Resolves #567 

With the new `Loop` infrastructure, no pairs are needed in `SignalType`! This PR removes them.