### PR TITLE
Update CavaClass to use circuits for indexing and arithmetic

### DIFF
--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -51,19 +51,27 @@ Section WithCava.
   (* increment a 4-bit vector *)
   Definition incr4 (input : signal (Vec Bit 4))
     : cava (signal (Vec Bit 4)) :=
-    '(sum0, carry) <- half_adder (one, indexConst input 0) ;;
-    '(sum1, carry) <- half_adder (carry, indexConst input 1) ;;
-    '(sum2, carry) <- half_adder (carry, indexConst input 2) ;;
-    '(sum3, carry) <- half_adder (carry, indexConst input 3) ;;
+    i0 <- indexConst input 0 ;;
+    i1 <- indexConst input 1 ;;
+    i2 <- indexConst input 2 ;;
+    i3 <- indexConst input 3 ;;
+    '(sum0, carry) <- half_adder (one, i0) ;;
+    '(sum1, carry) <- half_adder (carry, i1) ;;
+    '(sum2, carry) <- half_adder (carry, i2) ;;
+    '(sum3, carry) <- half_adder (carry, i3) ;;
     ret (unpeel [sum0;sum1;sum2;sum3]%vector).
 
   (* decrement a 4-bit vector *)
   Definition decr4 (input : signal (Vec Bit 4))
     : cava (signal (Vec Bit 4)) :=
-    '(diff0, borrow) <- half_subtractor (indexConst input 0, one) ;;
-    '(diff1, borrow) <- half_subtractor (indexConst input 1, borrow) ;;
-    '(diff2, borrow) <- half_subtractor (indexConst input 2, borrow) ;;
-    '(diff3, borrow) <- half_subtractor (indexConst input 3, borrow) ;;
+    i0 <- indexConst input 0 ;;
+    i1 <- indexConst input 1 ;;
+    i2 <- indexConst input 2 ;;
+    i3 <- indexConst input 3 ;;
+    '(diff0, borrow) <- half_subtractor (i0, one) ;;
+    '(diff1, borrow) <- half_subtractor (i1, borrow) ;;
+    '(diff2, borrow) <- half_subtractor (i2, borrow) ;;
+    '(diff3, borrow) <- half_subtractor (i3, borrow) ;;
     ret (unpeel [diff0;diff1;diff2;diff3]%vector).
 
   Fixpoint incr' {sz} (carry : signal Bit)

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -40,14 +40,13 @@ Section WithCava.
 Definition twoSorter {signal} `{Cava signal} {n}
                      (ab:  signal (Vec (Vec Bit n) 2)) :
                      cava (signal (Vec (Vec Bit n) 2)) :=
-   let a := indexConst ab 0 in
-   let b := indexConst ab 1 in
-   let comparison := greaterThanOrEqual (a, b) in
+   a <- indexConst ab 0 ;;
+   b <- indexConst ab 1 ;;
+   comparison <- greaterThanOrEqual (a, b) ;;
    negComparison <- inv comparison ;;
-   let sorted : Vector.t (signal (Vec Bit n)) 2 :=
-     [indexAt ab (unpeel [comparison]);
-      indexAt ab (unpeel [negComparison])] in
-   ret (unpeel sorted).
+   out0 <- indexAt ab (unpeel [comparison]) ;;
+   out1 <- indexAt ab (unpeel [negComparison]) ;;
+   ret (unpeel [out0;out1]).
 
 End WithCava.
 

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -63,7 +63,7 @@ Section WithCava.
   Definition unsignedAddCircuit {m n : nat}
                                 (ab : signal (Vec Bit m) * signal (Vec Bit n))
                                 : cava (signal (Vec Bit (1 + max m n))) :=
-    ret (unsignedAdd (fst ab, snd ab)).
+    unsignedAdd (fst ab, snd ab).
 
   Definition adderGrowth {aSize bSize: nat}
                         (ab: signal (Vec Bit aSize) * signal (Vec Bit bSize)) :

--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -58,24 +58,24 @@ Class Cava (signal : SignalType -> Type) := {
   indexAt : forall {t : SignalType} {sz isz: nat},
             signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
             signal (Vec Bit isz) ->  (* A bit-vector index of size isz bits *)
-            signal t;                (* The indexed value of type signal t *)
+            cava (signal t);                (* The indexed value of type signal t *)
   (* Static indexing *)
   indexConst : forall {t: SignalType} {sz: nat},
                signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
                nat ->                   (* Static index *)
-               signal t;                (* The indexed bit of type signal bit *)
+               cava (signal t);                (* The indexed bit of type signal bit *)
   slice : forall {t: SignalType} {sz: nat} (startAt len: nat),
                  signal (Vec t sz) ->
                  (startAt + len <= sz) ->
-                 signal (Vec t len);
+                 cava (signal (Vec t len));
   (* Synthesizable arithmetic operations. *)
   unsignedAdd : forall {a b : nat}, signal (Vec Bit a) * signal (Vec Bit b) ->
-                signal (Vec Bit (1 + max a b));
+                cava (signal (Vec Bit (1 + max a b)));
   unsignedMult : forall {a b : nat}, signal (Vec Bit a) * signal (Vec Bit b)->
-                signal (Vec Bit (a + b));              
+                cava (signal (Vec Bit (a + b)));
   (* Synthesizable relational operators *)
   greaterThanOrEqual : forall {a b : nat}, signal (Vec Bit a) * signal (Vec Bit b) ->
-                      signal Bit;
+                      cava (signal Bit);
   (* Naming for sharing. *)
   localSignal : forall {t : SignalType}, signal t -> cava (signal t);
   (* Hierarchy *)

--- a/cava/Cava/Acorn/CavaPrelude.v
+++ b/cava/Cava/Acorn/CavaPrelude.v
@@ -46,6 +46,6 @@ Section WithCava.
                      (sel : signal Bit)
                      (ab : signal A * signal A) : cava (signal A) :=
     let (a, b) := ab in
-    localSignal (indexAt (unpeel [a; b]) (unpeel [sel])).
+    indexAt (unpeel [a; b]) (unpeel [sel]).
 
 End WithCava.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -63,12 +63,12 @@ Instance CombinationalSemantics : Cava combType :=
     muxcy := fun sel x y => ret (if sel then x else y);
     peel _ _ v := v;
     unpeel _ _ v := v;
-    indexAt t sz isz := fun v sel => nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v;
-    indexConst t sz := fun v sel => nth_default (defaultCombValue _) sel v;
-    slice t sz startAt len v H := sliceVector v startAt len H;
-    unsignedAdd m n := unsignedAddBool;
-    unsignedMult m n := unsignedMultBool;
-    greaterThanOrEqual m n := greaterThanOrEqualBool;
+    indexAt t sz isz := fun v sel => ret (nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v);
+    indexConst t sz := fun v sel => ret (nth_default (defaultCombValue _) sel v);
+    slice t sz startAt len v H := ret (sliceVector v startAt len H);
+    unsignedAdd m n a := ret (unsignedAddBool a);
+    unsignedMult m n a := ret (unsignedMultBool a);
+    greaterThanOrEqual m n a := ret (greaterThanOrEqualBool a);
     localSignal _ v := ret v;
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefault (map port_type (circuitOutputs intf)));

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -154,12 +154,12 @@ Proof. destruct sel; reflexivity. Qed.
 Hint Rewrite @muxPair_correct using solve [eauto] : simpl_ident.
 
 Lemma indexAt2_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
-  indexAt [i0; i1]%vector [sel]%vector = if sel then i1 else i0.
+  unIdent (indexAt [i0; i1]%vector [sel]%vector) = if sel then i1 else i0.
 Proof. destruct sel; reflexivity. Qed.
 Hint Rewrite @indexAt2_correct using solve [eauto] : simpl_ident.
 
 Lemma mux4_correct {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
-  mux4 (i0,i1,i2,i3) sel =
+  unIdent (mux4 (i0,i1,i2,i3) sel) =
   if Vector.hd (Vector.tl sel)
   then if Vector.hd sel then i3 else i2
   else if Vector.hd sel then i1 else i0.
@@ -169,7 +169,7 @@ Qed.
 Hint Rewrite @mux4_correct using solve [eauto] : simpl_ident.
 
 Lemma indexConst_eq {A sz} (v : combType (Vec A sz)) (n : nat) :
-  indexConst v n = nth_default (defaultCombValue _) n v.
+  unIdent (indexConst v n) = nth_default (defaultCombValue _) n v.
 Proof. reflexivity. Qed.
 Hint Rewrite @indexConst_eq using solve [eauto] : simpl_ident.
 

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -620,7 +620,7 @@ Section WithCava.
     end.
 
   Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
-             (sel : signal (Vec Bit 2)) : signal t :=
+             (sel : signal (Vec Bit 2)) : cava (signal t) :=
     let '(i0,i1,i2,i3) := input in
     indexAt (unpeel [i0;i1;i2;i3]%vector) sel.
  End WithCava.

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -259,12 +259,15 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     muxcy := muxcyNet;
     peel := @peelNet;
     unpeel := @unpeelNet;
-    indexAt k sz isz := IndexAt;
-    indexConst k sz := IndexConst;
-    slice k sz := @sliceNet k sz;
-    unsignedAdd m n ab := @UnsignedAdd m n (1 + max m n) (fst ab) (snd ab);
-    unsignedMult m n ab := @UnsignedMultiply m n (m + n) (fst ab) (snd ab);
-    greaterThanOrEqual m n ab := @GreaterThanOrEqual m n (fst ab) (snd ab);
+    indexAt k sz isz v i := localSignalNet (IndexAt v i);
+    indexConst k sz v i := localSignalNet (IndexConst v i);
+    slice k sz start len v H := localSignalNet (@sliceNet k sz start len v H);
+    unsignedAdd m n ab :=
+      localSignalNet (@UnsignedAdd m n (1 + max m n) (fst ab) (snd ab));
+    unsignedMult m n ab :=
+      localSignalNet (@UnsignedMultiply m n (m + n) (fst ab) (snd ab));
+    greaterThanOrEqual m n ab :=
+      localSignalNet (@GreaterThanOrEqual m n (fst ab) (snd ab));
     localSignal := @localSignalNet;
     instantiate := instantiateNet;
     blackBox := blackBoxNet;

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -81,8 +81,8 @@ Section WithCava.
                           (c : signal (Vec Bit cSize)) :
                           cava (signal (Vec Bit (1 + max (1 + max aSize bSize) cSize)))
                           :=
-    let a_plus_b := unsignedAdd (a, b) in
-    let sum := unsignedAdd (a_plus_b, c) in
+    a_plus_b <- unsignedAdd (a, b) ;;
+    sum <- unsignedAdd (a_plus_b, c) ;;
     ret sum.
 
   Local Close Scope vector_scope.

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -65,9 +65,9 @@ Section WithCava.
 
     (* Different rounds perform different operations on the state before adding
        the round key; select the appropriate wire based on add_round_key_in_sel *)
-    let add_round_key_in :=
+    add_round_key_in <-
         mux4 (mix_columns_out, data, shift_rows_out, mix_columns_out)
-             add_round_key_in_sel in
+             add_round_key_in_sel ;;
 
     (* Intermediate decryption rounds need to mix the key columns *)
     mixed_round_key <- inv_mix_columns_key round_key ;;

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -73,7 +73,7 @@ Section WithCava.
       bitvec_to_signal (nat_to_bitvec_sized _ 14).
 
     Definition add_round (a b: signal round_index): cava (signal round_index) :=
-      let sum := (@unsignedAdd _ _ 4 4 (a, b)) in
+      sum <- (@unsignedAdd _ _ 4 4 (a, b)) ;;
       let '(trunc,_) := unsnoc (peel sum) in
       localSignal (unpeel trunc).
 
@@ -240,7 +240,7 @@ Section WithCava.
       v <- xs ;;
       v' <- localSignal (unpeel v) ;;
       sel' <- sel ;;
-      localSignal (indexAt v' sel')
+      indexAt v' sel'
     ).
 
   Definition signal_update := state (cipher_control_signals cava_signal) unit.

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -80,19 +80,28 @@ Section WithCava.
     (x : signal byte)
     : cava (signal byte) :=
 
-    a <- xor2 (x[@0], x[@7]) ;;
-    b <- xor2 (x[@2], x[@7]) ;;
-    c <- xor2 (x[@3], x[@7]) ;;
+    x0 <- x[@0] ;;
+    x1 <- x[@1] ;;
+    x2 <- x[@2] ;;
+    x3 <- x[@3] ;;
+    x4 <- x[@4] ;;
+    x5 <- x[@5] ;;
+    x6 <- x[@6] ;;
+    x7 <- x[@7] ;;
+
+    a <- xor2 (x0, x7) ;;
+    b <- xor2 (x2, x7) ;;
+    c <- xor2 (x3, x7) ;;
 
     ret (unpeel
-          [x[@7];
+          [x7;
            a;
-           x[@1];
+           x1;
            b;
            c;
-           x[@4];
-           x[@5];
-           x[@6]
+           x4;
+           x5;
+           x6
           ]
     ).
 
@@ -114,7 +123,8 @@ Section WithCava.
     cava (signal (Vec byte 4)) :=
     let indices := [4 - shift; 5 - shift; 6 - shift; 7 - shift] in
     let indices := map (fun x => Nat.modulo x 4) indices in
-    ret (unpeel (map (indexConst input) indices)).
+    out <- mapT (indexConst input) indices ;;
+    ret (unpeel out).
 
   Definition IDLE_S := bitvec_to_signal (nat_to_bitvec_sized 3 0).
   Definition INIT_S := bitvec_to_signal (nat_to_bitvec_sized 3 1).

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -33,25 +33,32 @@ Section WithCava.
     (op_i: signal Bit)
     (data_i: signal (Vec (Vec byte 4) 4))
     : cava (signal (Vec (Vec byte 4) 4)) :=
+  (* Get separate rows from the input data *)
+  data_i_0 <- data_i[@0] ;;
+  data_i_1 <- data_i[@1] ;;
+  data_i_2 <- data_i[@2] ;;
+  data_i_3 <- data_i[@3] ;;
+
   (* // Row 0 is left untouched *)
   (* assign data_o[0] = data_i[0]; *)
-  let data_o_0 := data_i[@0] in
+  let data_o_0 := data_i_0 in
+
   (* // Row 2 does not depend on op_i *)
   (* assign data_o[2] = aes_circ_byte_shift(data_i[2], 2'h2); *)
-  data_o_2 <- aes_circ_byte_shift 2 data_i[@2] ;;
+  data_o_2 <- aes_circ_byte_shift 2 data_i_2 ;;
 
   (* // Row 1 *)
   (* assign data_o[1] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[1], 2'h3) *)
   (*                                       : aes_circ_byte_shift(data_i[1], 2'h1); *)
-  data_o_1_0 <- aes_circ_byte_shift 3 data_i[@1] ;;
-  data_o_1_1 <- aes_circ_byte_shift 1 data_i[@1] ;;
+  data_o_1_0 <- aes_circ_byte_shift 3 data_i_1 ;;
+  data_o_1_1 <- aes_circ_byte_shift 1 data_i_1 ;;
   data_o_1 <- muxPair op_i (data_o_1_0, data_o_1_1) ;;
 
   (* // Row 3 *)
   (* assign data_o[3] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[3], 2'h1) *)
   (*                                       : aes_circ_byte_shift(data_i[3], 2'h3); *)
-  data_o_3_0 <- aes_circ_byte_shift 1 data_i[@3] ;;
-  data_o_3_1 <- aes_circ_byte_shift 3 data_i[@3] ;;
+  data_o_3_0 <- aes_circ_byte_shift 1 data_i_3 ;;
+  data_o_3_1 <- aes_circ_byte_shift 3 data_i_3 ;;
   data_o_3 <- muxPair op_i (data_o_3_0, data_o_3_1) ;;
 
   ret (unpeel [data_o_0; data_o_1; data_o_2; data_o_3]).

--- a/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
@@ -143,10 +143,9 @@ Section WithCava.
 
   Definition aes_sbox_lut (is_decrypt : signal Bit) (b : signal (Vec Bit 8))
     : cava (signal (Vec Bit 8)) :=
-    let encrypted := indexAt sbox_fwd_lut b in
-    let decrypted := indexAt sbox_inv_lut b in
-    let vec := unpeel [encrypted; decrypted] in
-    ret (indexAt vec (unpeel [is_decrypt])).
+    encrypted <- indexAt sbox_fwd_lut b ;;
+    decrypted <- indexAt sbox_inv_lut b ;;
+    muxPair is_decrypt (encrypted, decrypted).
 
   Definition aes_sub_bytes (is_decrypt : signal Bit) (b : signal state)
     : cava (signal state) :=

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -48,12 +48,12 @@ Section WithCava.
 
   Definition arrayTest (i : signal (Vec Bit 8))
                        : cava (signal (Vec Bit 8)) :=
-    ret (indexConst array 0).
+    indexConst array 0.
 
   Definition multiDimArrayTest (i : signal (Vec Bit 8))
                        : cava (signal (Vec Bit 8)) :=
-    let v := indexConst multiDimArray 0 in
-    ret (indexConst v 0).
+    v <- indexConst multiDimArray 0 ;;
+    indexConst v 0.
 
 End WithCava.
 

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -60,7 +60,9 @@ Section WithCava.
   Context {signal} {semantics: Cava signal}.
 
   Definition ltV {m n} (xy : signal (Vec Bit n) * signal (Vec Bit m))
-    : cava (signal Bit) := inv (greaterThanOrEqual (snd xy, fst xy)).
+    : cava (signal Bit) :=
+    geV <- greaterThanOrEqual (snd xy, fst xy) ;;
+    inv geV.
 
   (* add-with-carry *)
   Definition addC {n} (xy : signal (Vec Bit n) * signal (Vec Bit n))
@@ -73,7 +75,7 @@ Section WithCava.
   Definition incrN {n} (x : signal (Vec Bit (S n)))
     : cava (signal (Vec Bit (S n))) :=
     let one : signal (Vec Bit 1) := unpeel [constant true]%vector in
-    let xp1 : signal (Vec Bit (S (Nat.max 1 (S n)))) := unsignedAdd (one, x) in
+    xp1 <- unsignedAdd (one, x) ;;
     ret (unpeel (shiftout (peel xp1))).
 
   Definition count_by

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -46,7 +46,7 @@ Section WithCava.
                            signal (Vec Bit isz)) :
                       cava (signal (Vec Bit dsz)) :=
     let (v, sel) := vsel in
-    ret (indexAt v sel).
+    indexAt v sel.
 
 End WithCava.
 

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -34,7 +34,7 @@ Section WithCava.
   Definition multiplier {aSize bSize: nat}
                         (ab: signal (Vec Bit aSize) * signal (Vec Bit bSize)):
                         cava (signal (Vec Bit (aSize + bSize))) :=
-    ret (unsignedMult ab).
+    unsignedMult ab.
 
 End WithCava.
 


### PR DESCRIPTION
Updated version of #482 

Doesn't change `peel`/`unpeel`, since in discussion we weren't sure if they would need to change. @blaxill @satnam6502 , does this solve the duplicated-code problem you were seeing? Should we modify `peel`/`unpeel` as well?