### PR TITLE
Make peel and unpeel into circuits

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -45,9 +45,10 @@ Section WithCava.
 
   (* An adder-tree with no bit-growth. *)
   Definition adderTree {sz: nat}
-                       (n: nat) (v: signal (Vec (Vec Bit sz) (2^(S n)))):
-                       cava (signal (Vec Bit sz)) :=
-    treeS addN (peel v).
+             (n: nat)
+    : signal (Vec (Vec Bit sz) (2^(S n))) ->
+      cava (signal (Vec Bit sz)) :=
+    peel >=> treeS addN.
 
   (* An adder tree with 2 inputs. *)
   Definition adderTree2 {sz: nat}

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -59,7 +59,7 @@ Section WithCava.
     '(sum1, carry) <- half_adder (carry, i1) ;;
     '(sum2, carry) <- half_adder (carry, i2) ;;
     '(sum3, carry) <- half_adder (carry, i3) ;;
-    ret (unpeel [sum0;sum1;sum2;sum3]%vector).
+    unpeel [sum0;sum1;sum2;sum3]%vector.
 
   (* decrement a 4-bit vector *)
   Definition decr4 (input : signal (Vec Bit 4))
@@ -72,7 +72,7 @@ Section WithCava.
     '(diff1, borrow) <- half_subtractor (i1, borrow) ;;
     '(diff2, borrow) <- half_subtractor (i2, borrow) ;;
     '(diff3, borrow) <- half_subtractor (i3, borrow) ;;
-    ret (unpeel [diff0;diff1;diff2;diff3]%vector).
+    unpeel [diff0;diff1;diff2;diff3]%vector.
 
   Fixpoint incr' {sz} (carry : signal Bit)
     : signal (Vec Bit sz) -> cava (signal (Vec Bit sz)) :=
@@ -80,10 +80,13 @@ Section WithCava.
           signal (Vec Bit sz0) -> cava (signal (Vec Bit sz0)) with
     | 0 => fun input => ret input
     | S sz' => fun input : signal (Vec Bit (S sz')) =>
-                let i0 := Vector.hd (peel input) in
+                i <- peel input ;;
+                let i0 := Vector.hd i in
                 '(sum0, carry) <- half_adder (carry, i0) ;;
-                sum <- incr' carry (unpeel (Vector.tl (peel input))) ;;
-                ret (unpeel (sum0 :: peel sum)%vector)
+                rem <- unpeel (Vector.tl i) ;;
+                sum' <- incr' carry rem ;;
+                sum <- peel sum' ;;
+                unpeel (sum0 :: sum)%vector
     end.
 
   (* increments a bit vector of any length *)
@@ -96,10 +99,13 @@ Section WithCava.
           signal (Vec Bit sz0) -> cava (signal (Vec Bit sz0)) with
     | 0 => fun input => ret input
     | S sz' => fun input : signal (Vec Bit (S sz')) =>
-                let i0 := Vector.hd (peel input) in
+                i <- peel input ;;
+                let i0 := Vector.hd i in
                 '(diff0, borrow) <- half_subtractor (i0, borrow) ;;
-                diff <- decr' borrow (unpeel (Vector.tl (peel input))) ;;
-                ret (unpeel (diff0 :: peel diff)%vector)
+                rem <- unpeel (Vector.tl i) ;;
+                diff' <- decr' borrow rem ;;
+                diff <- peel diff' ;;
+                unpeel (diff0 :: diff)%vector
     end.
 
   (* decrements a bit vector of any length *)

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -37,16 +37,16 @@ Local Open Scope vector_scope.
 Section WithCava.
   Context {signal} `{Cava signal}.
 
-Definition twoSorter {signal} `{Cava signal} {n}
+  Definition twoSorter {signal} `{Cava signal} {n}
                      (ab:  signal (Vec (Vec Bit n) 2)) :
                      cava (signal (Vec (Vec Bit n) 2)) :=
    a <- indexConst ab 0 ;;
    b <- indexConst ab 1 ;;
    comparison <- greaterThanOrEqual (a, b) ;;
    negComparison <- inv comparison ;;
-   out0 <- indexAt ab (unpeel [comparison]) ;;
-   out1 <- indexAt ab (unpeel [negComparison]) ;;
-   ret (unpeel [out0;out1]).
+   out0 <- muxPair comparison (a, b) ;;
+   out1 <- muxPair negComparison (a, b) ;;
+   unpeel [out0; out1].
 
 End WithCava.
 

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -40,9 +40,10 @@ Section WithCava.
   (* by using the tree combinator.                                            *)
   (****************************************************************************)
   Definition adderTree {sz: nat}
-                       (n: nat) (v: signal (Vec (Vec Bit sz) (2^(S n)))):
-                       cava (signal (Vec Bit sz)) :=
-    tree defaultSignal n xilinxAdder (peel v).
+             (n: nat)
+    : signal (Vec (Vec Bit sz) (2^(S n))) ->
+      cava (signal (Vec Bit sz)) :=
+    peel >=> tree defaultSignal n xilinxAdder.
 
   (****************************************************************************)
   (* An adder tree with 2 inputs.                                             *)

--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -53,8 +53,8 @@ Class Cava (signal : SignalType -> Type) := {
   xorcy : signal Bit * signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
   muxcy : signal Bit -> signal  Bit -> signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
   (* Converting to/from Vector.t *)
-  peel : forall {t : SignalType} {s : nat}, signal (Vec t s) -> Vector.t (signal t) s;
-  unpeel : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> signal (Vec t s);
+  peel : forall {t : SignalType} {s : nat}, signal (Vec t s) -> cava (Vector.t (signal t) s);
+  unpeel : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> cava (signal (Vec t s));
   indexAt : forall {t : SignalType} {sz isz: nat},
             signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
             signal (Vec Bit isz) ->  (* A bit-vector index of size isz bits *)

--- a/cava/Cava/Acorn/CavaPrelude.v
+++ b/cava/Cava/Acorn/CavaPrelude.v
@@ -20,6 +20,7 @@ Import VectorNotations.
 
 Require Import ExtLib.Structures.Monads.
 Import MonadNotation.
+Local Open Scope monad_scope.
 
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Signal.
@@ -46,6 +47,8 @@ Section WithCava.
                      (sel : signal Bit)
                      (ab : signal A * signal A) : cava (signal A) :=
     let (a, b) := ab in
-    indexAt (unpeel [a; b]) (unpeel [sel]).
+    v <- unpeel [a;b] ;;
+    sel <- unpeel [sel] ;;
+    indexAt v sel.
 
 End WithCava.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -61,8 +61,8 @@ Instance CombinationalSemantics : Cava combType :=
     lut6 := fun f '(a,b,c,d,e,g) => ret (f a b c d e g);
     xorcy := fun '(x,y) => ret (xorb x y);
     muxcy := fun sel x y => ret (if sel then x else y);
-    peel _ _ v := v;
-    unpeel _ _ v := v;
+    peel _ _ v := ret v;
+    unpeel _ _ v := ret v;
     indexAt t sz isz := fun v sel => ret (nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v);
     indexConst t sz := fun v sel => ret (nth_default (defaultCombValue _) sel v);
     slice t sz startAt len v H := ret (sliceVector v startAt len H);

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -88,9 +88,10 @@ Lemma all_correct {n} v :
   unIdent (all (n:=n) v) = Vector.fold_left andb true v.
 Proof.
   destruct n; [ eapply case0 with (v:=v); reflexivity | ].
-  cbv [all]. cbn [one CombinationalSemantics].
-  erewrite tree_all_sizes_equiv with (op:=andb) (id:=true);
-    intros; simpl_ident; boolsimpl; try reflexivity; try lia;
+  cbv [all one]. simpl_ident.
+  erewrite (tree_all_sizes_equiv (semantics:=CombinationalSemantics))
+    with (op:=andb) (id:=true);
+    intros; boolsimpl; try reflexivity; try lia;
       auto using Bool.andb_assoc.
 Qed.
 Hint Rewrite @all_correct using solve [eauto] : simpl_ident.

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -73,10 +73,10 @@ Section WithCava.
            (a : signal (Vec A n))
            (b : signal (Vec B n))
            : cava (signal (Vec C n)) :=
-    let a' := peel a in
-    let b' := peel b in
+    a' <- peel a ;;
+    b' <- peel b ;;
     v <- mapT f (vcombine a' b') ;;
-    ret (unpeel v).
+    unpeel v.
 
   (* A list-based left monadic-fold. *)
   Fixpoint foldLM {m} `{Monad m} {A B : Type}
@@ -259,8 +259,10 @@ Section WithCava.
                (circuit : signal A * signal B -> cava (signal C * signal A))
                (aIn: signal A) (bIn: signal (Vec B n)) :
                cava (signal (Vec C n) * signal A) :=
-  '(c, a) <- colV circuit (aIn, (peel bIn)) ;;
-  ret (unpeel c, a).
+  b <- peel bIn ;;
+  '(c, a) <- colV circuit (aIn, b) ;;
+  cOut <- unpeel c ;;
+  ret (cOut, a).
 
   Local Close Scope vector_scope.
 
@@ -607,7 +609,8 @@ Section WithCava.
   Qed.
 
   Definition all {n} (v : signal (Vec Bit n)) : cava (signal Bit) :=
-    tree_all_sizes one (fun x y => and2 (x,y)) (peel v).
+    v <- peel v ;;
+    tree_all_sizes one (fun x y => and2 (x,y)) v.
 
   Fixpoint eqb {t : SignalType} : signal t -> signal t -> cava (signal Bit) :=
     match t as t0 return signal t0 -> signal t0 -> cava (signal Bit) with
@@ -622,5 +625,6 @@ Section WithCava.
   Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
              (sel : signal (Vec Bit 2)) : cava (signal t) :=
     let '(i0,i1,i2,i3) := input in
-    indexAt (unpeel [i0;i1;i2;i3]%vector) sel.
+    v <- unpeel [i0;i1;i2;i3]%vector ;;
+    indexAt v sel.
  End WithCava.

--- a/cava/Cava/Acorn/XilinxAdder.v
+++ b/cava/Cava/Acorn/XilinxAdder.v
@@ -53,10 +53,11 @@ Section WithCava.
               (cinab : signal Bit * (signal (Vec Bit n) * signal (Vec Bit n)))
             : cava (signal (Vec Bit n) * signal Bit)
     := let '(cin, (a, b)) := cinab in
-      let a0 := peel a in
-      let b0 := peel b in
+      a0 <- peel a ;;
+      b0 <- peel b ;;
       '(sum, cout) <- colV xilinxFullAdder (cin, vcombine a0 b0) ;;
-      ret (unpeel sum, cout).
+      sum <- unpeel sum ;;
+      ret (sum, cout).
 
   (******************************************************************************)
   (* An unsigned adder with no bit-growth and no carry in                       *)

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -66,10 +66,11 @@ Section WithCava.
   (* Adder with a pair of inputs of the same size and no bit-growth, as signal. *)
   Definition addN {n : nat}
             (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
-            cava (signal (Vec Bit n)) :=
-    let (a, b) := ab in
-    '(sum, _) <- unsignedAdderV (constant false, vcombine (peel a) (peel b)) ;;
-    ret (unpeel sum).
+    cava (signal (Vec Bit n)) :=
+    a <- peel (fst ab) ;;
+    b <- peel (snd ab) ;;
+    '(sum, _) <- unsignedAdderV (constant false, vcombine a b) ;;
+    unpeel sum.
 
   (****************************************************************************)
   (* A three input adder.                                                     *)

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -88,7 +88,7 @@ Section WithCava.
     is_final_round <- round_i ==? num_rounds_regular;;
     (* add_round_key_in_sel :
        1 if round_i = 0, 2 if round_i = num_rounds_regular, 0 otherwise *)
-    let add_round_key_in_sel := unpeel [is_first_round; is_final_round]%vector in
+    add_round_key_in_sel <- unpeel [is_first_round; is_final_round]%vector ;;
     is_middle_round <- nor2 (is_first_round, is_final_round) ;;
     (* round_key_sel : 1 for a decryption middle round, 0 otherwise *)
     round_key_sel <- and2 (is_middle_round, is_decrypt) ;;

--- a/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
@@ -48,11 +48,11 @@ Section Equivalence.
   Lemma aes_transpose_correct n m (v : combType (Vec (Vec (Vec Bit 8) n) m)) :
     m <> 0 ->
     n <> 0 ->
-    aes_transpose v = transpose v.
+    unIdent (aes_transpose v) = transpose v.
   Proof.
     intros Hm Hn.
     unfold aes_transpose.
-    cbv [unpeel peel Combinational.CombinationalSemantics].
+    simpl_ident.
     rewrite ! map_id.
     reflexivity.
   Qed.
@@ -113,6 +113,10 @@ Section Equivalence.
 
   Local Open Scope poly_scope.
 
+  Lemma zero_byte_correct : bitvec_to_byte (unIdent zero_byte) = fzero.
+  Proof. reflexivity. Qed.
+  Hint Rewrite zero_byte_correct using solve [eauto] : simpl_ident.
+
   Ltac prering :=
     change Byte.x03 with (Byte.x02 + Byte.x01);
     change Byte.x04 with (Byte.x02 * Byte.x02);
@@ -127,8 +131,7 @@ Section Equivalence.
     change Byte.x0d with (Byte.x02 * (Byte.x02 * Byte.x02) + Byte.x02 * Byte.x02 + Byte.x01);
     change Byte.x0e with (Byte.x02 * (Byte.x02 * Byte.x02) + Byte.x02 * (Byte.x02 + Byte.x01));
     change Byte.x0e with (Byte.x02 * (Byte.x02 * Byte.x02) + Byte.x02 * (Byte.x02 + Byte.x01) + Byte.x01);
-    change Byte.x01 with fone;
-    change (bitvec_to_byte zero_byte) with fzero.
+    change Byte.x01 with fone.
 
   Add Ring bytering : MixColumns.ByteTheory (preprocess [prering]).
 
@@ -168,7 +171,7 @@ Section Equivalence.
     unIdent (aes_mix_columns is_decrypt st)
     = AES256.aes_mix_columns_circuit_spec is_decrypt st.
   Proof.
-    cbv [aes_mix_columns]. simpl_ident.
+    cbv [aes_mix_columns mcompose]. simpl_ident.
     rewrite ! aes_transpose_correct by lia.
     erewrite map_ext by apply mix_single_column_equiv.
     cbv [AES256.aes_mix_columns_circuit_spec

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -61,6 +61,6 @@ Section WithCava.
   data_o_3_1 <- aes_circ_byte_shift 3 data_i_3 ;;
   data_o_3 <- muxPair op_i (data_o_3_0, data_o_3_1) ;;
 
-  ret (unpeel [data_o_0; data_o_1; data_o_2; data_o_3]).
+  unpeel [data_o_0; data_o_1; data_o_2; data_o_3].
 
 End WithCava.

--- a/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
@@ -83,6 +83,7 @@ Section Equivalence.
     intros.
     unfold state_map.
     unfold column_map.
+    unfold mcompose.
 
     do 2 (simpl_ident; apply map_ext; intros).
     reflexivity.

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -108,7 +108,8 @@ Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
                            Signal (Vec Bit NPeriphOut)  *
                            Signal (Vec Bit NPeriphOut) *
                            Signal (Vec Bit NMioPads)) :
-                   state CavaState (Signal (ExternalType "tlul_pkg::tl_d2h_t") *
+                    state CavaState
+                     (Signal (ExternalType "tlul_pkg::tl_d2h_t") *
                      Signal (Vec Bit NMioPads) *
                      Signal (Vec Bit NPeriphIn) *
                      Signal (Vec Bit NMioPads)) :=
@@ -117,22 +118,28 @@ Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
   let const1 := Vcc in
   '(tl_o, reg2hw) <- blackBoxNet pinmux_reg_top_Interface (tl_i, const1) ;;
   (* Input Mux *)
-  let data_in_mux := VecLit ([const0; const1] ++ peel mio_in_i) in
+  mio_in_i <- peelNet mio_in_i ;;
+  let data_in_mux := VecLit ([const0; const1] ++ mio_in_i) in
   let mio_to_periph_o :=
     Vector.map (fun k => IndexAt data_in_mux (kq "periph_insel" reg2hw k))
-     (vseq 0 NPeriphIn) in
+               (vseq 0 NPeriphIn) in
   (* Output Mux *)
-  let data_out_mux := VecLit ([const0; const1; const0] ++ peel periph_to_mio_i) in
-  let oe_mux := VecLit ([const1; const1; const0] ++ peel periph_to_mio_oe_i) in
+  periph_to_mio_i <- peelNet periph_to_mio_i ;;
+  periph_to_mio_oe_i <- peelNet periph_to_mio_oe_i ;;
+  let data_out_mux := VecLit ([const0; const1; const0] ++ periph_to_mio_i) in
+  let oe_mux := VecLit ([const1; const1; const0] ++ periph_to_mio_oe_i) in
   let mio_out_o :=
     Vector.map (fun k => IndexAt data_out_mux (kq "mio_outsel" reg2hw k))
               (vseq 0 NPeriphIn) in
   let mio_oe_o :=
     Vector.map (fun k => IndexAt oe_mux (kq "mio_outsel" reg2hw k))
                (vseq 0 NPeriphIn) in
+  mio_to_periph_o <- unpeelNet mio_to_periph_o ;;
+  mio_out_o <- unpeelNet mio_out_o ;;
+  mio_oe_o <- unpeelNet mio_oe_o ;;
   ret (tl_o,
-       unpeel mio_to_periph_o,
-       unpeel mio_out_o,
-       unpeel mio_oe_o).
+       mio_to_periph_o,
+       mio_out_o,
+       mio_oe_o).
 
 Definition pinmux_netlist := makeNetlist pinmuxInterface pinmux.

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -21,6 +21,7 @@ Import ListNotations.
 Import VectorNotations.
 
 Require Import ExtLib.Structures.Monads.
+Require Import ExtLib.Structures.Traversable.
 Export MonadNotation.
 
 Require Import Cava.Cava.
@@ -36,23 +37,27 @@ Existing Instance CavaCombinationalNet.
 Section WithCava.
   Context `{Cava}.
 
-  Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : signal (Vec Bit n) :=
+  Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : cava (signal (Vec Bit n)) :=
     unpeel (Vector.map constant lut).
-  Search (nat -> Bvector _).
 
-  Definition array : signal (Vec (Vec Bit 8) 4) :=
-    unpeel (map (fun x => bitvec_to_signal (nat_to_bitvec_sized _ x)) [0;1;2;3]).
+  Definition array : cava (signal (Vec (Vec Bit 8) 4)) :=
+    v <- mapT (fun x => bitvec_to_signal (nat_to_bitvec_sized _ x)) [0;1;2;3] ;;
+    unpeel v.
 
-  Definition multiDimArray : signal (Vec (Vec (Vec Bit 8) 4) 2) :=
-    unpeel ([array; array]).
+  Definition multiDimArray : cava (signal (Vec (Vec (Vec Bit 8) 4) 2)) :=
+    arr1 <- array ;;
+    arr2 <- array ;;
+    unpeel [arr1; arr2].
 
   Definition arrayTest (i : signal (Vec Bit 8))
-                       : cava (signal (Vec Bit 8)) :=
-    indexConst array 0.
+    : cava (signal (Vec Bit 8)) :=
+    arr <- array ;;
+    indexConst arr 0.
 
   Definition multiDimArrayTest (i : signal (Vec Bit 8))
-                       : cava (signal (Vec Bit 8)) :=
-    v <- indexConst multiDimArray 0 ;;
+    : cava (signal (Vec Bit 8)) :=
+    arr <- multiDimArray ;;
+    v <- indexConst arr 0 ;;
     indexConst v 0.
 
 End WithCava.

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -74,9 +74,10 @@ Section WithCava.
   (* incrementer *)
   Definition incrN {n} (x : signal (Vec Bit (S n)))
     : cava (signal (Vec Bit (S n))) :=
-    let one : signal (Vec Bit 1) := unpeel [constant true]%vector in
+    one <- unpeel [one]%vector ;;
     xp1 <- unsignedAdd (one, x) ;;
-    ret (unpeel (shiftout (peel xp1))).
+    xp1 <- peel xp1 ;;
+    unpeel (shiftout xp1).
 
   Definition count_by
     : Circuit (signal (Vec Bit 8)) (signal Bit)


### PR DESCRIPTION
Follow up for #582, #596

Make `peel` and `unpeel` circuits so that they can be essentially wrapped in `localSignal` always.

@blaxill I was kind of guessing with the naming in `CipherControlCircuit`, feel free to change anything that doesn't match your conventions!