### PR TITLE
Create test benches based on FIPS for subroutine netlists

### DIFF
--- a/silveroak-opentitan/aes/Acorn/AESSV.hs
+++ b/silveroak-opentitan/aes/Acorn/AESSV.hs
@@ -31,7 +31,5 @@ main = do writeSystemVerilog aes_mix_columns_Netlist
           writeSystemVerilog aes_sub_bytes_Netlist
           writeTestBench aes_sub_bytes_tb
           writeSystemVerilog aes_add_round_key_Netlist
-          writeTestBench aes_add_round_key_simple_tb
-          writeTestBench aes_add_round_key_enc_tb
-          writeTestBench aes_add_round_key_dec_tb
+          writeTestBench aes_add_round_key_tb
           writeSystemVerilog aes_cipher_core_Netlist

--- a/silveroak-opentitan/aes/Acorn/AESSV.hs
+++ b/silveroak-opentitan/aes/Acorn/AESSV.hs
@@ -31,5 +31,7 @@ main = do writeSystemVerilog aes_mix_columns_Netlist
           writeSystemVerilog aes_sub_bytes_Netlist
           writeTestBench aes_sub_bytes_tb
           writeSystemVerilog aes_add_round_key_Netlist
-          writeTestBench aes_add_round_key_tb
+          writeTestBench aes_add_round_key_simple_tb
+          writeTestBench aes_add_round_key_enc_tb
+          writeTestBench aes_add_round_key_dec_tb
           writeSystemVerilog aes_cipher_core_Netlist

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
@@ -21,6 +21,9 @@ Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
+Require Import AesSpec.AES256.
+Require Import AesSpec.Tests.Common.
+Require Import AesSpec.Tests.TestVectors.
 Require Import AcornAes.AddRoundKeyCircuit.
 Require Import AcornAes.Pkg.
 Local Open Scope vector_scope.
@@ -36,18 +39,56 @@ Definition aes_add_round_key_Interface :=
   [mkPort "data_o" (Vec (Vec (Vec Bit 8) 4) 4)]
   [].
 
-Definition aes_add_round_key_Netlist
-  := makeNetlist aes_add_round_key_Interface (fun '(key_i, data_i) => aes_add_round_key key_i data_i).
+Definition aes_add_round_key_Netlist :=
+  makeCircuitNetlist aes_add_round_key_Interface
+                     (Comb (fun '(k,st) => aes_add_round_key k st)).
 
-Local Open Scope list_scope.
+(* Test bench checking that for a single add_round_key, the circuit and Coq
+   semantics return the same result *)
+Section SimpleTestBench.
+  (* Compute the expected outputs from the Coq/Cava semantics. *)
+  Definition aes_add_round_key_simple_expected_outputs : seqType (Vec (Vec (Vec Bit 8) 4) 4)
+    := simulate (Comb (fun '(key_i, data_i) => aes_add_round_key key_i data_i))
+                 [(fromNatVec test_key, fromNatVec test_state)].
 
-(* Compute the expected outputs from the Coq/Cava semantics. *)
-Definition aes_add_round_key_expected_outputs : seqType (Vec (Vec (Vec Bit 8) 4) 4)
-  := simulate (Comb (fun '(key_i, data_i) => aes_add_round_key key_i data_i))
-               [(fromNatVec test_key, fromNatVec test_state)].
+  Definition aes_add_round_key_simple_tb :=
+    testBench "aes_add_round_key_simple_tb"
+              aes_add_round_key_Interface
+              [(fromNatVec test_key, fromNatVec test_state)]
+              aes_add_round_key_simple_expected_outputs.
+End SimpleTestBench.
 
-Definition aes_add_round_key_tb :=
-  testBench "aes_add_round_key_tb"
-            aes_add_round_key_Interface
-            [(fromNatVec test_key, fromNatVec test_state)]
-            aes_add_round_key_expected_outputs.
+(* Test bench checking against full FIPS AES-256 encryption test vector *)
+Section FIPSEncryptTestBench.
+  Definition aes_add_round_key_enc_tb_inputs :=
+    Eval vm_compute in
+      (combine (map from_flat (round_ksch fips_c3_forward))
+               (map from_flat (get_state_inputs AddRoundKey fips_c3_forward))).
+
+  Definition aes_add_round_key_enc_expected_outputs :=
+    Eval vm_compute in
+      (map from_flat (get_state_outputs AddRoundKey fips_c3_forward)).
+
+  Definition aes_add_round_key_enc_tb
+    := testBench "aes_add_round_key_enc_tb" aes_add_round_key_Interface
+                 aes_add_round_key_enc_tb_inputs
+                 aes_add_round_key_enc_expected_outputs.
+End FIPSEncryptTestBench.
+
+(* Test bench checking against full FIPS AES-256 decryption test vector (for
+   equivalent inverse cipher) *)
+Section FIPSDecryptTestBench.
+  Definition aes_add_round_key_dec_tb_inputs :=
+    Eval vm_compute in
+      (combine (map from_flat (round_ksch fips_c3_equivalent_inverse))
+               (map from_flat (get_state_inputs AddRoundKey fips_c3_equivalent_inverse))).
+
+  Definition aes_add_round_key_dec_expected_outputs :=
+    Eval vm_compute in
+      (map from_flat (get_state_outputs AddRoundKey fips_c3_equivalent_inverse)).
+
+  Definition aes_add_round_key_dec_tb
+    := testBench "aes_add_round_key_dec_tb" aes_add_round_key_Interface
+                 aes_add_round_key_dec_tb_inputs
+                 aes_add_round_key_dec_expected_outputs.
+End FIPSDecryptTestBench.

--- a/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
@@ -21,6 +21,9 @@ Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
+Require Import AesSpec.AES256.
+Require Import AesSpec.Tests.Common.
+Require Import AesSpec.Tests.TestVectors.
 Require Import AcornAes.SubBytesCircuit.
 Require Import AcornAes.Pkg.
 Import Pkg.Notations.
@@ -49,13 +52,59 @@ Definition aes_sbox_lut_Netlist
 Definition aes_sub_bytes_Netlist
   := makeNetlist aes_sub_bytes_Interface (fun '(op_i, data_i) => aes_sub_bytes op_i data_i).
 
-(* Compute the expected outputs from the Coq/Cava semantics. *)
-Definition aes_sub_bytes_expected_outputs :=
-  simulate (Comb (fun '(op_i, data_i) => aes_sub_bytes op_i data_i))
-            [(false, fromNatVec test_state)].
+(* Test bench checking that for a single step, the circuit and Coq semantics
+   return the same result *)
+Section SimpleTestBench.
+  Definition aes_sub_bytes_simple_inputs : list _ :=
+    [(false, fromNatVec test_state)].
+
+  (* Compute the expected outputs from the Coq/Cava semantics. *)
+  Definition aes_sub_bytes_simple_expected_outputs :=
+    simulate (Comb (fun '(op_i, data_i) => aes_sub_bytes op_i data_i))
+             aes_sub_bytes_simple_inputs.
+End SimpleTestBench.
+
+(* Test bench checking against full FIPS AES-256 encryption test vector *)
+Section FIPSEncryptTestBench.
+  Definition aes_sub_bytes_enc_tb_inputs :=
+    Eval vm_compute in
+      (map (fun v => (false, from_flat v))
+           (get_state_inputs SubBytes fips_c3_forward)).
+
+  Definition aes_sub_bytes_enc_expected_outputs :=
+    Eval vm_compute in
+      (map from_flat (get_state_outputs SubBytes fips_c3_forward)).
+End FIPSEncryptTestBench.
+
+(* Test bench checking against full FIPS AES-256 decryption test vector (for
+   equivalent inverse cipher) *)
+Section FIPSDecryptTestBench.
+  Definition aes_sub_bytes_dec_tb_inputs :=
+    Eval vm_compute in
+      (map (fun v => (true, from_flat v))
+           (get_state_inputs InvSubBytes fips_c3_equivalent_inverse)).
+
+  Definition aes_sub_bytes_dec_expected_outputs :=
+    Eval vm_compute in
+      (map from_flat (get_state_outputs InvSubBytes fips_c3_equivalent_inverse)).
+End FIPSDecryptTestBench.
+
+(* Concatenate inputs from all tests *)
+Definition aes_sub_bytes_tb_all_inputs :=
+  Eval vm_compute in
+    (aes_sub_bytes_simple_inputs
+       ++ aes_sub_bytes_enc_tb_inputs
+       ++ aes_sub_bytes_dec_tb_inputs)%list.
+
+(* Concatenate expected outputs from all tests *)
+Definition aes_sub_bytes_tb_all_expected_outputs :=
+  Eval vm_compute in
+    (aes_sub_bytes_simple_expected_outputs
+       ++ aes_sub_bytes_enc_expected_outputs
+       ++ aes_sub_bytes_dec_expected_outputs)%list.
 
 Definition aes_sub_bytes_tb :=
   testBench "aes_sub_bytes_tb"
             aes_sub_bytes_Interface
-            [(false, fromNatVec test_state)]
-            aes_sub_bytes_expected_outputs.
+            aes_sub_bytes_tb_all_inputs
+            aes_sub_bytes_tb_all_expected_outputs.

--- a/silveroak-opentitan/aes/Spec/Tests/Common.v
+++ b/silveroak-opentitan/aes/Spec/Tests/Common.v
@@ -159,3 +159,79 @@ Definition pretty_print_test_vector {key state}
     newline
     (List.map (pretty_print_step_data key_to_string state_to_string)
               (full_data_for_steps test)).
+
+(* Decidable equivalence test for AES steps *)
+Definition AESStep_eqb (step1 step2 : AESStep) : bool :=
+  match step1 with
+  | AddRoundKey => match step2 with
+                  | AddRoundKey => true
+                  | _ => false
+                  end
+  | MixColumns => match step2 with
+                  | MixColumns => true
+                  | _ => false
+                  end
+  | SubBytes => match step2 with
+                  | SubBytes => true
+                  | _ => false
+                  end
+  | ShiftRows => match step2 with
+                  | ShiftRows => true
+                  | _ => false
+                  end
+  | InvMixColumns => match step2 with
+                  | InvMixColumns => true
+                  | _ => false
+                  end
+  | InvSubBytes => match step2 with
+                  | InvSubBytes => true
+                  | _ => false
+                  end
+  | InvShiftRows => match step2 with
+                  | InvShiftRows => true
+                  | _ => false
+                   end
+  end.
+
+Definition get_state_inputs_for_round {state} (step : AESStep)
+           (state_before_round : state)
+           (round : list (AESStep * state))
+  : list state :=
+  (* Get the indices at which our desired step occurs *)
+  let step_indices := filter (fun i => match nth_error round i with
+                                    | None => false
+                                    | Some x => AESStep_eqb step (fst x)
+                                    end) (seq 0 (length round)) in
+  (* because the state listed for each step is the state *after* the step, we
+     need to find *previous* states to get the inputs to this AES step; shift
+     the list by adding state_before_round to the front *)
+  let default := state_before_round in (* for nth_default *)
+  map (fun i => nth i (state_before_round :: map snd round) default)
+      step_indices.
+Definition get_state_outputs_for_round {state} (step : AESStep)
+           (round : list (AESStep * state))
+  : list state :=
+  map snd (filter (fun x => AESStep_eqb step (fst x)) round).
+
+(* Get all output states of a particular step from FIPS test vector *)
+Definition get_state_outputs {key state} (step : AESStep) (test : @TestVector key state)
+  : list state :=
+  flat_map
+    (get_state_outputs_for_round step)
+    (test.(round_expected_states)).
+
+(* Get all input states of a particular step from FIPS test vector *)
+Definition get_state_inputs {key state} (step : AESStep) (test : @TestVector key state)
+  : list state :=
+  let default := test.(plaintext) in (* dummy value for last *)
+  (* get the final state of each round *)
+  let round_final_states :=
+      map (fun round_states => last round_states default)
+          (map (map snd) test.(round_expected_states)) in
+  (* get the initial state of each round by shifting the final-states list 1
+     place and adding the initial data *)
+  let round_input_states := test.(plaintext) :: removelast round_final_states in
+  flat_map
+    (fun '(start_state, round) =>
+       get_state_inputs_for_round step start_state round)
+    (combine round_input_states test.(round_expected_states)).

--- a/silveroak-opentitan/aes/Spec/Tests/Common.v
+++ b/silveroak-opentitan/aes/Spec/Tests/Common.v
@@ -208,6 +208,7 @@ Definition get_state_inputs_for_round {state} (step : AESStep)
   let default := state_before_round in (* for nth_default *)
   map (fun i => nth i (state_before_round :: map snd round) default)
       step_indices.
+
 Definition get_state_outputs_for_round {state} (step : AESStep)
            (round : list (AESStep * state))
   : list state :=


### PR DESCRIPTION
Currently, we're testing that the Coq semantics for our circuits match the test vectors from FIPS, but the actual test benches for the netlists only test one or two handwritten examples for each subroutine. This PR adds much more extensive test benches based on the same test data as the semantics tests. 