### PR TITLE
Reorganize/rename multiplexers

### DIFF
--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -28,6 +28,7 @@ Import VectorNotations.
 Require Import Coq.Arith.PeanoNat Coq.NArith.NArith.
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Lib.Multiplexers.
 Existing Instance CavaCombinationalNet.
 
 Require Import Coq.micromega.Lia.

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -44,8 +44,8 @@ Section WithCava.
    b <- indexConst ab 1 ;;
    comparison <- greaterThanOrEqual (a, b) ;;
    negComparison <- inv comparison ;;
-   out0 <- muxPair comparison (a, b) ;;
-   out1 <- muxPair negComparison (a, b) ;;
+   out0 <- mux2 comparison (a, b) ;;
+   out1 <- mux2 negComparison (a, b) ;;
    unpeel [out0; out1].
 
 End WithCava.

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -149,25 +149,10 @@ Proof.
   lia.
 Qed.
 
-Lemma muxPair_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
-  unIdent (muxPair sel (i0, i1)) = if sel then i1 else i0.
-Proof. destruct sel; reflexivity. Qed.
-Hint Rewrite @muxPair_correct using solve [eauto] : simpl_ident.
-
 Lemma indexAt2_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
   unIdent (indexAt [i0; i1]%vector [sel]%vector) = if sel then i1 else i0.
 Proof. destruct sel; reflexivity. Qed.
 Hint Rewrite @indexAt2_correct using solve [eauto] : simpl_ident.
-
-Lemma mux4_correct {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
-  unIdent (mux4 (i0,i1,i2,i3) sel) =
-  if Vector.hd (Vector.tl sel)
-  then if Vector.hd sel then i3 else i2
-  else if Vector.hd sel then i1 else i0.
-Proof.
-  cbv in sel. constant_bitvec_cases sel; reflexivity.
-Qed.
-Hint Rewrite @mux4_correct using solve [eauto] : simpl_ident.
 
 Lemma indexConst_eq {A sz} (v : combType (Vec A sz)) (n : nat) :
   unIdent (indexConst v n) = nth_default (defaultCombValue _) n v.

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -621,10 +621,4 @@ Section WithCava.
                   eq_results <- zipWith (fun '(a, b) => eqb a b) x y ;;
                   all eq_results
     end.
-
-  Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
-             (sel : signal (Vec Bit 2)) : cava (signal t) :=
-    let '(i0,i1,i2,i3) := input in
-    v <- unpeel [i0;i1;i2;i3]%vector ;;
-    indexAt v sel.
  End WithCava.

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -39,6 +39,7 @@ Require Import Cava.Acorn.Circuit.
 
 Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Lib.FullAdder.
+Require Import Cava.Lib.Multiplexers.
 Require Import Cava.Lib.UnsignedAdders.
 
 Recursive Extraction Library BitArithmetic.
@@ -59,4 +60,5 @@ Recursive Extraction Library CavaPrelude.
 
 Recursive Extraction Library BitVectorOps.
 Recursive Extraction Library FullAdder.
+Recursive Extraction Library Multiplexers.
 Recursive Extraction Library UnsignedAdders.

--- a/cava/Cava/Lib/Multiplexers.v
+++ b/cava/Cava/Lib/Multiplexers.v
@@ -15,11 +15,11 @@
 (****************************************************************************)
 
 Require Import Coq.Vectors.Vector.
-Local Open Scope vector_scope.
 Import VectorNotations.
 
 Require Import ExtLib.Structures.Monads.
 Import MonadNotation.
+Local Open Scope monad_scope.
 
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Signal.
@@ -32,12 +32,15 @@ Section WithCava.
   Definition mux2 {A : SignalType}
              (sel : signal Bit)
              (ab : signal A * signal A) : cava (signal A) :=
-    let (a, b) := ab in
-    indexAt (unpeel [a; b]) (unpeel [sel]).
+    let '(a,b) := ab in
+    v <- unpeel [a;b] ;;
+    i <- unpeel [sel] ;;
+    indexAt v i.
 
   (* 4-element multiplexer *)
   Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
              (sel : signal (Vec Bit 2)) : cava (signal t) :=
     let '(i0,i1,i2,i3) := input in
-    indexAt (unpeel [i0;i1;i2;i3]%vector) sel.
+    v <- unpeel [i0;i1;i2;i3]%vector ;;
+    indexAt v sel.
 End WithCava.

--- a/cava/Cava/Lib/Multiplexers.v
+++ b/cava/Cava/Lib/Multiplexers.v
@@ -20,7 +20,6 @@ Import VectorNotations.
 
 Require Import ExtLib.Structures.Monads.
 Import MonadNotation.
-Local Open Scope monad_scope.
 
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Signal.
@@ -28,12 +27,17 @@ Require Import Cava.Signal.
 Section WithCava.
   Context `{semantics:Cava}.
 
-  (* Constant signals. *)
+  (* A two to one multiplexer that takes its two arguments as a pair rather
+     than as a 2 element vector which is what indexAt works over. *)
+  Definition mux2 {A : SignalType}
+             (sel : signal Bit)
+             (ab : signal A * signal A) : cava (signal A) :=
+    let (a, b) := ab in
+    indexAt (unpeel [a; b]) (unpeel [sel]).
 
-  (* This component always returns the value 0. *)
-  Definition zero : signal Bit := constant false.
-
-  (* This component always returns the value 1. *)
-  Definition one : signal Bit := constant true.
-
+  (* 4-element multiplexer *)
+  Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
+             (sel : signal (Vec Bit 2)) : cava (signal t) :=
+    let '(i0,i1,i2,i3) := input in
+    indexAt (unpeel [i0;i1;i2;i3]%vector) sel.
 End WithCava.

--- a/cava/Cava/Lib/MultiplexersProperties.v
+++ b/cava/Cava/Lib/MultiplexersProperties.v
@@ -15,25 +15,23 @@
 (****************************************************************************)
 
 Require Import Coq.Vectors.Vector.
-Local Open Scope vector_scope.
-Import VectorNotations.
 
-Require Import ExtLib.Structures.Monads.
-Import MonadNotation.
-Local Open Scope monad_scope.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.BitArithmetic.
+Require Import Cava.Acorn.CombinationalProperties.
+Require Import Cava.Lib.Multiplexers.
 
-Require Import Cava.Acorn.CavaClass.
-Require Import Cava.Signal.
+Lemma mux2_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
+  unIdent (mux2 sel (i0, i1)) = if sel then i1 else i0.
+Proof. destruct sel; reflexivity. Qed.
+Hint Rewrite @mux2_correct using solve [eauto] : simpl_ident.
 
-Section WithCava.
-  Context `{semantics:Cava}.
-
-  (* Constant signals. *)
-
-  (* This component always returns the value 0. *)
-  Definition zero : signal Bit := constant false.
-
-  (* This component always returns the value 1. *)
-  Definition one : signal Bit := constant true.
-
-End WithCava.
+Lemma mux4_correct {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
+  unIdent (mux4 (i0,i1,i2,i3) sel) =
+  if Vector.hd (Vector.tl sel)
+  then if Vector.hd sel then i3 else i2
+  else if Vector.hd sel then i1 else i0.
+Proof.
+  cbv in sel. constant_bitvec_cases sel; reflexivity.
+Qed.
+Hint Rewrite @mux4_correct using solve [eauto] : simpl_ident.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -61,6 +61,7 @@ library
                      Logic
                      Monad
                      MonadState
+                     Multiplexers
                      Multistep
                      Netlist
                      NetlistGeneration

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -28,6 +28,7 @@ Require Import Cava.Acorn.CavaPrelude.
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.Circuit.
 Require Import Cava.Acorn.Combinators.
+Require Import Cava.Lib.Multiplexers.
 Import Circuit.Notations.
 
 Local Open Scope monad_scope.

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -72,7 +72,7 @@ Section WithCava.
     (* Intermediate decryption rounds need to mix the key columns *)
     mixed_round_key <- inv_mix_columns_key round_key ;;
 
-    key_to_add <- muxPair round_key_sel (round_key, mixed_round_key) ;;
+    key_to_add <- mux2 round_key_sel (round_key, mixed_round_key) ;;
     out <- add_round_key key_to_add add_round_key_in ;;
 
     ret out.
@@ -106,7 +106,7 @@ Section WithCava.
             let '(is_decrypt, num_rounds_regular,
                   round_0, idx, _, initial_state) := input in
             is_first_round <- idx ==? round_0 ;;
-            st <- muxPair is_first_round (feedback_state, initial_state) ;;
+            st <- mux2 is_first_round (feedback_state, initial_state) ;;
             st' <- cipher_step is_decrypt is_first_round
                              num_rounds_regular k idx st ;;
             ret (st',st'))).

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -238,7 +238,7 @@ Section WithCava.
       en' <- en ;;
       x' <- x ;;
       y' <- y ;;
-      muxPair en' (y',x')) s in
+      mux2 en' (y',x')) s in
     put s.
   Definition setEnSignal1 {T} F {_: Setter F} (en: cava_signal Bit) (x: signal T) : signal_update :=
     setEnSignal F en (ret x).
@@ -251,7 +251,7 @@ Section WithCava.
   Definition mux2Cond {t} (sel : signal Bit) (xy : cava_signal t * cava_signal t) : cava_signal t :=
     x' <- fst xy ;;
     y' <- snd xy ;;
-    muxPair sel (x',y').
+    mux2 sel (x',y').
 
   Definition transition_idle_pre: signal_update :=
     setSignal1 dec_key_gen_d (constant false) ;;
@@ -332,9 +332,9 @@ Section WithCava.
          sel1 <- bitvec_to_signal (nat_to_bitvec_sized 2 1) ;;
          sel2 <- bitvec_to_signal (nat_to_bitvec_sized 2 2) ;;
          cond3' <- cond3 ;;
-         x <- muxPair cond3' (sel0, sel2) ;;
+         x <- mux2 cond3' (sel0, sel2) ;;
          cond2' <- cond2 ;;
-         muxPair cond2' (x, sel1)) in
+         mux2 cond2' (x, sel1)) in
     put (select_state state_matrix sel).
 
   Definition transition_init (inputs: control_inputs): signal_update :=
@@ -401,7 +401,7 @@ Section WithCava.
 
     (* // Select round key: direct or mixed (equivalent inverse cipher) *)
     (* round_key_sel_o = (op_i == CIPH_FWD) ? ROUND_KEY_DIRECT : ROUND_KEY_MIXED; *)
-    setSignal round_key_sel_o (muxPair (op_i inputs) (ROUND_KEY_DIRECT, ROUND_KEY_MIXED)) ;;
+    setSignal round_key_sel_o (mux2 (op_i inputs) (ROUND_KEY_DIRECT, ROUND_KEY_MIXED)) ;;
 
     (* // Update round *)
     (* round_d = round_q + 4'b1; *)
@@ -619,7 +619,7 @@ Section WithCava.
     (* assign key_clear_o      = key_clear_q; *)
     (* assign data_out_clear_o = data_out_clear_q; *)
     key_gen <- or2 (dec_key_gen_d', dec_key_gen_d next_state) ;;
-    key_expand_op_o <- muxPair key_gen (op_i inputs, constant false) ;;
+    key_expand_op_o <- mux2 key_gen (op_i inputs, constant false) ;;
     ret
       ( extend_with_loop_state  ( extract_loop_outputs next_state
         , key_expand_op_o

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -29,7 +29,7 @@ From RecordUpdate Require Import RecordSet.
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Circuit.
 Require Import Cava.Acorn.Acorn.
-Require Import Cava.Acorn.Combinators.
+Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 Require Import AcornAes.SubBytesCircuit.
 Require Import AcornAes.AddRoundKeyCircuit.

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -38,6 +38,7 @@ Require Import Cava.Acorn.Combinational.
 Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Acorn.Identity.
 Require Import Cava.Acorn.Multistep.
+Require Import Cava.Lib.MultiplexersProperties.
 
 Require Import AesSpec.Cipher.
 Require Import AesSpec.CipherProperties.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -97,8 +97,8 @@ Section WithCava.
     (* assign z_muxed[0] = (op_i == CIPH_FWD) ? 8'b0 : z[0]; *)
     (* assign z_muxed[1] = (op_i == CIPH_FWD) ? 8'b0 : z[1]; *)
     zero_byte <- zero_byte ;;
-    z_muxed_0 <- muxPair op_i (zero_byte, z_0) ;;
-    z_muxed_1 <- muxPair op_i (zero_byte, z_1) ;;
+    z_muxed_0 <- mux2 op_i (zero_byte, z_0) ;;
+    z_muxed_1 <- mux2 op_i (zero_byte, z_1) ;;
 
     (* // Drive outputs *)
     (* assign data_o[0] = data_i[1] ^ x_mul2[3] ^ x[1] ^ z_muxed[1]; *)

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -23,6 +23,7 @@ Require Import ExtLib.Structures.Traversable.
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.BitVectorOps.
+Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 
 Local Notation byte := (Vec Bit 8) (only parsing).

--- a/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
@@ -27,6 +27,7 @@ Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Acorn.Identity.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.BitVectorOps.
+Require Import Cava.Lib.MultiplexersProperties.
 Import ListNotations VectorNotations.
 Local Open Scope list_scope.
 

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -52,14 +52,14 @@ Section WithCava.
   (*                                       : aes_circ_byte_shift(data_i[1], 2'h1); *)
   data_o_1_0 <- aes_circ_byte_shift 3 data_i_1 ;;
   data_o_1_1 <- aes_circ_byte_shift 1 data_i_1 ;;
-  data_o_1 <- muxPair op_i (data_o_1_0, data_o_1_1) ;;
+  data_o_1 <- mux2 op_i (data_o_1_0, data_o_1_1) ;;
 
   (* // Row 3 *)
   (* assign data_o[3] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[3], 2'h1) *)
   (*                                       : aes_circ_byte_shift(data_i[3], 2'h3); *)
   data_o_3_0 <- aes_circ_byte_shift 1 data_i_3 ;;
   data_o_3_1 <- aes_circ_byte_shift 3 data_i_3 ;;
-  data_o_3 <- muxPair op_i (data_o_3_0, data_o_3_1) ;;
+  data_o_3 <- mux2 op_i (data_o_3_0, data_o_3_1) ;;
 
   unpeel [data_o_0; data_o_1; data_o_2; data_o_3].
 

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -21,6 +21,7 @@ Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 
 Local Notation byte := (Vec Bit 8) (only parsing).

--- a/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
@@ -22,6 +22,7 @@ Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 Import Pkg.Notations.
 

--- a/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
@@ -147,7 +147,7 @@ Section WithCava.
     inv_sbox <- sbox_inv_lut ;;
     encrypted <- indexAt fwd_sbox b ;;
     decrypted <- indexAt inv_sbox b ;;
-    muxPair is_decrypt (encrypted, decrypted).
+    mux2 is_decrypt (encrypted, decrypted).
 
   Definition aes_sub_bytes (is_decrypt : signal Bit) (b : signal state)
     : cava (signal state) :=

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -27,6 +27,7 @@ Export MonadNotation.
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.UnsignedAdders.
+Require Import Cava.Lib.Multiplexers.
 Import Circuit.Notations.
 
 (******************************************************************************)

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -91,7 +91,7 @@ Section WithCava.
                >==>
                Comb (fun '(carry1, acc2) =>
                        acc2p1 <- incrN acc2 ;;
-                       out <- muxPair carry1 (acc2, acc2p1) ;;
+                       out <- mux2 carry1 (acc2, acc2p1) ;;
                        ret (out, out))).
 End WithCava.
 

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -32,6 +32,7 @@ Require Import Cava.Acorn.Acorn.
 Require Import Cava.Acorn.Identity.
 Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Lib.UnsignedAdders.
+Require Import Cava.Lib.MultiplexersProperties.
 
 Require Import DoubleCountBy.DoubleCountBy.
 

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -23,6 +23,7 @@ Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Lib.Multiplexers.
 
 Require Import Coq.Bool.Bvector.
 Import Vector.VectorNotations.

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -33,9 +33,9 @@ Existing Instance CavaCombinationalNet.
 Section WithCava.
   Context {signal} `{Cava signal}.
 
-  (* muxPair specialized to single bit inputs *)
+  (* mux2 specialized to single bit inputs *)
   Definition mux2_1: signal Bit -> signal Bit * signal Bit -> cava (signal Bit)
-  := muxPair.
+  := mux2.
 
   Definition mux2_1_top '(sel, a, b) := mux2_1 sel (a, b).
 
@@ -53,7 +53,7 @@ End WithCava.
 Local Close Scope vector_scope.
 
 (******************************************************************************)
-(* muxPair tests                                                              *)
+(* mux2 tests                                                                 *)
 (******************************************************************************)
 
 Definition mux2_1_tb_inputs :=


### PR DESCRIPTION
A bit of cleanup. Now that we don't need `muxPair` to define loops, we can move it back to `Lib` (and move `mux4` there too). And since we don't have pairs any more, I renamed `muxPair` to `mux2`.

Resolves #450