### PR TITLE
Vec library

### DIFF
--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -27,6 +27,8 @@ Require Import Cava.BitArithmetic.
 Require Import Cava.NatUtils.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
+Require Import Cava.Lib.VecProperties.
+Require Cava.Lib.Vec.
 Import VectorNotations ListNotations MonadNotation.
 Open Scope monad_scope.
 Open Scope list_scope.
@@ -80,13 +82,11 @@ Section WithCava.
           signal (Vec Bit sz0) -> cava (signal (Vec Bit sz0)) with
     | 0 => fun input => ret input
     | S sz' => fun input : signal (Vec Bit (S sz')) =>
-                i <- peel input ;;
-                let i0 := Vector.hd i in
+                i0 <- Vec.hd input ;;
+                rem <- Vec.tl input ;;
                 '(sum0, carry) <- half_adder (carry, i0) ;;
-                rem <- unpeel (Vector.tl i) ;;
-                sum' <- incr' carry rem ;;
-                sum <- peel sum' ;;
-                unpeel (sum0 :: sum)%vector
+                sum <- incr' carry rem ;;
+                Vec.cons sum0 sum
     end.
 
   (* increments a bit vector of any length *)
@@ -99,13 +99,11 @@ Section WithCava.
           signal (Vec Bit sz0) -> cava (signal (Vec Bit sz0)) with
     | 0 => fun input => ret input
     | S sz' => fun input : signal (Vec Bit (S sz')) =>
-                i <- peel input ;;
-                let i0 := Vector.hd i in
+                i0 <- Vec.hd input ;;
+                rem <- Vec.tl input ;;
                 '(diff0, borrow) <- half_subtractor (i0, borrow) ;;
-                rem <- unpeel (Vector.tl i) ;;
-                diff' <- decr' borrow rem ;;
-                diff <- peel diff' ;;
-                unpeel (diff0 :: diff)%vector
+                diff <- decr' borrow rem ;;
+                Vec.cons diff0 diff
     end.
 
   (* decrements a bit vector of any length *)

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -41,6 +41,7 @@ Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Lib.FullAdder.
 Require Import Cava.Lib.Multiplexers.
 Require Import Cava.Lib.UnsignedAdders.
+Require Import Cava.Lib.Vec.
 
 Recursive Extraction Library BitArithmetic.
 Recursive Extraction Library Cava.
@@ -62,3 +63,4 @@ Recursive Extraction Library BitVectorOps.
 Recursive Extraction Library FullAdder.
 Recursive Extraction Library Multiplexers.
 Recursive Extraction Library UnsignedAdders.
+Recursive Extraction Library Vec.

--- a/cava/Cava/Lib/Vec.v
+++ b/cava/Cava/Lib/Vec.v
@@ -1,0 +1,118 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Coq.Vectors.Vector.
+Require Import ExtLib.Structures.Monads.
+Require Import Cava.Cava.
+Require Import Cava.VectorUtils.
+Require Import Cava.Acorn.Acorn.
+Import MonadNotation.
+Import Vector.VectorNotations.
+Local Open Scope monad_scope.
+Local Open Scope vector_scope.
+
+Section WithCava.
+  Context `{semantics:Cava}.
+
+  Definition bitvec_literal {n} (v : Vector.t bool n)
+    : cava (signal (Vec Bit n)) :=
+    unpeel (Vector.map constant v).
+
+  Definition nil {A} : cava (signal (Vec A 0)) :=
+    unpeel [].
+
+  Definition cons {A n} (a : signal A) (v : signal (Vec A n))
+    : cava (signal (Vec A (S n))) :=
+    v <- peel v ;;
+    unpeel (a :: v).
+
+  Definition tl {A n} (v : signal (Vec A (S n))) : cava (signal (Vec A n)) :=
+    v <- peel v ;;
+    unpeel (Vector.tl v).
+
+  Definition hd {A n} (v : signal (Vec A (S n))) : cava (signal A) :=
+    v <- peel v ;;
+    ret (Vector.hd v).
+
+  Definition const {A} (x : signal A) n
+    : cava (signal (Vec A n)) :=
+    unpeel (Vector.const x n).
+
+  Definition rev {A n} (v : signal (Vec A n))
+    : cava (signal (Vec A n)) :=
+    v <- peel v ;;
+    unpeel (Vector.rev v).
+
+  Fixpoint fold_left {A B}
+             (f : B * signal A -> cava B)
+             {n}
+    : signal (Vec A n) -> B -> cava B :=
+    match n with
+    | 0 => fun v st => ret st
+    | S n => fun v st =>
+              v0 <- hd v ;;
+              st' <- f (st, v0) ;;
+              v' <- tl v ;;
+              fold_left f v' st'
+    end.
+
+  Fixpoint fold_left2 {A B C}
+             (f : C * signal A * signal B -> cava C)
+             {n}
+    : signal (Vec A n) -> signal (Vec B n) -> C -> cava C :=
+    match n with
+    | 0 => fun va vb st => ret st
+    | S n => fun va vb st =>
+              va0 <- hd va ;;
+              vb0 <- hd vb ;;
+              st' <- f (st, va0, vb0) ;;
+              va' <- tl va ;;
+              vb' <- tl vb ;;
+              fold_left2 f va' vb' st'
+    end.
+
+  Definition last {A n} (v : signal (Vec A (S n)))
+    : cava (signal A) :=
+    v <- peel v ;;
+    ret (Vector.last v).
+
+  Definition shiftin {A n} (x : signal A) (v : signal (Vec A n))
+    : cava (signal (Vec A (S n))) :=
+    v <- peel v ;;
+    unpeel (Vector.shiftin x v).
+
+  Definition shiftout {A n} (v : signal (Vec A (S n)))
+    : cava (signal (Vec A n)) :=
+    v <- peel v ;;
+    unpeel (Vector.shiftout v).
+
+  Definition map {A B n} (f : signal A -> cava (signal B))
+             (v : signal (Vec A n))
+    : cava (signal (Vec B n)) :=
+    v <- peel v ;;
+    out <- Traversable.mapT f v ;;
+    unpeel out.
+
+  Definition map2 {A B C n}
+             (f : signal A * signal B -> cava (signal C))
+             (va : signal (Vec A n)) (vb : signal (Vec B n))
+    : cava (signal (Vec C n)) :=
+    va <- peel va ;;
+    vb <- peel vb ;;
+    out <- Traversable.mapT f (vcombine va vb) ;;
+    unpeel out.
+
+End WithCava.

--- a/cava/Cava/Lib/Vec.v
+++ b/cava/Cava/Lib/Vec.v
@@ -56,6 +56,28 @@ Section WithCava.
     v <- peel v ;;
     unpeel (Vector.rev v).
 
+  Definition last {A n} (v : signal (Vec A (S n)))
+    : cava (signal A) :=
+    v <- peel v ;;
+    ret (Vector.last v).
+
+  Definition shiftin {A n} (x : signal A) (v : signal (Vec A n))
+    : cava (signal (Vec A (S n))) :=
+    v <- peel v ;;
+    unpeel (Vector.shiftin x v).
+
+  Definition shiftout {A n} (v : signal (Vec A (S n)))
+    : cava (signal (Vec A n)) :=
+    v <- peel v ;;
+    unpeel (Vector.shiftout v).
+
+  Definition transpose {A n m} (v : signal (Vec (Vec A n) m))
+    : cava (signal (Vec (Vec A m) n)) :=
+    v <- peel v ;;
+    v <- Traversable.mapT peel v ;;
+    v <- Traversable.mapT unpeel (transpose v) ;;
+    unpeel v.
+
   Fixpoint fold_left {A B}
              (f : B * signal A -> cava B)
              {n}
@@ -84,21 +106,6 @@ Section WithCava.
               fold_left2 f va' vb' st'
     end.
 
-  Definition last {A n} (v : signal (Vec A (S n)))
-    : cava (signal A) :=
-    v <- peel v ;;
-    ret (Vector.last v).
-
-  Definition shiftin {A n} (x : signal A) (v : signal (Vec A n))
-    : cava (signal (Vec A (S n))) :=
-    v <- peel v ;;
-    unpeel (Vector.shiftin x v).
-
-  Definition shiftout {A n} (v : signal (Vec A (S n)))
-    : cava (signal (Vec A n)) :=
-    v <- peel v ;;
-    unpeel (Vector.shiftout v).
-
   Definition map {A B n} (f : signal A -> cava (signal B))
              (v : signal (Vec A n))
     : cava (signal (Vec B n)) :=
@@ -114,5 +121,4 @@ Section WithCava.
     vb <- peel vb ;;
     out <- Traversable.mapT f (vcombine va vb) ;;
     unpeel out.
-
 End WithCava.

--- a/cava/Cava/Lib/VecProperties.v
+++ b/cava/Cava/Lib/VecProperties.v
@@ -1,0 +1,136 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Cava.Cava.
+Require Import Cava.Tactics.
+Require Import Cava.VectorUtils.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Identity.
+Require Coq.Vectors.Vector.
+Require Cava.Lib.Vec.
+Import Vector.VectorNotations.
+Local Open Scope vector_scope.
+
+Existing Instance CombinationalSemantics.
+
+Local Ltac crush :=
+  (* inline Vec definition *)
+  lazymatch goal with
+  | |- unIdent ?x = _ =>
+    let f := app_head x in cbv [f]
+  end;
+  simpl_ident; eauto using map_id_ext.
+
+
+Lemma bitvec_literal_correct n (v : Vector.t bool n) :
+  unIdent (Vec.bitvec_literal v) = v.
+Proof. crush. Qed.
+Hint Rewrite @bitvec_literal_correct using solve [eauto] : simpl_ident.
+
+Lemma nil_correct A :
+  unIdent (@Vec.nil _ _ A) = [].
+Proof. crush. Qed.
+Hint Rewrite @nil_correct using solve [eauto] : simpl_ident.
+
+Lemma cons_correct A n x (v : combType (Vec A n)) :
+  unIdent (Vec.cons x v) = (x :: v).
+Proof. crush. Qed.
+Hint Rewrite @cons_correct using solve [eauto] : simpl_ident.
+
+Lemma tl_correct A n (v : combType (Vec A (S n))) :
+  unIdent (Vec.tl v) = Vector.tl v.
+Proof. crush. Qed.
+Hint Rewrite @tl_correct using solve [eauto] : simpl_ident.
+
+Lemma hd_correct A n (v : combType (Vec A (S n))) :
+  unIdent (Vec.hd v) = Vector.hd v.
+Proof. crush. Qed.
+Hint Rewrite @hd_correct using solve [eauto] : simpl_ident.
+
+Lemma const_correct A (x : combType A) n :
+  unIdent (Vec.const x n) = Vector.const x n.
+Proof. crush. Qed.
+Hint Rewrite @const_correct using solve [eauto] : simpl_ident.
+
+Lemma rev_correct A n (v : combType (Vec A (S n))) :
+  unIdent (Vec.rev v) = Vector.rev v.
+Proof. crush. Qed.
+Hint Rewrite @rev_correct using solve [eauto] : simpl_ident.
+
+Lemma last_correct A n (v : combType (Vec A (S n))) :
+  unIdent (Vec.last v) = Vector.last v.
+Proof. crush. Qed.
+Hint Rewrite @last_correct using solve [eauto] : simpl_ident.
+
+Lemma shiftin_correct A n x (v : combType (Vec A n)) :
+  unIdent (Vec.shiftin x v) = (Vector.shiftin x v).
+Proof. crush. Qed.
+Hint Rewrite @shiftin_correct using solve [eauto] : simpl_ident.
+
+Lemma shiftout_correct A n (v : combType (Vec A (S n))) :
+  unIdent (Vec.shiftout v) = Vector.shiftout v.
+Proof. crush. Qed.
+Hint Rewrite @shiftout_correct using solve [eauto] : simpl_ident.
+
+Lemma transpose_correct A n m (v : combType (Vec (Vec A n) m)) :
+  unIdent (Vec.transpose v) = transpose v.
+Proof.
+  crush. rewrite !Vector.map_id; reflexivity.
+Qed.
+Hint Rewrite @transpose_correct using solve [eauto] : simpl_ident.
+
+Lemma fold_left_correct A B n f b v :
+  unIdent (@Vec.fold_left _ _ A B f n v b)
+  = Vector.fold_left (fun x y => unIdent (f (x,y))) b v.
+Proof.
+  revert v b; induction n; intros;
+    [ apply Vector.case0 with (v:=v); reflexivity | ].
+  rewrite (Vector.eta v).
+  cbn [Vec.fold_left Vector.fold_left].
+  simpl_ident. autorewrite with vsimpl.
+  rewrite IHn. reflexivity.
+Qed.
+Hint Rewrite @fold_left_correct using solve [eauto] : simpl_ident.
+
+Lemma fold_left2_correct A B C n f c va vb :
+  unIdent (@Vec.fold_left2 _ _ A B C f n va vb c)
+  = Vector.fold_left2 (fun x y z => unIdent (f (x,y,z))) c va vb.
+Proof.
+  revert va vb c; induction n; intros;
+    [ apply Vector.case0 with (v:=va);
+      apply Vector.case0 with (v:=vb);
+      reflexivity | ].
+  rewrite (Vector.eta va), (Vector.eta vb).
+  cbn [Vec.fold_left2 Vector.fold_left2].
+  simpl_ident. autorewrite with vsimpl.
+  rewrite IHn. reflexivity.
+Qed.
+Hint Rewrite @fold_left2_correct using solve [eauto] : simpl_ident.
+
+Lemma map_correct A B n f v :
+  unIdent (@Vec.map _ _ A B n f v)
+  = Vector.map (fun x => unIdent (f x)) v.
+Proof. crush. Qed.
+Hint Rewrite @map_correct using solve [eauto] : simpl_ident.
+
+Lemma map2_correct A B C n f va vb :
+  unIdent (@Vec.map2 _ _ A B C n f va vb)
+  = Vector.map2 (fun x y => unIdent (f (x,y))) va vb.
+Proof.
+  crush. rewrite map_vcombine_map2.
+  reflexivity.
+Qed.
+Hint Rewrite @map2_correct using solve [eauto] : simpl_ident.

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -29,6 +29,10 @@ Require Export ExtLib.Data.Monads.IdentityMonad.
 
 Require Cava.ListUtils.
 
+(* automatically interpret arguments expected to have type Vector.t in
+   vector_scope *)
+Bind Scope vector_scope with Vector.t.
+
 Section traversable.
   Universe u v vF.
   Context {F : Type@{v} -> Type@{vF}}.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -72,6 +72,7 @@ library
                      StateMonad
                      Traversable
                      UnsignedAdders
+                     Vec
                      VectorDef
                      Vector
                      VectorUtils

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -66,9 +66,7 @@ Section WithCava.
 
   Definition add_round (a b: signal round_index): cava (signal round_index) :=
     sum <- (@unsignedAdd _ _ 4 4 (a, b)) ;;
-    sum <- peel sum ;;
-    let '(trunc,_) := unsnoc sum in
-    unpeel trunc.
+    Vec.shiftout sum.
 
   Definition inc_round (current: signal round_index): cava (signal round_index)
     := round_1 <- round_1 ;; add_round current round_1.

--- a/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
@@ -43,7 +43,7 @@ Definition aes_mix_columns' x y :=
 Definition aes_sbox_lut' x y :=
   blackBoxNet aes_sbox_lut_Interface (x, y).
 Definition aes_sub_bytes' (is_decrypt : Signal Bit) (b : Signal state)
-  : cava (Signal state) := state_map (aes_sbox_lut' is_decrypt) b.
+  : cava (Signal state) := Vec.map (Vec.map (aes_sbox_lut' is_decrypt)) b.
 
 Definition inv_mix_columns_key := aes_mix_columns' (constant true).
 

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -133,9 +133,7 @@ Section WithCava.
     end
 
     assign data_o = aes_transpose(data_o_transposed); *)
-    aes_transpose >=> peel
-                  >=> mapT (aes_mix_single_column op_i)
-                  >=> unpeel
+    aes_transpose >=> Vec.map (aes_mix_single_column op_i)
                   >=> aes_transpose.
 
 End WithCava.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
@@ -28,6 +28,7 @@ Require Import Cava.Acorn.Identity.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Lib.MultiplexersProperties.
+Require Import Cava.Lib.VecProperties.
 Import ListNotations VectorNotations.
 Local Open Scope list_scope.
 
@@ -47,16 +48,8 @@ Section Equivalence.
   Local Notation key := (Vector.t (Vector.t byte 4) 4) (only parsing).
 
   Lemma aes_transpose_correct n m (v : combType (Vec (Vec (Vec Bit 8) n) m)) :
-    m <> 0 ->
-    n <> 0 ->
     unIdent (aes_transpose v) = transpose v.
-  Proof.
-    intros Hm Hn.
-    unfold aes_transpose.
-    simpl_ident.
-    rewrite ! map_id.
-    reflexivity.
-  Qed.
+  Proof. cbv [aes_transpose]; simpl_ident; reflexivity. Qed.
 
   Lemma poly_to_byte_to_bitvec p :
     length p = 8 -> byte_to_bitvec (MixColumns.poly_to_byte p) = of_list_sized false 8 p.

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -25,6 +25,7 @@ Require Import ExtLib.Structures.Traversable.
 Require Import Cava.VectorUtils.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.BitVectorOps.
+Require Cava.Lib.Vec.
 Require Import Cava.Signal.
 Require Import AesSpec.StateTypeConversions.
 Require Import AesSpec.Tests.CipherTest.
@@ -60,7 +61,7 @@ Section WithCava.
   Context {signal} {semantics : Cava signal}.
 
   Definition bitvec_to_signal {n : nat} (lut : t bool n) : cava (signal (Vec Bit n)) :=
-    unpeel (Vector.map constant lut).
+    Vec.bitvec_literal lut.
 
   Definition bitvecvec_to_signal {a b : nat} (lut : t (t bool b) a) : cava (signal (Vec (Vec Bit b) a)) :=
     v <- mapT bitvec_to_signal lut ;;
@@ -72,11 +73,8 @@ Section WithCava.
 
   Definition aes_transpose {n m}
       (matrix : signal (Vec (Vec byte n) m))
-      : cava (signal (Vec (Vec byte m) n)) :=
-    columns <- peel matrix ;;
-    items <- mapT peel columns ;;
-    columns <- mapT unpeel (transpose items) ;;
-    unpeel columns.
+    : cava (signal (Vec (Vec byte m) n)) :=
+    Vec.transpose matrix.
 
   Definition aes_mul2
     (x : signal byte)
@@ -110,7 +108,7 @@ Section WithCava.
     : signal byte -> cava (signal byte) :=
     aes_mul2 >=> aes_mul2.
 
-  Definition zero_byte : cava (signal byte) := unpeel (Vector.const zero 8).
+  Definition zero_byte : cava (signal byte) := Vec.const (constant false) 8.
 
   (* function automatic logic [31:0] aes_circ_byte_shift(logic [31:0] in, logic [1:0] shift);
     logic [31:0] out;

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -108,7 +108,7 @@ Section WithCava.
     : signal byte -> cava (signal byte) :=
     aes_mul2 >=> aes_mul2.
 
-  Definition zero_byte : cava (signal byte) := Vec.const (constant false) 8.
+  Definition zero_byte : cava (signal byte) := Vec.const zero 8.
 
   (* function automatic logic [31:0] aes_circ_byte_shift(logic [31:0] in, logic [1:0] shift);
     logic [31:0] out;

--- a/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
@@ -23,6 +23,7 @@ Require Import ExtLib.Structures.Monads.
 Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.Multiplexers.
+Require Cava.Lib.Vec.
 Require Import AcornAes.Pkg.
 Import Pkg.Notations.
 
@@ -134,14 +135,6 @@ Section WithCava.
   Definition sbox_fwd_lut := natvec_to_signal_sized 8 sbox_fwd.
   Definition sbox_inv_lut := natvec_to_signal_sized 8 sbox_inv.
 
-  Definition column_map (f : signal (Vec Bit 8) -> cava (signal (Vec Bit 8)))
-    : signal (Vec (Vec Bit 8) 4) -> cava (signal (Vec (Vec Bit 8) 4)) :=
-    peel >=> Traversable.mapT f >=> unpeel.
-
-  Definition state_map (f : signal (Vec Bit 8) -> cava (signal (Vec Bit 8)))
-    : signal state -> cava (signal state) :=
-    peel >=> Traversable.mapT (column_map f) >=> unpeel.
-
   Definition aes_sbox_lut (is_decrypt : signal Bit) (b : signal (Vec Bit 8))
     : cava (signal (Vec Bit 8)) :=
     fwd_sbox <- sbox_fwd_lut ;;
@@ -152,5 +145,5 @@ Section WithCava.
 
   Definition aes_sub_bytes (is_decrypt : signal Bit) (b : signal state)
     : cava (signal state) :=
-    state_map (aes_sbox_lut is_decrypt) b.
+    Vec.map (Vec.map (aes_sbox_lut is_decrypt)) b.
 End WithCava.

--- a/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
@@ -19,6 +19,7 @@ Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Acorn.Identity.
 Require Import Cava.BitArithmetic.
 Require Import Cava.Lib.BitVectorOps.
+Require Import Cava.Lib.VecProperties.
 Require Import Cava.ListUtils.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
@@ -76,19 +77,6 @@ Section Equivalence.
     destruct is_decrypt; auto using sub_bytes_fwd_bytewise, sub_bytes_inv_bytewise.
   Qed.
 
-  Lemma map_interchange :
-    forall (st : state) (f : byte -> ident byte),
-    unIdent (@state_map combType _ f st) = map (map (fun b => unIdent (f b))) st.
-  Proof.
-    intros.
-    unfold state_map.
-    unfold column_map.
-    unfold mcompose.
-
-    do 2 (simpl_ident; apply map_ext; intros).
-    reflexivity.
-  Qed.
-
   Lemma sub_bytes_equiv :
     forall (is_decrypt : bool) (st : state),
       unIdent (aes_sub_bytes is_decrypt st)
@@ -103,9 +91,8 @@ Section Equivalence.
          AES256.sub_bytes
          AesSpec.SubBytes.sub_bytes].
 
-    rewrite (map_interchange
-                st
-                (@aes_sbox_lut combType Combinational.CombinationalSemantics is_decrypt)).
+    simpl_ident.
+    erewrite map_ext; [ | intros; simpl_ident; reflexivity ].
 
     cbv [from_flat
          to_flat

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -28,6 +28,7 @@ Require Import Cava.Cava.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Lib.UnsignedAdders.
 Require Import Cava.Lib.Multiplexers.
+Require Cava.Lib.Vec.
 Import Circuit.Notations.
 
 (******************************************************************************)
@@ -75,10 +76,9 @@ Section WithCava.
   (* incrementer *)
   Definition incrN {n} (x : signal (Vec Bit (S n)))
     : cava (signal (Vec Bit (S n))) :=
-    one <- unpeel [one]%vector ;;
-    xp1 <- unsignedAdd (one, x) ;;
-    xp1 <- peel xp1 ;;
-    unpeel (shiftout xp1).
+    onev <- Vec.bitvec_literal [true] ;;
+    xp1 <- unsignedAdd (onev, x) ;;
+    Vec.shiftout xp1.
 
   Definition count_by
     : Circuit (signal (Vec Bit 8)) (signal Bit)


### PR DESCRIPTION
While trying to write a tutorial for Cava, I noticed myself writing some boilterplate `peel`s and `unpeel`s that followed similar patterns -- convert to `Vector.t`, do a vector operation, and then convert back to `Vec`. I've had the thought before that it would be nice if we had a clean library with all the `Vector.t` operations we need that does the `peel` and `unpeel` work in the background, so here it is. Now, instead of `peel >=> mapT f >=> unpeel`, you can write `Vec.map f`, and instead of `v' <- peel v ;; unpeel (x :: v')` you can write `Vec.cons x v`, and so on. There's also `Vec.bitvec_literal` for quick literal bit-vectors. The `simpl_ident` tactic will convert these definitions back to `Vector.t` automatically in proofs.

- Defines circuits for all of the `Vector.t` operations (there aren't that many) on `Vec` (in `Cava/Lib/Vec.v`)
- Proves the circuits equivalent to the standard library implementations
- Adjusts tests, examples, and AES circuits to use the `Vec` implementations