### PR TITLE
Rename peel/unpeel to packv and unpackv

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -48,7 +48,7 @@ Section WithCava.
              (n: nat)
     : signal (Vec (Vec Bit sz) (2^(S n))) ->
       cava (signal (Vec Bit sz)) :=
-    peel >=> treeS addN.
+    unpackv >=> treeS addN.
 
   (* An adder tree with 2 inputs. *)
   Definition adderTree2 {sz: nat}

--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -48,7 +48,7 @@ Section WithCava.
              (n: nat)
     : signal (Vec (Vec Bit sz) (2^(S n))) ->
       cava (signal (Vec Bit sz)) :=
-    unpackv >=> treeS addN.
+    unpackV >=> treeS addN.
 
   (* An adder tree with 2 inputs. *)
   Definition adderTree2 {sz: nat}

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -61,7 +61,7 @@ Section WithCava.
     '(sum1, carry) <- half_adder (carry, i1) ;;
     '(sum2, carry) <- half_adder (carry, i2) ;;
     '(sum3, carry) <- half_adder (carry, i3) ;;
-    unpeel [sum0;sum1;sum2;sum3]%vector.
+    packv [sum0;sum1;sum2;sum3]%vector.
 
   (* decrement a 4-bit vector *)
   Definition decr4 (input : signal (Vec Bit 4))
@@ -74,7 +74,7 @@ Section WithCava.
     '(diff1, borrow) <- half_subtractor (i1, borrow) ;;
     '(diff2, borrow) <- half_subtractor (i2, borrow) ;;
     '(diff3, borrow) <- half_subtractor (i3, borrow) ;;
-    unpeel [diff0;diff1;diff2;diff3]%vector.
+    packv [diff0;diff1;diff2;diff3]%vector.
 
   Fixpoint incr' {sz} (carry : signal Bit)
     : signal (Vec Bit sz) -> cava (signal (Vec Bit sz)) :=
@@ -126,7 +126,7 @@ Section Proofs.
     unIdent (incr4 input) = N2Bv_sized 4 (Bv2N input + 1).
   Proof.
     cbv [incr4]. simpl_ident. boolsimpl.
-    cbn [unpeel indexConst CombinationalSemantics].
+    cbn [packv indexConst CombinationalSemantics].
     cbn [combType] in input. constant_bitvec_cases input.
     all:reflexivity.
   Qed.

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -61,7 +61,7 @@ Section WithCava.
     '(sum1, carry) <- half_adder (carry, i1) ;;
     '(sum2, carry) <- half_adder (carry, i2) ;;
     '(sum3, carry) <- half_adder (carry, i3) ;;
-    packv [sum0;sum1;sum2;sum3]%vector.
+    packV [sum0;sum1;sum2;sum3]%vector.
 
   (* decrement a 4-bit vector *)
   Definition decr4 (input : signal (Vec Bit 4))
@@ -74,7 +74,7 @@ Section WithCava.
     '(diff1, borrow) <- half_subtractor (i1, borrow) ;;
     '(diff2, borrow) <- half_subtractor (i2, borrow) ;;
     '(diff3, borrow) <- half_subtractor (i3, borrow) ;;
-    packv [diff0;diff1;diff2;diff3]%vector.
+    packV [diff0;diff1;diff2;diff3]%vector.
 
   Fixpoint incr' {sz} (carry : signal Bit)
     : signal (Vec Bit sz) -> cava (signal (Vec Bit sz)) :=
@@ -126,7 +126,7 @@ Section Proofs.
     unIdent (incr4 input) = N2Bv_sized 4 (Bv2N input + 1).
   Proof.
     cbv [incr4]. simpl_ident. boolsimpl.
-    cbn [packv indexConst CombinationalSemantics].
+    cbn [packV indexConst CombinationalSemantics].
     cbn [combType] in input. constant_bitvec_cases input.
     all:reflexivity.
   Qed.

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -47,7 +47,7 @@ Section WithCava.
    negComparison <- inv comparison ;;
    out0 <- mux2 comparison (a, b) ;;
    out1 <- mux2 negComparison (a, b) ;;
-   unpeel [out0; out1].
+   packv [out0; out1].
 
 End WithCava.
 

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -47,7 +47,7 @@ Section WithCava.
    negComparison <- inv comparison ;;
    out0 <- mux2 comparison (a, b) ;;
    out1 <- mux2 negComparison (a, b) ;;
-   packv [out0; out1].
+   packV [out0; out1].
 
 End WithCava.
 

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -43,7 +43,7 @@ Section WithCava.
              (n: nat)
     : signal (Vec (Vec Bit sz) (2^(S n))) ->
       cava (signal (Vec Bit sz)) :=
-    unpackv >=> tree defaultSignal n xilinxAdder.
+    unpackV >=> tree defaultSignal n xilinxAdder.
 
   (****************************************************************************)
   (* An adder tree with 2 inputs.                                             *)

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -43,7 +43,7 @@ Section WithCava.
              (n: nat)
     : signal (Vec (Vec Bit sz) (2^(S n))) ->
       cava (signal (Vec Bit sz)) :=
-    peel >=> tree defaultSignal n xilinxAdder.
+    unpackv >=> tree defaultSignal n xilinxAdder.
 
   (****************************************************************************)
   (* An adder tree with 2 inputs.                                             *)

--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -53,8 +53,8 @@ Class Cava (signal : SignalType -> Type) := {
   xorcy : signal Bit * signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
   muxcy : signal Bit -> signal  Bit -> signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
   (* Converting to/from Vector.t *)
-  peel : forall {t : SignalType} {s : nat}, signal (Vec t s) -> cava (Vector.t (signal t) s);
-  unpeel : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> cava (signal (Vec t s));
+  unpackv : forall {t : SignalType} {s : nat}, signal (Vec t s) -> cava (Vector.t (signal t) s);
+  packv : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> cava (signal (Vec t s));
   indexAt : forall {t : SignalType} {sz isz: nat},
             signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
             signal (Vec Bit isz) ->  (* A bit-vector index of size isz bits *)

--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -53,8 +53,8 @@ Class Cava (signal : SignalType -> Type) := {
   xorcy : signal Bit * signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
   muxcy : signal Bit -> signal  Bit -> signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
   (* Converting to/from Vector.t *)
-  unpackv : forall {t : SignalType} {s : nat}, signal (Vec t s) -> cava (Vector.t (signal t) s);
-  packv : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> cava (signal (Vec t s));
+  unpackV : forall {t : SignalType} {s : nat}, signal (Vec t s) -> cava (Vector.t (signal t) s);
+  packV : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> cava (signal (Vec t s));
   indexAt : forall {t : SignalType} {sz isz: nat},
             signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
             signal (Vec Bit isz) ->  (* A bit-vector index of size isz bits *)

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -61,8 +61,8 @@ Instance CombinationalSemantics : Cava combType :=
     lut6 := fun f '(a,b,c,d,e,g) => ret (f a b c d e g);
     xorcy := fun '(x,y) => ret (xorb x y);
     muxcy := fun sel x y => ret (if sel then x else y);
-    unpackv _ _ v := ret v;
-    packv _ _ v := ret v;
+    unpackV _ _ v := ret v;
+    packV _ _ v := ret v;
     indexAt t sz isz := fun v sel => ret (nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v);
     indexConst t sz := fun v sel => ret (nth_default (defaultCombValue _) sel v);
     slice t sz startAt len v H := ret (sliceVector v startAt len H);

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -61,8 +61,8 @@ Instance CombinationalSemantics : Cava combType :=
     lut6 := fun f '(a,b,c,d,e,g) => ret (f a b c d e g);
     xorcy := fun '(x,y) => ret (xorb x y);
     muxcy := fun sel x y => ret (if sel then x else y);
-    peel _ _ v := ret v;
-    unpeel _ _ v := ret v;
+    unpackv _ _ v := ret v;
+    packv _ _ v := ret v;
     indexAt t sz isz := fun v sel => ret (nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v);
     indexConst t sz := fun v sel => ret (nth_default (defaultCombValue _) sel v);
     slice t sz startAt len v H := ret (sliceVector v startAt len H);

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -73,10 +73,10 @@ Section WithCava.
            (a : signal (Vec A n))
            (b : signal (Vec B n))
            : cava (signal (Vec C n)) :=
-    a' <- peel a ;;
-    b' <- peel b ;;
+    a' <- unpackv a ;;
+    b' <- unpackv b ;;
     v <- mapT f (vcombine a' b') ;;
-    unpeel v.
+    packv v.
 
   (* A list-based left monadic-fold. *)
   Fixpoint foldLM {m} `{Monad m} {A B : Type}
@@ -259,9 +259,9 @@ Section WithCava.
                (circuit : signal A * signal B -> cava (signal C * signal A))
                (aIn: signal A) (bIn: signal (Vec B n)) :
                cava (signal (Vec C n) * signal A) :=
-  b <- peel bIn ;;
+  b <- unpackv bIn ;;
   '(c, a) <- colV circuit (aIn, b) ;;
-  cOut <- unpeel c ;;
+  cOut <- packv c ;;
   ret (cOut, a).
 
   Local Close Scope vector_scope.
@@ -609,7 +609,7 @@ Section WithCava.
   Qed.
 
   Definition all {n} (v : signal (Vec Bit n)) : cava (signal Bit) :=
-    v <- peel v ;;
+    v <- unpackv v ;;
     tree_all_sizes one (fun x y => and2 (x,y)) v.
 
   Fixpoint eqb {t : SignalType} : signal t -> signal t -> cava (signal Bit) :=

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -73,10 +73,10 @@ Section WithCava.
            (a : signal (Vec A n))
            (b : signal (Vec B n))
            : cava (signal (Vec C n)) :=
-    a' <- unpackv a ;;
-    b' <- unpackv b ;;
+    a' <- unpackV a ;;
+    b' <- unpackV b ;;
     v <- mapT f (vcombine a' b') ;;
-    packv v.
+    packV v.
 
   (* A list-based left monadic-fold. *)
   Fixpoint foldLM {m} `{Monad m} {A B : Type}
@@ -259,9 +259,9 @@ Section WithCava.
                (circuit : signal A * signal B -> cava (signal C * signal A))
                (aIn: signal A) (bIn: signal (Vec B n)) :
                cava (signal (Vec C n) * signal A) :=
-  b <- unpackv bIn ;;
+  b <- unpackV bIn ;;
   '(c, a) <- colV circuit (aIn, b) ;;
-  cOut <- packv c ;;
+  cOut <- packV c ;;
   ret (cOut, a).
 
   Local Close Scope vector_scope.
@@ -609,7 +609,7 @@ Section WithCava.
   Qed.
 
   Definition all {n} (v : signal (Vec Bit n)) : cava (signal Bit) :=
-    v <- unpackv v ;;
+    v <- unpackV v ;;
     tree_all_sizes one (fun x y => and2 (x,y)) v.
 
   Fixpoint eqb {t : SignalType} : signal t -> signal t -> cava (signal Bit) :=

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -67,5 +67,5 @@ Ltac simpl_ident :=
   repeat
     first [ progress autorewrite with simpl_ident
           | progress cbn [fst snd bind ret Monad_ident monad
-                              peel unpeel constant
+                              unpackv packv constant
                               CombinationalSemantics unIdent] ].

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -67,5 +67,5 @@ Ltac simpl_ident :=
   repeat
     first [ progress autorewrite with simpl_ident
           | progress cbn [fst snd bind ret Monad_ident monad
-                              unpackv packv constant
+                              unpackV packV constant
                               CombinationalSemantics unIdent] ].

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -197,11 +197,11 @@ Definition localSignalNet {A : SignalType}
    assignSignal localSig v ;;
    ret localSig.
 
-Definition unpackvNet {t : SignalType} {s : nat} (v : Signal (Vec t s))
+Definition unpackVNet {t : SignalType} {s : nat} (v : Signal (Vec t s))
   : state CavaState (Vector.t (Signal t) s) :=
   mapT_vector (fun x => localSignalNet (IndexConst v x)) (vseq 0 s).
 
-Definition packvNet {t : SignalType} {s : nat} (v: Vector.t (Signal t) s)
+Definition packVNet {t : SignalType} {s : nat} (v: Vector.t (Signal t) s)
   : state CavaState (Signal (Vec t s)) :=
   localSignalNet (VecLit v).
 
@@ -210,8 +210,8 @@ Definition sliceNet {t: SignalType} {sz: nat}
                     (v: Signal (Vec t sz))
                     (H: startAt + len <= sz) :
                     state CavaState (Signal (Vec t len)) :=
-  v <- unpackvNet v ;;
-  packvNet (sliceVector v startAt len H).
+  v <- unpackVNet v ;;
+  packVNet (sliceVector v startAt len H).
 
 Fixpoint combToSignal (t : SignalType) (v : combType t) : Signal t :=
   match t, v with
@@ -260,8 +260,8 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     lut6 := lut6Net;
     xorcy := xorcyNet;
     muxcy := muxcyNet;
-    unpackv := @unpackvNet;
-    packv := @packvNet;
+    unpackV := @unpackVNet;
+    packV := @packVNet;
     indexAt k sz isz v i := localSignalNet (IndexAt v i);
     indexConst k sz v i := localSignalNet (IndexConst v i);
     slice k sz start len v H := @sliceNet k sz start len v H;

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -197,11 +197,11 @@ Definition localSignalNet {A : SignalType}
    assignSignal localSig v ;;
    ret localSig.
 
-Definition peelNet {t : SignalType} {s : nat} (v : Signal (Vec t s))
+Definition unpackvNet {t : SignalType} {s : nat} (v : Signal (Vec t s))
   : state CavaState (Vector.t (Signal t) s) :=
   mapT_vector (fun x => localSignalNet (IndexConst v x)) (vseq 0 s).
 
-Definition unpeelNet {t : SignalType} {s : nat} (v: Vector.t (Signal t) s)
+Definition packvNet {t : SignalType} {s : nat} (v: Vector.t (Signal t) s)
   : state CavaState (Signal (Vec t s)) :=
   localSignalNet (VecLit v).
 
@@ -210,8 +210,8 @@ Definition sliceNet {t: SignalType} {sz: nat}
                     (v: Signal (Vec t sz))
                     (H: startAt + len <= sz) :
                     state CavaState (Signal (Vec t len)) :=
-  v <- peelNet v ;;
-  unpeelNet (sliceVector v startAt len H).
+  v <- unpackvNet v ;;
+  packvNet (sliceVector v startAt len H).
 
 Fixpoint combToSignal (t : SignalType) (v : combType t) : Signal t :=
   match t, v with
@@ -260,8 +260,8 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     lut6 := lut6Net;
     xorcy := xorcyNet;
     muxcy := muxcyNet;
-    peel := @peelNet;
-    unpeel := @unpeelNet;
+    unpackv := @unpackvNet;
+    packv := @packvNet;
     indexAt k sz isz v i := localSignalNet (IndexAt v i);
     indexConst k sz v i := localSignalNet (IndexConst v i);
     slice k sz start len v H := @sliceNet k sz start len v H;

--- a/cava/Cava/Acorn/XilinxAdder.v
+++ b/cava/Cava/Acorn/XilinxAdder.v
@@ -53,10 +53,10 @@ Section WithCava.
               (cinab : signal Bit * (signal (Vec Bit n) * signal (Vec Bit n)))
             : cava (signal (Vec Bit n) * signal Bit)
     := let '(cin, (a, b)) := cinab in
-      a0 <- unpackv a ;;
-      b0 <- unpackv b ;;
+      a0 <- unpackV a ;;
+      b0 <- unpackV b ;;
       '(sum, cout) <- colV xilinxFullAdder (cin, vcombine a0 b0) ;;
-      sum <- packv sum ;;
+      sum <- packV sum ;;
       ret (sum, cout).
 
   (******************************************************************************)

--- a/cava/Cava/Acorn/XilinxAdder.v
+++ b/cava/Cava/Acorn/XilinxAdder.v
@@ -53,10 +53,10 @@ Section WithCava.
               (cinab : signal Bit * (signal (Vec Bit n) * signal (Vec Bit n)))
             : cava (signal (Vec Bit n) * signal Bit)
     := let '(cin, (a, b)) := cinab in
-      a0 <- peel a ;;
-      b0 <- peel b ;;
+      a0 <- unpackv a ;;
+      b0 <- unpackv b ;;
       '(sum, cout) <- colV xilinxFullAdder (cin, vcombine a0 b0) ;;
-      sum <- unpeel sum ;;
+      sum <- packv sum ;;
       ret (sum, cout).
 
   (******************************************************************************)

--- a/cava/Cava/Lib/Multiplexers.v
+++ b/cava/Cava/Lib/Multiplexers.v
@@ -33,14 +33,14 @@ Section WithCava.
              (sel : signal Bit)
              (ab : signal A * signal A) : cava (signal A) :=
     let '(a,b) := ab in
-    v <- packv [a;b] ;;
-    i <- packv [sel] ;;
+    v <- packV [a;b] ;;
+    i <- packV [sel] ;;
     indexAt v i.
 
   (* 4-element multiplexer *)
   Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
              (sel : signal (Vec Bit 2)) : cava (signal t) :=
     let '(i0,i1,i2,i3) := input in
-    v <- packv [i0;i1;i2;i3]%vector ;;
+    v <- packV [i0;i1;i2;i3]%vector ;;
     indexAt v sel.
 End WithCava.

--- a/cava/Cava/Lib/Multiplexers.v
+++ b/cava/Cava/Lib/Multiplexers.v
@@ -33,14 +33,14 @@ Section WithCava.
              (sel : signal Bit)
              (ab : signal A * signal A) : cava (signal A) :=
     let '(a,b) := ab in
-    v <- unpeel [a;b] ;;
-    i <- unpeel [sel] ;;
+    v <- packv [a;b] ;;
+    i <- packv [sel] ;;
     indexAt v i.
 
   (* 4-element multiplexer *)
   Definition mux4 {t} (input : signal t * signal t * signal t * signal t)
              (sel : signal (Vec Bit 2)) : cava (signal t) :=
     let '(i0,i1,i2,i3) := input in
-    v <- unpeel [i0;i1;i2;i3]%vector ;;
+    v <- packv [i0;i1;i2;i3]%vector ;;
     indexAt v sel.
 End WithCava.

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -67,10 +67,10 @@ Section WithCava.
   Definition addN {n : nat}
             (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
     cava (signal (Vec Bit n)) :=
-    a <- peel (fst ab) ;;
-    b <- peel (snd ab) ;;
+    a <- unpackv (fst ab) ;;
+    b <- unpackv (snd ab) ;;
     '(sum, _) <- unsignedAdderV (constant false, vcombine a b) ;;
-    unpeel sum.
+    packv sum.
 
   (****************************************************************************)
   (* A three input adder.                                                     *)

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -67,10 +67,10 @@ Section WithCava.
   Definition addN {n : nat}
             (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
     cava (signal (Vec Bit n)) :=
-    a <- unpackv (fst ab) ;;
-    b <- unpackv (snd ab) ;;
+    a <- unpackV (fst ab) ;;
+    b <- unpackV (snd ab) ;;
     '(sum, _) <- unsignedAdderV (constant false, vcombine a b) ;;
-    packv sum.
+    packV sum.
 
   (****************************************************************************)
   (* A three input adder.                                                     *)

--- a/cava/Cava/Lib/Vec.v
+++ b/cava/Cava/Lib/Vec.v
@@ -29,54 +29,54 @@ Section WithCava.
 
   Definition bitvec_literal {n} (v : Vector.t bool n)
     : cava (signal (Vec Bit n)) :=
-    packv (Vector.map constant v).
+    packV (Vector.map constant v).
 
   Definition nil {A} : cava (signal (Vec A 0)) :=
-    packv [].
+    packV [].
 
   Definition cons {A n} (a : signal A) (v : signal (Vec A n))
     : cava (signal (Vec A (S n))) :=
-    v <- unpackv v ;;
-    packv (a :: v).
+    v <- unpackV v ;;
+    packV (a :: v).
 
   Definition tl {A n} (v : signal (Vec A (S n))) : cava (signal (Vec A n)) :=
-    v <- unpackv v ;;
-    packv (Vector.tl v).
+    v <- unpackV v ;;
+    packV (Vector.tl v).
 
   Definition hd {A n} (v : signal (Vec A (S n))) : cava (signal A) :=
-    v <- unpackv v ;;
+    v <- unpackV v ;;
     ret (Vector.hd v).
 
   Definition const {A} (x : signal A) n
     : cava (signal (Vec A n)) :=
-    packv (Vector.const x n).
+    packV (Vector.const x n).
 
   Definition rev {A n} (v : signal (Vec A n))
     : cava (signal (Vec A n)) :=
-    v <- unpackv v ;;
-    packv (Vector.rev v).
+    v <- unpackV v ;;
+    packV (Vector.rev v).
 
   Definition last {A n} (v : signal (Vec A (S n)))
     : cava (signal A) :=
-    v <- unpackv v ;;
+    v <- unpackV v ;;
     ret (Vector.last v).
 
   Definition shiftin {A n} (x : signal A) (v : signal (Vec A n))
     : cava (signal (Vec A (S n))) :=
-    v <- unpackv v ;;
-    packv (Vector.shiftin x v).
+    v <- unpackV v ;;
+    packV (Vector.shiftin x v).
 
   Definition shiftout {A n} (v : signal (Vec A (S n)))
     : cava (signal (Vec A n)) :=
-    v <- unpackv v ;;
-    packv (Vector.shiftout v).
+    v <- unpackV v ;;
+    packV (Vector.shiftout v).
 
   Definition transpose {A n m} (v : signal (Vec (Vec A n) m))
     : cava (signal (Vec (Vec A m) n)) :=
-    v <- unpackv v ;;
-    v <- Traversable.mapT unpackv v ;;
-    v <- Traversable.mapT packv (transpose v) ;;
-    packv v.
+    v <- unpackV v ;;
+    v <- Traversable.mapT unpackV v ;;
+    v <- Traversable.mapT packV (transpose v) ;;
+    packV v.
 
   Fixpoint fold_left {A B}
              (f : B * signal A -> cava B)
@@ -109,16 +109,16 @@ Section WithCava.
   Definition map {A B n} (f : signal A -> cava (signal B))
              (v : signal (Vec A n))
     : cava (signal (Vec B n)) :=
-    v <- unpackv v ;;
+    v <- unpackV v ;;
     out <- Traversable.mapT f v ;;
-    packv out.
+    packV out.
 
   Definition map2 {A B C n}
              (f : signal A * signal B -> cava (signal C))
              (va : signal (Vec A n)) (vb : signal (Vec B n))
     : cava (signal (Vec C n)) :=
-    va <- unpackv va ;;
-    vb <- unpackv vb ;;
+    va <- unpackV va ;;
+    vb <- unpackV vb ;;
     out <- Traversable.mapT f (vcombine va vb) ;;
-    packv out.
+    packV out.
 End WithCava.

--- a/cava/Cava/Lib/Vec.v
+++ b/cava/Cava/Lib/Vec.v
@@ -29,54 +29,54 @@ Section WithCava.
 
   Definition bitvec_literal {n} (v : Vector.t bool n)
     : cava (signal (Vec Bit n)) :=
-    unpeel (Vector.map constant v).
+    packv (Vector.map constant v).
 
   Definition nil {A} : cava (signal (Vec A 0)) :=
-    unpeel [].
+    packv [].
 
   Definition cons {A n} (a : signal A) (v : signal (Vec A n))
     : cava (signal (Vec A (S n))) :=
-    v <- peel v ;;
-    unpeel (a :: v).
+    v <- unpackv v ;;
+    packv (a :: v).
 
   Definition tl {A n} (v : signal (Vec A (S n))) : cava (signal (Vec A n)) :=
-    v <- peel v ;;
-    unpeel (Vector.tl v).
+    v <- unpackv v ;;
+    packv (Vector.tl v).
 
   Definition hd {A n} (v : signal (Vec A (S n))) : cava (signal A) :=
-    v <- peel v ;;
+    v <- unpackv v ;;
     ret (Vector.hd v).
 
   Definition const {A} (x : signal A) n
     : cava (signal (Vec A n)) :=
-    unpeel (Vector.const x n).
+    packv (Vector.const x n).
 
   Definition rev {A n} (v : signal (Vec A n))
     : cava (signal (Vec A n)) :=
-    v <- peel v ;;
-    unpeel (Vector.rev v).
+    v <- unpackv v ;;
+    packv (Vector.rev v).
 
   Definition last {A n} (v : signal (Vec A (S n)))
     : cava (signal A) :=
-    v <- peel v ;;
+    v <- unpackv v ;;
     ret (Vector.last v).
 
   Definition shiftin {A n} (x : signal A) (v : signal (Vec A n))
     : cava (signal (Vec A (S n))) :=
-    v <- peel v ;;
-    unpeel (Vector.shiftin x v).
+    v <- unpackv v ;;
+    packv (Vector.shiftin x v).
 
   Definition shiftout {A n} (v : signal (Vec A (S n)))
     : cava (signal (Vec A n)) :=
-    v <- peel v ;;
-    unpeel (Vector.shiftout v).
+    v <- unpackv v ;;
+    packv (Vector.shiftout v).
 
   Definition transpose {A n m} (v : signal (Vec (Vec A n) m))
     : cava (signal (Vec (Vec A m) n)) :=
-    v <- peel v ;;
-    v <- Traversable.mapT peel v ;;
-    v <- Traversable.mapT unpeel (transpose v) ;;
-    unpeel v.
+    v <- unpackv v ;;
+    v <- Traversable.mapT unpackv v ;;
+    v <- Traversable.mapT packv (transpose v) ;;
+    packv v.
 
   Fixpoint fold_left {A B}
              (f : B * signal A -> cava B)
@@ -109,16 +109,16 @@ Section WithCava.
   Definition map {A B n} (f : signal A -> cava (signal B))
              (v : signal (Vec A n))
     : cava (signal (Vec B n)) :=
-    v <- peel v ;;
+    v <- unpackv v ;;
     out <- Traversable.mapT f v ;;
-    unpeel out.
+    packv out.
 
   Definition map2 {A B C n}
              (f : signal A * signal B -> cava (signal C))
              (va : signal (Vec A n)) (vb : signal (Vec B n))
     : cava (signal (Vec C n)) :=
-    va <- peel va ;;
-    vb <- peel vb ;;
+    va <- unpackv va ;;
+    vb <- unpackv vb ;;
     out <- Traversable.mapT f (vcombine va vb) ;;
-    unpeel out.
+    packv out.
 End WithCava.

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -89,7 +89,7 @@ Section WithCava.
     is_final_round <- round_i ==? num_rounds_regular;;
     (* add_round_key_in_sel :
        1 if round_i = 0, 2 if round_i = num_rounds_regular, 0 otherwise *)
-    add_round_key_in_sel <- packv [is_first_round; is_final_round]%vector ;;
+    add_round_key_in_sel <- packV [is_first_round; is_final_round]%vector ;;
     is_middle_round <- nor2 (is_first_round, is_final_round) ;;
     (* round_key_sel : 1 for a decryption middle round, 0 otherwise *)
     round_key_sel <- and2 (is_middle_round, is_decrypt) ;;

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -89,7 +89,7 @@ Section WithCava.
     is_final_round <- round_i ==? num_rounds_regular;;
     (* add_round_key_in_sel :
        1 if round_i = 0, 2 if round_i = num_rounds_regular, 0 otherwise *)
-    add_round_key_in_sel <- unpeel [is_first_round; is_final_round]%vector ;;
+    add_round_key_in_sel <- packv [is_first_round; is_final_round]%vector ;;
     is_middle_round <- nor2 (is_first_round, is_final_round) ;;
     (* round_key_sel : 1 for a decryption middle round, 0 otherwise *)
     round_key_sel <- and2 (is_middle_round, is_decrypt) ;;

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -209,7 +209,7 @@ Section WithCava.
     : cipher_control_signals cava_signal :=
     map_natural_transform x (fun _ xs =>
       v <- xs ;;
-      v' <- packv v ;;
+      v' <- packV v ;;
       sel' <- sel ;;
       indexAt v' sel'
     ).

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -209,7 +209,7 @@ Section WithCava.
     : cipher_control_signals cava_signal :=
     map_natural_transform x (fun _ xs =>
       v <- xs ;;
-      v' <- unpeel v ;;
+      v' <- packv v ;;
       sel' <- sel ;;
       indexAt v' sel'
     ).

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -111,7 +111,7 @@ Section WithCava.
     data_o2 <- (xorv data_i_3 x_mul2_1 >>= xorv x_3 >>= xorv z_muxed_1) ;;
     data_o3 <- (xorv data_i_2 x_mul2_0 >>= xorv x_3 >>= xorv z_muxed_0) ;;
 
-    unpeel [data_o0; data_o1; data_o2; data_o3].
+    packv [data_o0; data_o1; data_o2; data_o3].
 
   Definition aes_mix_columns
              (op_i : signal Bit)

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -111,7 +111,7 @@ Section WithCava.
     data_o2 <- (xorv data_i_3 x_mul2_1 >>= xorv x_3 >>= xorv z_muxed_1) ;;
     data_o3 <- (xorv data_i_2 x_mul2_0 >>= xorv x_3 >>= xorv z_muxed_0) ;;
 
-    packv [data_o0; data_o1; data_o2; data_o3].
+    packV [data_o0; data_o1; data_o2; data_o3].
 
   Definition aes_mix_columns
              (op_i : signal Bit)

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -65,7 +65,7 @@ Section WithCava.
 
   Definition bitvecvec_to_signal {a b : nat} (lut : t (t bool b) a) : cava (signal (Vec (Vec Bit b) a)) :=
     v <- mapT bitvec_to_signal lut ;;
-    packv v.
+    packV v.
 
   Definition natvec_to_signal_sized {n : nat} (size : nat) (lut : t nat n)
     : cava (signal (Vec (Vec Bit size) n)) :=
@@ -93,7 +93,7 @@ Section WithCava.
     b <- xor2 (x2, x7) ;;
     c <- xor2 (x3, x7) ;;
 
-    packv
+    packV
       [x7;
       a;
       x1;
@@ -123,7 +123,7 @@ Section WithCava.
     let indices := [4 - shift; 5 - shift; 6 - shift; 7 - shift] in
     let indices := map (fun x => Nat.modulo x 4) indices in
     out <- mapT (indexConst input) indices ;;
-    packv out.
+    packV out.
 
   Definition IDLE_S := bitvec_to_signal (nat_to_bitvec_sized 3 0).
   Definition INIT_S := bitvec_to_signal (nat_to_bitvec_sized 3 1).

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -65,7 +65,7 @@ Section WithCava.
 
   Definition bitvecvec_to_signal {a b : nat} (lut : t (t bool b) a) : cava (signal (Vec (Vec Bit b) a)) :=
     v <- mapT bitvec_to_signal lut ;;
-    unpeel v.
+    packv v.
 
   Definition natvec_to_signal_sized {n : nat} (size : nat) (lut : t nat n)
     : cava (signal (Vec (Vec Bit size) n)) :=
@@ -93,7 +93,7 @@ Section WithCava.
     b <- xor2 (x2, x7) ;;
     c <- xor2 (x3, x7) ;;
 
-    unpeel
+    packv
       [x7;
       a;
       x1;
@@ -123,7 +123,7 @@ Section WithCava.
     let indices := [4 - shift; 5 - shift; 6 - shift; 7 - shift] in
     let indices := map (fun x => Nat.modulo x 4) indices in
     out <- mapT (indexConst input) indices ;;
-    unpeel out.
+    packv out.
 
   Definition IDLE_S := bitvec_to_signal (nat_to_bitvec_sized 3 0).
   Definition INIT_S := bitvec_to_signal (nat_to_bitvec_sized 3 1).

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -62,6 +62,6 @@ Section WithCava.
   data_o_3_1 <- aes_circ_byte_shift 3 data_i_3 ;;
   data_o_3 <- mux2 op_i (data_o_3_0, data_o_3_1) ;;
 
-  unpeel [data_o_0; data_o_1; data_o_2; data_o_3].
+  packv [data_o_0; data_o_1; data_o_2; data_o_3].
 
 End WithCava.

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -62,6 +62,6 @@ Section WithCava.
   data_o_3_1 <- aes_circ_byte_shift 3 data_i_3 ;;
   data_o_3 <- mux2 op_i (data_o_3_0, data_o_3_1) ;;
 
-  packv [data_o_0; data_o_1; data_o_2; data_o_3].
+  packV [data_o_0; data_o_1; data_o_2; data_o_3].
 
 End WithCava.

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -118,14 +118,14 @@ Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
   let const1 := Vcc in
   '(tl_o, reg2hw) <- blackBoxNet pinmux_reg_top_Interface (tl_i, const1) ;;
   (* Input Mux *)
-  mio_in_i <- unpackvNet mio_in_i ;;
+  mio_in_i <- unpackVNet mio_in_i ;;
   let data_in_mux := VecLit ([const0; const1] ++ mio_in_i) in
   let mio_to_periph_o :=
     Vector.map (fun k => IndexAt data_in_mux (kq "periph_insel" reg2hw k))
                (vseq 0 NPeriphIn) in
   (* Output Mux *)
-  periph_to_mio_i <- unpackvNet periph_to_mio_i ;;
-  periph_to_mio_oe_i <- unpackvNet periph_to_mio_oe_i ;;
+  periph_to_mio_i <- unpackVNet periph_to_mio_i ;;
+  periph_to_mio_oe_i <- unpackVNet periph_to_mio_oe_i ;;
   let data_out_mux := VecLit ([const0; const1; const0] ++ periph_to_mio_i) in
   let oe_mux := VecLit ([const1; const1; const0] ++ periph_to_mio_oe_i) in
   let mio_out_o :=
@@ -134,9 +134,9 @@ Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
   let mio_oe_o :=
     Vector.map (fun k => IndexAt oe_mux (kq "mio_outsel" reg2hw k))
                (vseq 0 NPeriphIn) in
-  mio_to_periph_o <- packvNet mio_to_periph_o ;;
-  mio_out_o <- packvNet mio_out_o ;;
-  mio_oe_o <- packvNet mio_oe_o ;;
+  mio_to_periph_o <- packVNet mio_to_periph_o ;;
+  mio_out_o <- packVNet mio_out_o ;;
+  mio_oe_o <- packVNet mio_oe_o ;;
   ret (tl_o,
        mio_to_periph_o,
        mio_out_o,

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -118,14 +118,14 @@ Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
   let const1 := Vcc in
   '(tl_o, reg2hw) <- blackBoxNet pinmux_reg_top_Interface (tl_i, const1) ;;
   (* Input Mux *)
-  mio_in_i <- peelNet mio_in_i ;;
+  mio_in_i <- unpackvNet mio_in_i ;;
   let data_in_mux := VecLit ([const0; const1] ++ mio_in_i) in
   let mio_to_periph_o :=
     Vector.map (fun k => IndexAt data_in_mux (kq "periph_insel" reg2hw k))
                (vseq 0 NPeriphIn) in
   (* Output Mux *)
-  periph_to_mio_i <- peelNet periph_to_mio_i ;;
-  periph_to_mio_oe_i <- peelNet periph_to_mio_oe_i ;;
+  periph_to_mio_i <- unpackvNet periph_to_mio_i ;;
+  periph_to_mio_oe_i <- unpackvNet periph_to_mio_oe_i ;;
   let data_out_mux := VecLit ([const0; const1; const0] ++ periph_to_mio_i) in
   let oe_mux := VecLit ([const1; const1; const0] ++ periph_to_mio_oe_i) in
   let mio_out_o :=
@@ -134,9 +134,9 @@ Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
   let mio_oe_o :=
     Vector.map (fun k => IndexAt oe_mux (kq "mio_outsel" reg2hw k))
                (vseq 0 NPeriphIn) in
-  mio_to_periph_o <- unpeelNet mio_to_periph_o ;;
-  mio_out_o <- unpeelNet mio_out_o ;;
-  mio_oe_o <- unpeelNet mio_oe_o ;;
+  mio_to_periph_o <- packvNet mio_to_periph_o ;;
+  mio_out_o <- packvNet mio_out_o ;;
+  mio_oe_o <- packvNet mio_oe_o ;;
   ret (tl_o,
        mio_to_periph_o,
        mio_out_o,

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -38,16 +38,16 @@ Section WithCava.
   Context `{Cava}.
 
   Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : cava (signal (Vec Bit n)) :=
-    packv (Vector.map constant lut).
+    packV (Vector.map constant lut).
 
   Definition array : cava (signal (Vec (Vec Bit 8) 4)) :=
     v <- mapT (fun x => bitvec_to_signal (nat_to_bitvec_sized _ x)) [0;1;2;3] ;;
-    packv v.
+    packV v.
 
   Definition multiDimArray : cava (signal (Vec (Vec (Vec Bit 8) 4) 2)) :=
     arr1 <- array ;;
     arr2 <- array ;;
-    packv [arr1; arr2].
+    packV [arr1; arr2].
 
   Definition arrayTest (i : signal (Vec Bit 8))
     : cava (signal (Vec Bit 8)) :=

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -38,16 +38,16 @@ Section WithCava.
   Context `{Cava}.
 
   Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : cava (signal (Vec Bit n)) :=
-    unpeel (Vector.map constant lut).
+    packv (Vector.map constant lut).
 
   Definition array : cava (signal (Vec (Vec Bit 8) 4)) :=
     v <- mapT (fun x => bitvec_to_signal (nat_to_bitvec_sized _ x)) [0;1;2;3] ;;
-    unpeel v.
+    packv v.
 
   Definition multiDimArray : cava (signal (Vec (Vec (Vec Bit 8) 4) 2)) :=
     arr1 <- array ;;
     arr2 <- array ;;
-    unpeel [arr1; arr2].
+    packv [arr1; arr2].
 
   Definition arrayTest (i : signal (Vec Bit 8))
     : cava (signal (Vec Bit 8)) :=

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -87,7 +87,7 @@ Lemma incrN_correct {n} (x : combType (Vec Bit (S n))) :
   unIdent (incrN x) = N2Bv_sized (S n) (Bv2N x + 1).
 Proof.
   cbv [incrN].
-  cbn [CombinationalSemantics peel unpeel unsignedAdd unsignedAddBool constant].
+  cbn [CombinationalSemantics unpackv packv unsignedAdd unsignedAddBool constant].
   simpl_ident. cbn [Nat.max Nat.add Bv2N N.succ_double].
   (* just proof about shiftout from here *)
 Admitted.

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -87,7 +87,7 @@ Lemma incrN_correct {n} (x : combType (Vec Bit (S n))) :
   unIdent (incrN x) = N2Bv_sized (S n) (Bv2N x + 1).
 Proof.
   cbv [incrN].
-  cbn [CombinationalSemantics unpackv packv unsignedAdd unsignedAddBool constant].
+  cbn [CombinationalSemantics unpackV packV unsignedAdd unsignedAddBool constant].
   simpl_ident. cbn [Nat.max Nat.add Bv2N N.succ_double].
   (* just proof about shiftout from here *)
 Admitted.


### PR DESCRIPTION
Progress on #610

I have put `packv` for what used to be `unpeel` -- packaging a Coq vector into a signal -- and `unpackv` for its inverse. Does that match others' intuitions?