### PR TITLE
Rename multistep to simulate

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -111,7 +111,7 @@ Definition adder_tree4_8_tb_inputs
      ].
 
 Definition adder_tree4_8_tb_expected_outputs
-  := multistep (Comb adderTree4) adder_tree4_8_tb_inputs.
+  := simulate (Comb adderTree4) adder_tree4_8_tb_inputs.
 
 Definition adder_tree4_8_tb :=
   testBench "adder_tree4_8_tb" adder_tree4_8Interface
@@ -139,7 +139,7 @@ Definition adder_tree64_8_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_8_tb_expected_outputs
-  := multistep (Comb (adderTree 5)) adder_tree64_8_tb_inputs.
+  := simulate (Comb (adderTree 5)) adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "adder_tree64_8_tb" adder_tree64_8Interface
@@ -158,7 +158,7 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := multistep (Comb (adderTree 5)) adder_tree64_128_tb_inputs.
+  := simulate (Comb (adderTree 5)) adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "adder_tree64_128_tb" adder_tree64_128Interface

--- a/acorn-examples/FullAdderExample.v
+++ b/acorn-examples/FullAdderExample.v
@@ -74,7 +74,7 @@ Definition fullAdder_tb_inputs :=
 ].
 
 Definition fullAdder_tb_expected_outputs :=
-  multistep (Comb fullAdderTop) fullAdder_tb_inputs.
+  simulate (Comb fullAdderTop) fullAdder_tb_inputs.
 
 Definition fullAdder_tb
   := testBench "fullAdder_tb" fullAdderInterface

--- a/acorn-examples/NandGate.v
+++ b/acorn-examples/NandGate.v
@@ -80,7 +80,7 @@ Definition nand_tb_inputs : list (bool * bool) :=
 
 (* Compute expected outputs. *)
 Definition nand_tb_expected_outputs : list bool :=
-  multistep (Comb nand2_gate) nand_tb_inputs.
+  simulate (Comb nand2_gate) nand_tb_inputs.
 
 Definition nand2_tb :=
   testBench "nand2_tb" nand2Interface nand_tb_inputs nand_tb_expected_outputs.

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -75,7 +75,7 @@ Definition two_sorter_tb_inputs : list (Vector.t (Bvector 8) _) :=
   ].
 
 Definition two_sorter_tb_expected_outputs : list (Vector.t (Bvector 8) _) :=
-  multistep (Comb twoSorter) two_sorter_tb_inputs.
+  simulate (Comb twoSorter) two_sorter_tb_inputs.
 
 Definition two_sorter_tb :=
   testBench "two_sorter_tb" (two_sorter_Interface 8)

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -116,7 +116,7 @@ Definition adder4_tb_inputs
   := [(bv4_0, bv4_0); (bv4_1, bv4_2); (bv4_15, bv4_1); (bv4_15, bv4_15)].
 
 Definition adder4_tb_expected_outputs
-  := multistep (Comb unsignedAddCircuit) adder4_tb_inputs.
+  := simulate (Comb unsignedAddCircuit) adder4_tb_inputs.
 
 Definition adder4_tb
   := testBench "adder4_tb" adder4Interface
@@ -142,7 +142,7 @@ Definition adder8_3input_tb_inputs :=
   [(17, 23, 95); (4, 200, 30); (255, 255, 200)].
 
 Definition adder8_3input_tb_expected_outputs :=
-  multistep (Comb (add3InputTuple 8 8 8)) adder8_3input_tb_inputs.
+  simulate (Comb (add3InputTuple 8 8 8)) adder8_3input_tb_inputs.
 
 Definition adder8_3input_tb :=
   testBench "adder8_3input_tb" adder8_3inputInterface

--- a/acorn-examples/xilinx/NandLUT.v
+++ b/acorn-examples/xilinx/NandLUT.v
@@ -42,7 +42,7 @@ Definition lutNANDNetlist := makeNetlist lutNANDInterface lutNAND.
  [(false, false); (false, true); (true, false); (true, true)].
 
  Definition lutNAND_tb_expected_outputs : list bool :=
-   multistep (Comb lutNAND) lutNAND_tb_inputs.
+   simulate (Comb lutNAND) lutNAND_tb_inputs.
 
 Definition lutNAND_tb :=
   testBench "lutNAND_tb" lutNANDInterface

--- a/acorn-examples/xilinx/XilinxAdderExamples.v
+++ b/acorn-examples/xilinx/XilinxAdderExamples.v
@@ -96,7 +96,7 @@ Definition adder8_tb_inputs :=
    (1, (255, 255))].
 
 Definition adder8_tb_expected_outputs :=
-  multistep (Comb xilinxAdderWithCarryFlat) adder8_tb_inputs.
+  simulate (Comb xilinxAdderWithCarryFlat) adder8_tb_inputs.
 
 Definition adder8_tb :=
   testBench "adder8_tb" adder8Interface

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -112,7 +112,7 @@ Definition adder_tree4_8_tb_inputs
       [9; 56; 2; 87];   [14; 72; 90; 11]; [64; 12; 92; 13];    [88; 24; 107; 200]]).
 
 Definition adder_tree4_8_tb_expected_outputs
-  := multistep (Comb adderTree4) adder_tree4_8_tb_inputs.
+  := simulate (Comb adderTree4) adder_tree4_8_tb_inputs.
 
 Definition adder_tree4_8_tb :=
   testBench "xadder_tree4_8_tb" adder_tree4_8Interface
@@ -146,7 +146,7 @@ Definition adder_tree64_8_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64].
 
 Definition adder_tree64_8_tb_expected_outputs
-  := multistep (Comb (adderTree 5)) adder_tree64_8_tb_inputs.
+  := simulate (Comb (adderTree 5)) adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "xadder_tree64_8_tb" adder_tree64_8Interface
@@ -167,7 +167,7 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := multistep (Comb (adderTree 5)) adder_tree64_128_tb_inputs.
+  := simulate (Comb (adderTree 5)) adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "xadder_tree64_128_tb" adder_tree64_128Interface
@@ -189,7 +189,7 @@ Definition adder_tree128_256_tb_inputs : list (Vector.t (Bvector 256) 128)
 
 Definition adder_tree128_256_tb_expected_outputs
            : list (Bvector 256)
-  := multistep (Comb (adderTree 6)) adder_tree128_256_tb_inputs.
+  := simulate (Comb (adderTree 6)) adder_tree128_256_tb_inputs.
 
 Definition adder_tree128_256_tb :=
   testBench "xadder_tree128_256_tb" adder_tree128_256Interface

--- a/cava/Cava/Acorn/Acorn.v
+++ b/cava/Cava/Acorn/Acorn.v
@@ -21,4 +21,4 @@ Require Export Cava.Acorn.Circuit.
 Require Export Cava.Acorn.Combinational.
 Require Export Cava.Acorn.Combinators.
 Require Export Cava.Acorn.NetlistGeneration.
-Require Export Cava.Acorn.Multistep.
+Require Export Cava.Acorn.Simulation.

--- a/cava/Cava/Acorn/Simulation.v
+++ b/cava/Cava/Acorn/Simulation.v
@@ -29,7 +29,7 @@ Require Import Cava.Acorn.Identity.
 Existing Instance CombinationalSemantics.
 
 (* Run a circuit for many timesteps, starting at the reset value *)
-Definition multistep {i o} (c : Circuit i o) (input : list i) : list o :=
+Definition simulate {i o} (c : Circuit i o) (input : list i) : list o :=
   match input with
   | [] => []
   | i :: input =>
@@ -40,11 +40,11 @@ Definition multistep {i o} (c : Circuit i o) (input : list i) : list o :=
     map fst acc
   end.
 
-Lemma multistep_compose {A B C} (c1 : Circuit A B) (c2 : Circuit B C) (input : list A) :
-  multistep (Compose c1 c2) input = multistep c2 (multistep c1 input).
+Lemma simulate_compose {A B C} (c1 : Circuit A B) (c2 : Circuit B C) (input : list A) :
+  simulate (Compose c1 c2) input = simulate c2 (simulate c1 input).
 Proof.
   clear.
-  cbv [multistep]. destruct input as [|i0 input]; [ reflexivity | ].
+  cbv [simulate]. destruct input as [|i0 input]; [ reflexivity | ].
   repeat destruct_pair_let; simpl_ident.
   destruct input as [|i1 input]; [ cbn; repeat destruct_pair_let; reflexivity | ].
   rewrite !fold_left_accumulate_cons_full.
@@ -68,27 +68,27 @@ Proof.
     subst. rewrite !map_map. apply map_ext; intros.
     reflexivity. }
 Qed.
-Hint Rewrite @multistep_compose using solve [eauto] : push_multistep.
+Hint Rewrite @simulate_compose using solve [eauto] : push_simulate.
 
-Lemma multistep_comb {A B} (c : A -> ident B) (input : list A) :
-  multistep (Comb c) input = map (fun a => unIdent (c a)) input.
+Lemma simulate_comb {A B} (c : A -> ident B) (input : list A) :
+  simulate (Comb c) input = map (fun a => unIdent (c a)) input.
 Proof.
   clear.
-  cbv [multistep]. destruct input as [|i0 input]; [ reflexivity | ].
+  cbv [simulate]. destruct input as [|i0 input]; [ reflexivity | ].
   repeat destruct_pair_let; simpl_ident.
   cbn [fst snd map step reset_state circuit_state].
   simpl_ident. rewrite fold_left_accumulate_to_map.
   cbn [map fst]. rewrite map_map. cbn [fst].
   reflexivity.
 Qed.
-Hint Rewrite @multistep_comb using solve [eauto] : push_multistep.
+Hint Rewrite @simulate_comb using solve [eauto] : push_simulate.
 
-Lemma multistep_first {A B C} (f : Circuit A C) (input : list (A * B)) :
-  multistep (First f) input = combine (multistep f (map fst input))
+Lemma simulate_first {A B C} (f : Circuit A C) (input : list (A * B)) :
+  simulate (First f) input = combine (simulate f (map fst input))
                                       (map snd input).
 Proof.
   clear.
-  cbv [multistep]. destruct input as [|i0 input]; [ reflexivity | ].
+  cbv [simulate]. destruct input as [|i0 input]; [ reflexivity | ].
   repeat destruct_pair_let; simpl_ident.
   cbn [fst snd map step reset_state circuit_state].
   simpl_ident. repeat destruct_pair_let; simpl_ident.
@@ -116,14 +116,14 @@ Proof.
     erewrite !map_nth_inbounds by length_hammer.
     reflexivity. }
 Qed.
-Hint Rewrite @multistep_first using solve [eauto] : push_multistep.
+Hint Rewrite @simulate_first using solve [eauto] : push_simulate.
 
-Lemma multistep_second {A B C} (f : Circuit B C) (input : list (A * B)) :
-  multistep (Second f) input = combine (map fst input)
-                                       (multistep f (map snd input)).
+Lemma simulate_second {A B C} (f : Circuit B C) (input : list (A * B)) :
+  simulate (Second f) input = combine (map fst input)
+                                       (simulate f (map snd input)).
 Proof.
   clear.
-  cbv [multistep]. destruct input as [|i0 input]; [ reflexivity | ].
+  cbv [simulate]. destruct input as [|i0 input]; [ reflexivity | ].
   repeat destruct_pair_let; simpl_ident.
   cbn [fst snd map step reset_state circuit_state].
   simpl_ident. repeat destruct_pair_let; simpl_ident.
@@ -151,17 +151,17 @@ Proof.
     erewrite !map_nth_inbounds by length_hammer.
     reflexivity. }
 Qed.
-Hint Rewrite @multistep_second using solve [eauto] : push_multistep.
+Hint Rewrite @simulate_second using solve [eauto] : push_simulate.
 
-Lemma multistep_length {i o} (c : Circuit i o) input :
-  length (multistep c input) = length input.
+Lemma simulate_length {i o} (c : Circuit i o) input :
+  length (simulate c input) = length input.
 Proof.
-  cbv [multistep].
+  cbv [simulate].
   destruct input; repeat destruct_pair_let; length_hammer.
 Qed.
-Hint Rewrite @multistep_length using solve [eauto] : push_length.
+Hint Rewrite @simulate_length using solve [eauto] : push_length.
 
-Lemma multistep_LoopInitICE_invariant
+Lemma simulate_LoopInitICE_invariant
       {i s o} resetval (body : Circuit (i * combType s) (o * combType s))
       (I : nat -> combType s -> circuit_state body -> list o -> Prop ) (P : list o -> Prop)
       (input : list (i * bool)) :
@@ -180,9 +180,9 @@ Lemma multistep_LoopInitICE_invariant
       I (S t) new_state bodyst' (acc ++ [out])) ->
   (* invariant implies postcondition *)
   (forall acc st bodyst, I (length input) st bodyst acc -> P acc) ->
-  P (multistep (LoopInitCE resetval body) input).
+  P (simulate (LoopInitCE resetval body) input).
 Proof.
-  intros ? Ipreserved IimpliesP. cbv [multistep].
+  intros ? Ipreserved IimpliesP. cbv [simulate].
   destruct input; [ solve [eauto] | ].
   repeat destruct_pair_let.
   cbn [circuit_state reset_state step fst snd].
@@ -199,7 +199,7 @@ Proof.
   { eapply IimpliesP. }
 Qed.
 
-Lemma multistep_LoopCE_invariant
+Lemma simulate_LoopCE_invariant
       {i s o} (body : Circuit (i * combType s) (o * combType s))
       (I : nat -> combType s -> circuit_state body -> list o -> Prop ) (P : list o -> Prop)
       (input : list (i * bool)) :
@@ -218,10 +218,10 @@ Lemma multistep_LoopCE_invariant
       I (S t) new_state bodyst' (acc ++ [out])) ->
   (* invariant implies postcondition *)
   (forall acc st bodyst, I (length input) st bodyst acc -> P acc) ->
-  P (multistep (LoopCE body) input).
-Proof. apply multistep_LoopInitICE_invariant. Qed.
+  P (simulate (LoopCE body) input).
+Proof. apply simulate_LoopInitICE_invariant. Qed.
 
-Lemma multistep_LoopInit_invariant
+Lemma simulate_LoopInit_invariant
       {i s o} resetval (body : Circuit (i * combType s) (o * combType s))
       (I : nat -> combType s -> circuit_state body -> list o -> Prop ) (P : list o -> Prop)
       (input : list i) :
@@ -238,11 +238,11 @@ Lemma multistep_LoopInit_invariant
       I (S t) st' bodyst' (acc ++ [out])) ->
   (* invariant implies postcondition *)
   (forall acc st bodyst, I (length input) st bodyst acc -> P acc) ->
-  P (multistep (LoopInit resetval body) input).
+  P (simulate (LoopInit resetval body) input).
 Proof.
   intros? Ipres IimpliesP; cbv [LoopInit].
-  autorewrite with push_multistep. simpl_ident.
-  eapply multistep_LoopInitICE_invariant with (I0:=I).
+  autorewrite with push_simulate. simpl_ident.
+  eapply simulate_LoopInitICE_invariant with (I0:=I).
   { eassumption. }
   { cbv zeta in *. intros *. destruct_products.
     autorewrite with push_length. intros.
@@ -253,7 +253,7 @@ Proof.
     apply IimpliesP. }
 Qed.
 
-Lemma multistep_Loop_invariant
+Lemma simulate_Loop_invariant
       {i s o} (body : Circuit (i * combType s) (o * combType s))
       (I : nat -> combType s -> circuit_state body -> list o -> Prop ) (P : list o -> Prop)
       (input : list i) :
@@ -270,5 +270,5 @@ Lemma multistep_Loop_invariant
       I (S t) st' bodyst' (acc ++ [out])) ->
   (* invariant implies postcondition *)
   (forall acc st bodyst, I (length input) st bodyst acc -> P acc) ->
-  P (multistep (Loop body) input).
-Proof. apply multistep_LoopInit_invariant. Qed.
+  P (simulate (Loop body) input).
+Proof. apply simulate_LoopInit_invariant. Qed.

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -49,7 +49,7 @@ Recursive Extraction Library Acorn.
 Recursive Extraction Library Circuit.
 Recursive Extraction Library Combinational.
 Recursive Extraction Library Combinators.
-Recursive Extraction Library Multistep.
+Recursive Extraction Library Simulation.
 Recursive Extraction Library NetlistGeneration.
 
 Recursive Extraction Library Netlist.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -62,7 +62,7 @@ library
                      Monad
                      MonadState
                      Multiplexers
-                     Multistep
+                     Simulation
                      Netlist
                      NetlistGeneration
                      Nat

--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -28,7 +28,7 @@ Require Import Cava.Acorn.Acorn.
 Require Import Cava.Acorn.Combinational.
 Require Import Cava.Acorn.Circuit.
 Require Import Cava.Acorn.Identity.
-Require Import Cava.Acorn.Multistep.
+Require Import Cava.Acorn.Simulation.
 
 Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
@@ -118,9 +118,9 @@ Lemma full_cipher_equiv
   cipher_input = make_cipher_signals Nr is_decrypt init_key_input
                                      (init_state :: init_state_ignored) ->
   (* precomputed keys match key expansion *)
-  multistep key_expand cipher_input = init_key :: middle_keys ++ [last_key] ->
+  simulate key_expand cipher_input = init_key :: middle_keys ++ [last_key] ->
   forall d,
-    nth Nr (multistep (full_cipher key_expand) cipher_input) d
+    nth Nr (simulate (full_cipher key_expand) cipher_input) d
     = from_flat
         ((if is_decrypt then aes256_decrypt else aes256_encrypt)
            (to_flat init_key) (to_flat last_key) middle_keys_flat
@@ -168,12 +168,12 @@ Lemma full_cipher_inverse
   length init_state_ignored_inv = Nr ->
   cipher_input_fwd = make_cipher_signals Nr false init_key_input_fwd
                                          (plaintext :: init_state_ignored_fwd) ->
-  let ciphertext := nth Nr (multistep (full_cipher key_expand) cipher_input_fwd) d in
+  let ciphertext := nth Nr (simulate (full_cipher key_expand) cipher_input_fwd) d in
   cipher_input_inv = make_cipher_signals Nr true init_key_input_inv
                                          (ciphertext :: init_state_ignored_inv) ->
   (* inverse key expansion reverses key expansion *)
-  multistep key_expand cipher_input_fwd = rev (multistep key_expand cipher_input_inv) ->
-  nth Nr (multistep (full_cipher key_expand) cipher_input_inv) d = plaintext.
+  simulate key_expand cipher_input_fwd = rev (simulate key_expand cipher_input_inv) ->
+  nth Nr (simulate (full_cipher key_expand) cipher_input_inv) d = plaintext.
 Proof.
   intros. simpl_ident. subst_lets.
 
@@ -193,7 +193,7 @@ Proof.
 
   autorewrite with conversions.
   cbv [combType Bvector.Bvector] in *.
-  lazymatch goal with H : multistep key_expand _ = _ |- _ =>
+  lazymatch goal with H : simulate key_expand _ = _ |- _ =>
                       rewrite H end.
   let l := lazymatch goal with
              |- context [map inv_mix_columns ?l] =>

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
@@ -43,7 +43,7 @@ Local Open Scope list_scope.
 
 (* Compute the expected outputs from the Coq/Cava semantics. *)
 Definition aes_add_round_key_expected_outputs : seqType (Vec (Vec (Vec Bit 8) 4) 4)
-  := multistep (Comb (fun '(key_i, data_i) => aes_add_round_key key_i data_i))
+  := simulate (Comb (fun '(key_i, data_i) => aes_add_round_key key_i data_i))
                [(fromNatVec test_key, fromNatVec test_state)].
 
 Definition aes_add_round_key_tb :=

--- a/silveroak-opentitan/aes/Acorn/MixColumnsNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsNetlist.v
@@ -44,7 +44,7 @@ Local Open Scope list_scope.
 
 (* Compute the expected outputs from the Coq/Cava semantics. *)
 Definition aes_mix_cols_expected_outputs :=
-  multistep (Comb (fun '(op_i, data_i) => aes_mix_columns op_i data_i))
+  simulate (Comb (fun '(op_i, data_i) => aes_mix_columns op_i data_i))
             [(false, fromNatVec test_state)].
 
 Definition aes_mix_columns_tb :=

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsNetlist.v
@@ -38,7 +38,7 @@ Definition aes_shift_rows_Netlist
 
 (* Compute the expected outputs from the Coq/Cava semantics. *)
 Definition aes_shift_rows_expected_outputs :=
-  multistep (Comb (fun '(op_i, data_i) => aes_shift_rows op_i data_i))
+  simulate (Comb (fun '(op_i, data_i) => aes_shift_rows op_i data_i))
             [(false, fromNatVec test_state)].
 
 Definition aes_shift_rows_tb :=

--- a/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
@@ -51,7 +51,7 @@ Definition aes_sub_bytes_Netlist
 
 (* Compute the expected outputs from the Coq/Cava semantics. *)
 Definition aes_sub_bytes_expected_outputs :=
-  multistep (Comb (fun '(op_i, data_i) => aes_sub_bytes op_i data_i))
+  simulate (Comb (fun '(op_i, data_i) => aes_sub_bytes op_i data_i))
             [(false, fromNatVec test_state)].
 
 Definition aes_sub_bytes_tb :=

--- a/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
+++ b/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
@@ -79,14 +79,14 @@ Local Notation "'#' l" := (map (fun i => N2Bv_sized 8 (N.of_nat i)) l)
 Local Open Scope list_scope.
 
 Example accumulatingAdderEnable_ex1:
-  multistep accumulatingAdderEnable
+  simulate accumulatingAdderEnable
             (combine
                (# [1;1;1;1;1;1;1;1])
                (map nat2bool [1;1;1;1;0;0;0;0])) = # [1;2;3;4;5;5;5;5].
 Proof. reflexivity. Qed.
 
 Example accumulatingAdderEnable_ex2:
-  multistep accumulatingAdderEnable
+  simulate accumulatingAdderEnable
             (combine
                (# [0;1;2;3;4;5;6;7])
                (map nat2bool [0;0;0;1;1;1;0;1])) = # [0;1;2;3;7;12;18;19].

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -71,10 +71,10 @@ Proof.
 Qed.
 
 Lemma accumulatingAdderEnableCorrect (i : list (Bvector 8 * bool)) :
-  multistep accumulatingAdderEnable i = fst (accumulatingAdderEnableSpec i).
+  simulate accumulatingAdderEnable i = fst (accumulatingAdderEnableSpec i).
 Proof.
   intros; cbv [accumulatingAdderEnable].
-  eapply multistep_LoopCE_invariant
+  eapply simulate_LoopCE_invariant
     with (I:=fun t st _ acc =>
                st = snd (accumulatingAdderEnableSpec (firstn t i))
                /\ acc = fst (accumulatingAdderEnableSpec (firstn t i))).

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -78,11 +78,11 @@ Local Notation "'#' l" := (map (fun i => N2Bv_sized 8 (N.of_nat i)) l)
 
 Local Open Scope list_scope.
 
-Example addWithDelay_ex1: multistep addWithDelay (# [0;1;2;3;4;5;6;7;8]) = # [0;0;1;2;4;6;9;12;16].
+Example addWithDelay_ex1: simulate addWithDelay (# [0;1;2;3;4;5;6;7;8]) = # [0;0;1;2;4;6;9;12;16].
 Proof. reflexivity. Qed.
 
-Example addWithDelay_ex2: multistep addWithDelay (# [1;1;1;1;1;1;1;1;1]) = # [0;1;1;2;2;3;3;4;4].
+Example addWithDelay_ex2: simulate addWithDelay (# [1;1;1;1;1;1;1;1;1]) = # [0;1;1;2;2;3;3;4;4].
 Proof. reflexivity. Qed.
 
-Example addWithDelay_ex3: multistep addWithDelay (# [14; 7; 3; 250]) = # [0; 14; 7; 17].
+Example addWithDelay_ex3: simulate addWithDelay (# [14; 7; 3; 250]) = # [0; 14; 7; 17].
 Proof. reflexivity. Qed.

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -88,11 +88,11 @@ Proof.
 Qed.
 
 Lemma addWithDelayCorrect (i : list (Bvector 8)) :
-  multistep addWithDelay i = map (fun t => addWithDelaySpecF (fun n => nth n i bvzero) t)
+  simulate addWithDelay i = map (fun t => addWithDelaySpecF (fun n => nth n i bvzero) t)
                                  (seq 0 (length i)).
 Proof.
   intros; cbv [addWithDelay].
-  eapply multistep_Loop_invariant
+  eapply simulate_Loop_invariant
     with (body:=(Comb addN >==> Delay >==> Comb fork2))
          (I := fun t st body_st acc =>
                  st = match t with

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -84,9 +84,9 @@ Definition multiDimArrayTest_Netlist := makeNetlist multiDimArrayTest_Interface 
 Definition arrayTest_tb_inputs := List.repeat (nat_to_bitvec_sized 8 0) 2.
 
 Definition arrayTest_tb_expected_outputs
-  := multistep (Comb arrayTest) arrayTest_tb_inputs.
+  := simulate (Comb arrayTest) arrayTest_tb_inputs.
 Definition multiDimArrayTest_tb_expected_outputs
-  := multistep (Comb multiDimArrayTest) arrayTest_tb_inputs.
+  := simulate (Comb multiDimArrayTest) arrayTest_tb_inputs.
 
 Definition arrayTest_tb
   := testBench "arrayTest_tb" arrayTest_Interface

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -67,7 +67,7 @@ Definition b250 := N2Bv_sized 8 250.
 
 Local Open Scope list_scope.
 
-Example countBy_ex1: multistep countBy [b14; b7; b3; b250] = [b14; b21; b24; b18].
+Example countBy_ex1: simulate countBy [b14; b7; b3; b250] = [b14; b21; b24; b18].
 Proof. reflexivity. Qed.
 
 Definition countBy_Interface
@@ -82,7 +82,7 @@ Definition countBy_Netlist := makeCircuitNetlist countBy_Interface countBy.
 Definition countBy_tb_inputs
   := [b14; b7; b3; b250].
 
-Definition countBy_tb_expected_outputs := multistep countBy countBy_tb_inputs.
+Definition countBy_tb_expected_outputs := simulate countBy countBy_tb_inputs.
 
 Definition countBy_tb
   := testBench "countBy_tb" countBy_Interface

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -53,10 +53,10 @@ Lemma bvadd_comm {n} a b : @bvadd n a b = bvadd b a.
 Proof. cbv [bvadd]. rewrite N.add_comm. reflexivity. Qed.
 
 Lemma countByCorrect: forall (i : list (Bvector 8)),
-    multistep countBy i = countBySpec i.
+    simulate countBy i = countBySpec i.
 Proof.
   intros; cbv [countBy].
-  eapply (multistep_Loop_invariant (s:=Vec Bit 8)) with
+  eapply (simulate_Loop_invariant (s:=Vec Bit 8)) with
       (I:=fun t st _ acc =>
             st = bvsum (firstn t i)
             /\ acc = countBySpec (firstn t i)).

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -52,7 +52,7 @@ Definition b250 := N2Bv_sized 8 250.
 
 Local Open Scope list_scope.
 
-Example delay_ex1: multistep delayByte [b14; b7; b250] = [b0; b14; b7].
+Example delay_ex1: simulate delayByte [b14; b7; b250] = [b0; b14; b7].
 Proof. reflexivity. Qed.
 
 Definition delayByte_Interface
@@ -67,7 +67,7 @@ Definition delayByte_Netlist := makeCircuitNetlist delayByte_Interface delayByte
 Definition delayByte_tb_inputs := [b14; b7; b250].
 
 Definition delayByte_tb_expected_outputs
-  := multistep delayByte delayByte_tb_inputs.
+  := simulate delayByte delayByte_tb_inputs.
 
 Definition delayByte_tb
   := testBench "delayByte_tb" delayByte_Interface
@@ -106,11 +106,11 @@ Definition delayEnableByte_tb_inputs :=
   [(b14, true); (b7, false); (b250, true); (b18, true)].
 
 Example delayEnableByte_test:
-  multistep delayEnableByte delayEnableByte_tb_inputs = [b0; b14; b14; b250].
+  simulate delayEnableByte delayEnableByte_tb_inputs = [b0; b14; b14; b250].
 Proof. reflexivity. Qed.
 
 Definition delayEnableByte_tb_expected_outputs
-  := multistep delayEnableByte delayEnableByte_tb_inputs.
+  := simulate delayEnableByte delayEnableByte_tb_inputs.
 
 Definition delayEnableByte_tb
   := testBench "delayEnableByte_tb" delayEnableByte_Interface
@@ -173,12 +173,12 @@ out  0  1  0  0  1  0  0  0
  *)
 
 Example pipelinedNAND_test:
-  multistep pipelinedNAND pipelinedNAND_tb_inputs
+  simulate pipelinedNAND pipelinedNAND_tb_inputs
   = [false; true; false; false; true; false; false; false].
 Proof. reflexivity. Qed.
 
 Definition pipelinedNAND_tb_expected_outputs
-  := multistep pipelinedNAND pipelinedNAND_tb_inputs.
+  := simulate pipelinedNAND pipelinedNAND_tb_inputs.
 
 Definition pipelinedNAND_tb
   := testBench "pipelinedNAND_tb" pipelinedNANDInterface

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -111,23 +111,23 @@ Definition b24 := N2Bv_sized 8 24.
 Definition b250 := N2Bv_sized 8 250.
 Definition b251 := N2Bv_sized 8 251.
 
-Goal (multistep
+Goal (simulate
         (Comb addC)
         [(b14,b0); (b7,b14); (b3,b4); (b24,b250)]
       = [(b14,false);(b21,false);(b7,false);(b18,true)]).
 Proof. vm_compute. reflexivity. Qed.
 
-Goal (multistep
+Goal (simulate
         (Comb incrN)
         [b14; b7; b3; b250] = [b15;b8;b4;b251]).
 Proof. vm_compute. reflexivity. Qed.
 
-Goal (multistep
+Goal (simulate
         count_by
         [b14; b7; b3; b250] = [false;false;false;true]).
 Proof. vm_compute. reflexivity. Qed.
 
-Goal (multistep
+Goal (simulate
         double_count_by
         [b14; b7; b3; b250]
       = [b0;b0;b0;b1]).
@@ -146,7 +146,7 @@ Definition double_count_by_Netlist :=
 Definition double_count_by_tb_inputs := [b14; b7; b3; b250].
 
 Definition double_count_by_tb_expected_outputs :=
-  multistep double_count_by double_count_by_tb_inputs.
+  simulate double_count_by double_count_by_tb_inputs.
 
 Definition double_count_by_tb
   := testBench "double_count_by_tb" double_count_by_interface

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -122,10 +122,10 @@ Proof.
 Qed.
 
 Lemma count_by_correct (input : list (combType (Vec Bit 8))) :
-  multistep count_by input = map snd (count_by_spec input).
+  simulate count_by input = map snd (count_by_spec input).
 Proof.
   intros; cbv [count_by].
-  eapply (multistep_Loop_invariant (s:=Vec Bit 8)) with
+  eapply (simulate_Loop_invariant (s:=Vec Bit 8)) with
       (I:=fun t st _ acc =>
             st = fst (bvsumc (firstn t input))
             /\ acc = map snd (count_by_spec (firstn t input))).
@@ -180,11 +180,11 @@ Qed.
 Hint Rewrite @firstn_count_by_spec using solve [eauto] : push_firstn.
 
 Lemma double_count_by_correct (input : list (combType (Vec Bit 8))) :
-  multistep double_count_by input = double_count_by_spec input.
+  simulate double_count_by input = double_count_by_spec input.
 Proof.
   intros; cbv [double_count_by].
   let f := lazymatch goal with |- context [Loop ?body] => body end in
-  eapply multistep_Loop_invariant
+  eapply simulate_Loop_invariant
     with (body:=f)
          (I:= fun t st body_st acc =>
                 body_st = (tt, (tt, fst (bvsumc (firstn t input))), tt)

--- a/tests/Instantiate.v
+++ b/tests/Instantiate.v
@@ -67,7 +67,7 @@ Definition instantiate_tb_inputs : list (bool * bool * bool) :=
 
 (* Compute expected outputs. *)
 Definition instantiate_tb_expected_outputs : list bool :=
-  multistep (Comb nand3_gate) instantiate_tb_inputs.
+  simulate (Comb nand3_gate) instantiate_tb_inputs.
 
 Definition instantiate_tb :=
   testBench "instantiate_tb" nand3Interface instantiate_tb_inputs instantiate_tb_expected_outputs.

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -67,7 +67,7 @@ Definition mux2_1_tb_inputs :=
 Definition muxManualExpectedOutputs := [false; true; true; false].
 
 (* Compute the expected outputs from the semantics *)
-Definition mux2_1_tb_expected_outputs := multistep (Comb mux2_1_top) mux2_1_tb_inputs.
+Definition mux2_1_tb_expected_outputs := simulate (Comb mux2_1_top) mux2_1_tb_inputs.
 
 Example m1_4: mux2_1_tb_expected_outputs = muxManualExpectedOutputs.
 Proof. reflexivity. Qed.
@@ -134,7 +134,7 @@ Definition muxBus4_8_tb_inputs : list (Vector.t (Bvector 8) 4 * Vector.t bool 2)
   ].
 
 Definition muxBus4_8_tb_expected_outputs : list (Bvector 8)
-  := multistep (Comb muxBus) muxBus4_8_tb_inputs.
+  := simulate (Comb muxBus) muxBus4_8_tb_inputs.
 
 Definition muxBus4_8_tb
   := testBench "muxBus4_8_tb" muxBus4_8Interface

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -72,7 +72,7 @@ Definition mult2_3_5_tb_inputs
   := [(bv2_3, bv3_5); (bv2_3, bv3_7); (bv2_0, bv3_0)].
 
 Definition mult2_3_5_tb_expected_outputs
-  := multistep (Comb multiplier) mult2_3_5_tb_inputs.
+  := simulate (Comb multiplier) mult2_3_5_tb_inputs.
 
 Definition  mult2_3_5_tb
   := testBench "mult2_3_5_tb" mult2_3_5Interface

--- a/tests/xilinx/LUTTests.v
+++ b/tests/xilinx/LUTTests.v
@@ -67,7 +67,7 @@ End WithCava.
   Definition lut1_inv_tb_inputs := [false; true].
 
   Definition lut1_inv_tb_expected_outputs : list bool :=
-    multistep (Comb lut1_inv) lut1_inv_tb_inputs.
+    simulate (Comb lut1_inv) lut1_inv_tb_inputs.
 
   Definition lut1_inv_tb :=
     testBench "lut1_inv_tb" lut1_inv_Interface
@@ -89,7 +89,7 @@ Definition lut2_and_tb_inputs : list (bool * bool) :=
  [(false, false); (false, true); (true, false); (true, true)].
 
 Definition lut2_and_tb_expected_outputs : list bool :=
-  multistep (Comb lut2_and) lut2_and_tb_inputs.
+  simulate (Comb lut2_and) lut2_and_tb_inputs.
 
 Definition lut2_and_tb :=
   testBench "lut2_and_tb" lut2_and_Interface
@@ -116,7 +116,7 @@ Definition lut3_mux_tb_inputs : list (bool * bool * bool) :=
   (true, true, true)].
 
 Definition lut3_mux_tb_expected_outputs : list bool :=
-  multistep (Comb lut3_mux) lut3_mux_tb_inputs.
+  simulate (Comb lut3_mux) lut3_mux_tb_inputs.
 
 Definition lut3_mux_tb :=
   testBench "lut3_mux_tb" lut3_mux_Interface
@@ -142,7 +142,7 @@ Definition lut4_and_tb_inputs : list (bool * bool * bool * bool) :=
   (true, true, true, true)].
 
 Definition lut4_and_tb_expected_outputs : list bool :=
-  multistep (Comb lut4_and) lut4_and_tb_inputs.
+  simulate (Comb lut4_and) lut4_and_tb_inputs.
 
 Definition lut4_and_tb :=
   testBench "lut4_and_tb" lut4_and_Interface
@@ -169,7 +169,7 @@ Definition lut5_and_tb_inputs : list (bool * bool * bool * bool * bool) :=
   (true, true, true, true, true)].
 
 Definition lut5_and_tb_expected_outputs : list bool :=
-  multistep (Comb lut5_and) lut5_and_tb_inputs.
+  simulate (Comb lut5_and) lut5_and_tb_inputs.
 
 Definition lut5_and_tb :=
   testBench "lut5_and_tb" lut5_and_Interface
@@ -198,7 +198,7 @@ Definition lut6_and_tb_inputs : list (bool * bool * bool * bool * bool * bool) :
 
 
 Definition lut6_and_tb_expected_outputs : list bool :=
-  multistep (Comb lut6_and) lut6_and_tb_inputs.
+  simulate (Comb lut6_and) lut6_and_tb_inputs.
 
 Definition lut6_and_tb :=
   testBench "lut6_and_tb" lut6_and_Interface


### PR DESCRIPTION
Resolves #610 

The operation we call `multistep` is really a circuit simulator; accordingly, this PR
- renames `multistep` to `simulate`
- renames `Multistep.v` to `Simulation.v`
- renames `push_multistep` to `push_simulate`