### PR TITLE
Remove unIdent

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -79,15 +79,15 @@ Local Open Scope string_scope.
 Local Open Scope vector_scope.
 
 Definition v0_v1 := [v0; v1].
-Definition v0_plus_v1 : Bvector 8 := unIdent (adderTree 0 v0_v1).
+Definition v0_plus_v1 : Bvector 8 := adderTree 0 v0_v1.
 
-Example sum_vo_v1 : unIdent (adderTree2 v0_v1) = N2Bv_sized 8 21.
+Example sum_vo_v1 : adderTree2 v0_v1 = N2Bv_sized 8 21.
 Proof. reflexivity. Qed.
 
 Definition v0_3 := [v0; v1; v2; v3].
-Definition sum_v0_3 : Bvector 8 := unIdent (adderTree4 v0_3).
+Definition sum_v0_3 : Bvector 8 := adderTree4 v0_3.
 
-Example sum_v0_v1_v2_v3 : unIdent (adderTree4 v0_3) = N2Bv_sized 8 30.
+Example sum_v0_v1_v2_v3 : adderTree4 v0_3 = N2Bv_sized 8 30.
 Proof. reflexivity. Qed.
 
 Definition adder_tree_Interface name nrInputs bitSize

--- a/acorn-examples/Examples.v
+++ b/acorn-examples/Examples.v
@@ -22,14 +22,14 @@ Import ListNotations.
 
 (* Experiments with the primitive Cava gates. *)
 
-Example inv_false : unIdent (inv false) = true.
+Example inv_false : inv false = true.
 Proof. reflexivity. Qed.
 
-Example inv_true  : unIdent (inv true) = false.
+Example inv_true  : inv true = false.
 Proof. reflexivity. Qed.
 
-Example and_00 : unIdent (and2 (false, false)) = false.
+Example and_00 : and2 (false, false) = false.
 Proof. reflexivity. Qed.
 
-Example and_11 : unIdent (and2 (true, true)) = true.
+Example and_11 : and2 (true, true) = true.
 Proof. reflexivity. Qed.

--- a/acorn-examples/FullAdderExample.v
+++ b/acorn-examples/FullAdderExample.v
@@ -48,7 +48,7 @@ Definition halfAdderNetlist := makeNetlist halfAdderInterface halfAdder.
 
 (* A proof that the half-adder is correct. *)
 Lemma halfAdder_behaviour : forall (a : bool) (b : bool),
-                            unIdent (halfAdder (a, b)) = (xorb a b, a && b).
+                            halfAdder (a, b) = (xorb a b, a && b).
 
 Proof.
   auto.
@@ -82,7 +82,7 @@ Definition fullAdder_tb
 
 (* A proof that the the full-adder is correct. *)
 Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
-                            unIdent (fullAdderTop (cin, a, b))
+                            fullAdderTop (cin, a, b)
                               = (xorb cin (xorb a b),
                                  (a && b) || (b && cin) || (a && cin)).
 Proof.
@@ -95,8 +95,8 @@ Qed.
 
 (* Prove the generic full adder is equivalent to Xilinx fast adder. *)
 Lemma generic_vs_xilinx_adder : forall (a : bool) (b : bool) (cin : bool),
-                                unIdent (fullAdderTop (cin, a, b)) =
-                                unIdent (xilinxFullAdder (cin, (a, b))).
+                                fullAdderTop (cin, a, b) =
+                                xilinxFullAdder (cin, (a, b)).
 Proof.
   intros. simpl.
   case a, b, cin.

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -115,7 +115,7 @@ Section Proofs.
   Existing Instance CombinationalSemantics.
 
   Lemma half_adder_correct (x y : combType Bit) :
-    unIdent (half_adder (x,y)) = (xorb x y, andb x y).
+    half_adder (x,y) = (xorb x y, andb x y).
   Proof.
     cbv [half_adder and2 xor2 CombinationalSemantics].
     simpl_ident. reflexivity.
@@ -123,7 +123,7 @@ Section Proofs.
   Hint Rewrite half_adder_correct using solve [eauto] : simpl_ident.
 
   Lemma incr4_correct (input : combType (Vec Bit 4)) :
-    unIdent (incr4 input) = N2Bv_sized 4 (Bv2N input + 1).
+    incr4 input = N2Bv_sized 4 (Bv2N input + 1).
   Proof.
     cbv [incr4]. simpl_ident. boolsimpl.
     cbn [packV indexConst CombinationalSemantics].
@@ -132,7 +132,7 @@ Section Proofs.
   Qed.
 
   Lemma half_subtractor_correct (x y : combType Bit) :
-    unIdent (half_subtractor (x,y)) = (xorb x y, andb (negb x) y).
+    half_subtractor (x,y) = (xorb x y, andb (negb x) y).
   Proof.
     cbv [half_subtractor and2 xor2 CombinationalSemantics].
     simpl_ident; reflexivity.
@@ -140,7 +140,7 @@ Section Proofs.
   Hint Rewrite half_subtractor_correct using solve [eauto] : simpl_ident.
 
   Lemma decr4_correct (input : combType (Vec Bit 4)) :
-    unIdent (decr4 input) = N2Bv_sized 4 (if (Bv2N input =? 0)%N then 15
+    decr4 input = N2Bv_sized 4 (if (Bv2N input =? 0)%N then 15
                                           else Bv2N input - 1).
   Proof.
     cbv [decr4]. simpl_ident. boolsimpl.
@@ -149,7 +149,7 @@ Section Proofs.
   Qed.
 
   Lemma incr'_correct {sz} carry (input : combType (Vec Bit sz)) :
-    unIdent (incr' carry input)
+    incr' carry input
     = N2Bv_sized _ (Bv2N input + if carry then 1 else 0)%N.
   Proof.
     revert carry input; induction sz; intros; [ cbn; f_equal; solve [apply nil_eq] | ].
@@ -163,11 +163,11 @@ Section Proofs.
   Qed.
 
   Lemma incr_correct {sz} (input : combType (Vec Bit sz)) :
-    unIdent (incr input) = N2Bv_sized _ (Bv2N input + 1).
+    incr input = N2Bv_sized _ (Bv2N input + 1).
   Proof. cbv [incr]. simpl_ident. apply incr'_correct. Qed.
 
   Lemma decr'_correct {sz} borrow (input : combType (Vec Bit sz)) :
-    unIdent (decr' borrow input)
+    decr' borrow input
     = N2Bv_sized _ (if borrow
                     then if (Bv2N input =? 0)%N
                          then N.ones (N.of_nat sz)
@@ -204,7 +204,7 @@ Section Proofs.
   Qed.
 
   Lemma decr_correct {sz} (input : combType (Vec Bit sz)) :
-    unIdent (decr input)
+    decr input
     = N2Bv_sized _ ( if (Bv2N input =? 0)%N
                      then 2 ^ (N.of_nat sz) - 1
                      else Bv2N input - 1)%N.

--- a/acorn-examples/NandGate.v
+++ b/acorn-examples/NandGate.v
@@ -56,22 +56,22 @@ Definition nand2Netlist := makeNetlist nand2Interface nand2_gate.
 
 (* A proof that the NAND gate implementation is correct. *)
 Lemma nand2_behaviour : forall (a : bool) (b : bool),
-                        unIdent (nand2_gate (a, b)) = negb (a && b).
+                        nand2_gate (a, b) = negb (a && b).
 Proof.
   auto.
 Qed.
 
 (* An exhuastive proof by analyzing all four cases. *)
-Example nand_00 : unIdent (nand2_gate (false, false)) = true.
+Example nand_00 : nand2_gate (false, false) = true.
 Proof. reflexivity. Qed.
 
-Example nand_01 : unIdent (nand2_gate (false, true)) = true.
+Example nand_01 : nand2_gate (false, true) = true.
 Proof. reflexivity. Qed.
 
-Example nand_10 : unIdent (nand2_gate (true, false)) = true.
+Example nand_10 : nand2_gate (true, false) = true.
 Proof. reflexivity. Qed.
 
-Example nand_11 : unIdent (nand2_gate (true, true)) = false.
+Example nand_11 : nand2_gate (true, true) = false.
 Proof. reflexivity. Qed.
 
 (* Test bench tables for generated SystemVerilog simulation test bench *)

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -91,10 +91,10 @@ Definition twoSorterSpec {bw: nat} (ab : Vector.t (Bvector bw) 2) :
     [a; b].
 
 Lemma twoSorterCorrect {bw : nat} (v : Vector.t (Bvector bw) 2) :
-  unIdent (@twoSorter combType _ _ v) = twoSorterSpec v.
+  @twoSorter combType _ _ v = twoSorterSpec v.
 Proof.
   constant_vector_simpl v.
-  cbv [twoSorterSpec nth_order].
+  cbv [twoSorterSpec twoSorter nth_order].
   simpl.
-  destruct (Bv2N _ <=? Bv2N _)%N; reflexivity.
+  destruct (Bv2N _ <=? Bv2N _)%N; try reflexivity.
 Qed.

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -46,11 +46,11 @@ Definition bv5_30 := N2Bv_sized 5 30.
 (******************************************************************************)
 
 (* Check 0 + 0 = 0 *)
-Example add0_0 : unIdent (addN (bv4_0, bv4_0)) = bv4_0.
+Example add0_0 : addN (bv4_0, bv4_0) = bv4_0.
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 0 *)
-Example add15_1 : unIdent (addN (bv4_15, bv4_1)) = bv4_0.
+Example add15_1 : addN (bv4_15, bv4_1) = bv4_0.
 Proof. reflexivity. Qed.
 
 Section WithCava.
@@ -81,19 +81,19 @@ Section WithCava.
 End WithCava.
 
 (* Check 0 + 0 = 0 *)
-Example add5_0_0 : unIdent (adderGrowth (bv4_0, bv4_0)) = bv5_0.
+Example add5_0_0 : adderGrowth (bv4_0, bv4_0) = bv5_0.
 Proof. reflexivity. Qed.
 
 (* Check 1 + 2 = 3 *)
-Example add5_1_2 : unIdent (adderGrowth (bv4_1, bv4_2)) = bv5_3.
+Example add5_1_2 : adderGrowth (bv4_1, bv4_2) = bv5_3.
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 16 *)
-Example add5_15_1 : unIdent (adderGrowth (bv4_15, bv4_1)) = bv5_16.
+Example add5_15_1 : adderGrowth (bv4_15, bv4_1) = bv5_16.
 Proof. reflexivity. Qed.
 
 (* Check 15 + 15 = 30 *)
-Example add5_15_15 : unIdent (adderGrowth (bv4_15, bv4_15)) = bv5_30.
+Example add5_15_15 : adderGrowth (bv4_15, bv4_15) = bv5_30.
 Proof. reflexivity. Qed.
 
 (******************************************************************************)

--- a/acorn-examples/xilinx/XilinxAdderExamples.v
+++ b/acorn-examples/xilinx/XilinxAdderExamples.v
@@ -43,23 +43,23 @@ Definition v44  := N2Bv_sized 8 44.
 
 (* Perform a few basic checks to make sure the adder works. *)
 
-Example xadd_17_52_0 : unIdent (xilinxAdderWithCarry (false, (v17, v52))) =
+Example xadd_17_52_0 : xilinxAdderWithCarry (false, (v17, v52)) =
                        (v69, false).
 Proof. reflexivity. Qed.
 
-Example xadd_17_52_1 : unIdent (xilinxAdderWithCarry (true, (v17, v52))) =
+Example xadd_17_52_1 : xilinxAdderWithCarry (true, (v17, v52)) =
                        (v70, false).
 Proof. reflexivity. Qed.
 
-Example xadd_1_255_1 : unIdent (xilinxAdderWithCarry (false, (v1, v255))) =
+Example xadd_1_255_1 : xilinxAdderWithCarry (false, (v1, v255)) =
                        (v0, true).
 Proof. reflexivity. Qed.
 
-Example xadd_0_255_1 : unIdent (xilinxAdderWithCarry (true, (v0, v255))) =
+Example xadd_0_255_1 : xilinxAdderWithCarry (true, (v0, v255)) =
                        (v0, true).
 Proof. reflexivity. Qed.
 
-Example xadd_200_100_0 : unIdent (xilinxAdderWithCarry (false, (v200, v100))) =
+Example xadd_200_100_0 : xilinxAdderWithCarry (false, (v200, v100)) =
                          (v44, true).
 Proof. reflexivity. Qed.
 

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -76,16 +76,15 @@ Local Open Scope nat_scope.
 Local Open Scope vector_scope.
 
 Definition v0_v1 : Vector.t (Bvector 8) 2 := [v0; v1].
-Definition v0_plus_v1 : Bvector 8 := unIdent (adderTree2 v0_v1).
+Definition v0_plus_v1 : Bvector 8 := adderTree2 v0_v1.
 Example sum_vo_v1 : v0_plus_v1 = N2Bv_sized 8 21.
 Proof. reflexivity. Qed.
 
 Local Open Scope N_scope.
 
 Definition v0_v1_v2_v3 := [v0; v1; v2; v3].
-Definition adderTree4_v0_v1_v2_v3 := unIdent (adderTree4 v0_v1_v2_v3).
 Example sum_v0_v1_v2_v3 :
-  Bv2N (unIdent (adderTree4 v0_v1_v2_v3)) = 30.
+  Bv2N (adderTree4 v0_v1_v2_v3) = 30.
 Proof. reflexivity. Qed.
 
 Local Open Scope nat_scope.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -79,7 +79,7 @@ Fixpoint step {i o} (c : Circuit i o)
   : circuit_state c -> i -> o * circuit_state c :=
   match c in Circuit i o return circuit_state c -> i
                                 -> o * circuit_state c with
-  | Comb f => fun _ i => (unIdent (f i), tt)
+  | Comb f => fun _ i => (f i, tt)
   | Compose f g =>
     fun cs input =>
       let '(x, cs1) := step f (fst cs) input in
@@ -105,11 +105,11 @@ Fixpoint step {i o} (c : Circuit i o)
   end.
 
 (* Automation to help simplify expressions using the identity monad *)
-Create HintDb simpl_ident discriminated.
-Hint Rewrite @mapT_vector_ident @mapT_vident @mapT_lident using solve [eauto] : simpl_ident.
+Create HintDb simpl_ident.
+Hint Rewrite @Combinators.foldLM_ident_fold_left using solve [eauto]
+  : simpl_ident.
 Ltac simpl_ident :=
-  repeat
-    first [ progress autorewrite with simpl_ident
-          | progress cbn [fst snd bind ret Monad_ident monad
-                              packV unpackV constant
-                              CombinationalSemantics ] ].
+  cbn [fst snd bind ret Monad_ident monad
+           packV unpackV constant
+           CombinationalSemantics ];
+  autorewrite with simpl_ident.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -19,7 +19,6 @@ Require Import Coq.Vectors.Vector.
 Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
 Require Import ExtLib.Structures.Monads.
-Require Export ExtLib.Data.Monads.IdentityMonad.
 Import ListNotations MonadNotation.
 
 Require Import Cava.Cava.
@@ -113,4 +112,4 @@ Ltac simpl_ident :=
     first [ progress autorewrite with simpl_ident
           | progress cbn [fst snd bind ret Monad_ident monad
                               packV unpackV constant
-                              CombinationalSemantics unIdent] ].
+                              CombinationalSemantics ] ].

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -112,4 +112,14 @@ Ltac simpl_ident :=
   cbn [fst snd bind ret Monad_ident monad
            packV unpackV constant
            CombinationalSemantics ];
-  autorewrite with simpl_ident.
+  repeat lazymatch goal with
+         | |- context [(@Traversable.mapT
+                         _ (@Traversable_vector ?n)
+                         ?m (@Monad.Applicative_Monad ?m Monad_ident)
+                         ?A ?B ?f ?v)] =>
+           change (@Traversable.mapT
+                     _ (@Traversable_vector n)
+                     m (@Monad.Applicative_Monad m Monad_ident)
+                     A B f v) with (@Vector.map A B f n v)
+         | _ => progress autorewrite with simpl_ident
+         end.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -26,6 +26,7 @@ Require Import Cava.Cava.
 Require Import Cava.ListUtils.
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.Circuit.
+Require Import Cava.Acorn.Identity.
 
 (******************************************************************************)
 (* A boolean combinational logic interpretation for the Cava class            *)
@@ -103,3 +104,13 @@ Fixpoint step {i o} (c : Circuit i o)
       let new_state := if en then input else st in
       (st, new_state)
   end.
+
+(* Automation to help simplify expressions using the identity monad *)
+Create HintDb simpl_ident discriminated.
+Hint Rewrite @mapT_vector_ident @mapT_vident @mapT_lident using solve [eauto] : simpl_ident.
+Ltac simpl_ident :=
+  repeat
+    first [ progress autorewrite with simpl_ident
+          | progress cbn [fst snd bind ret Monad_ident monad
+                              packV unpackV constant
+                              CombinationalSemantics unIdent] ].

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -66,8 +66,8 @@ End DecidableEquality.
 Lemma zipWith_correct {A B C : SignalType} n
       (f : combType A * combType B -> cava (combType C))
       (va : combType (Vec A n)) (vb : combType (Vec B n)) :
-  unIdent (@zipWith _ _ A B C n f va vb)
-  = Vector.map2 (fun a b => unIdent (f (a,b))) va vb.
+  @zipWith _ _ A B C n f va vb
+  = Vector.map2 (fun a b => f (a,b)) va vb.
 Proof.
   cbv [zipWith]; intros. simpl_ident.
   rewrite map_vcombine_map2. reflexivity.
@@ -75,7 +75,7 @@ Qed.
 Hint Rewrite @zipWith_correct using solve [eauto] : simpl_ident.
 
 Lemma xorV_correct n a b :
-  unIdent (@xorV _ _ n (a,b)) = Vector.map2 xorb a b.
+  @xorV _ _ n (a,b ) = Vector.map2 xorb a b.
 Proof.
   intros. cbv [xorV]. cbn [fst snd].
   simpl_ident. apply map2_ext; intros.
@@ -83,9 +83,8 @@ Proof.
 Qed.
 Hint Rewrite @xorV_correct using solve [eauto] : simpl_ident.
 
-
 Lemma all_correct {n} v :
-  unIdent (all (n:=n) v) = Vector.fold_left andb true v.
+  all (n:=n) v = Vector.fold_left andb true v.
 Proof.
   destruct n; [ eapply case0 with (v:=v); reflexivity | ].
   cbv [all one]. simpl_ident.
@@ -97,7 +96,7 @@ Qed.
 Hint Rewrite @all_correct using solve [eauto] : simpl_ident.
 
 Lemma eqb_correct {t} (x y : combType t) :
-  unIdent (eqb x y) = combType_eqb x y.
+  eqb x y = combType_eqb x y.
 Proof.
   revert x y.
   induction t;
@@ -119,7 +118,7 @@ Proof.
 Qed.
 
 Lemma eqb_eq {t} (x y : combType t) :
-  unIdent (eqb x y) = true <-> x = y.
+  eqb x y = true <-> x = y.
 Proof.
   rewrite eqb_correct. split.
   { inversion 1. apply combType_eqb_true_iff. auto. }
@@ -127,10 +126,10 @@ Proof.
     apply combType_eqb_true_iff. reflexivity. }
 Qed.
 
-Lemma eqb_refl {t} (x : combType t) : unIdent (eqb x x) = true.
+Lemma eqb_refl {t} (x : combType t) : eqb x x = true.
 Proof. apply eqb_eq. reflexivity. Qed.
 
-Lemma eqb_neq {t} (x y : combType t) : x <> y ->  unIdent (eqb x y) = false.
+Lemma eqb_neq {t} (x y : combType t) : x <> y ->  eqb x y = false.
 Proof.
   rewrite eqb_correct; intros. f_equal.
   apply Bool.not_true_is_false.
@@ -139,8 +138,8 @@ Qed.
 
 Lemma eqb_nat_to_bitvec_sized sz n m :
   n < 2 ^ sz -> m < 2 ^ sz ->
-  unIdent (eqb (t:=Vec Bit sz) (nat_to_bitvec_sized sz n)
-               (nat_to_bitvec_sized sz m))
+  eqb (t:=Vec Bit sz) (nat_to_bitvec_sized sz n)
+      (nat_to_bitvec_sized sz m)
   = if Nat.eqb n m then true else false.
 Proof.
   intros; destruct_one_match; subst; [ solve [apply (eqb_refl (t:=Vec Bit sz))] | ].
@@ -150,16 +149,16 @@ Proof.
 Qed.
 
 Lemma indexAt2_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
-  unIdent (indexAt [i0; i1]%vector [sel]%vector) = if sel then i1 else i0.
+  indexAt [i0; i1]%vector [sel]%vector = if sel then i1 else i0.
 Proof. destruct sel; reflexivity. Qed.
 Hint Rewrite @indexAt2_correct using solve [eauto] : simpl_ident.
 
 Lemma indexConst_eq {A sz} (v : combType (Vec A sz)) (n : nat) :
-  unIdent (indexConst v n) = nth_default (defaultCombValue _) n v.
+  indexConst v n = nth_default (defaultCombValue _) n v.
 Proof. reflexivity. Qed.
 Hint Rewrite @indexConst_eq using solve [eauto] : simpl_ident.
 
 Lemma fork2Correct {A} (i : combType A) :
- unIdent (fork2 i) = (i, i).
+ fork2 i = (i, i).
 Proof. reflexivity. Qed.
 Hint Rewrite @fork2Correct using solve [eauto] : simpl_ident.

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -28,6 +28,7 @@ Require Import Coq.Arith.PeanoNat.
 Export MonadNotation.
 
 Require Import Cava.Acorn.CavaClass.
+Require Import Cava.Acorn.Identity.
 Require Import Cava.VectorUtils.
 Require Import Cava.ListUtils.
 Require Import Cava.Signal.
@@ -132,7 +133,7 @@ Section WithCava.
 
   Lemma foldLM_ident_fold_left
         {A B} (f : B -> A -> ident B) ls b :
-    unIdent (foldLM f ls b) = List.fold_left (fun b a => unIdent (f b a)) ls b.
+    foldLM f ls b = List.fold_left f ls b.
   Proof.
     revert b; induction ls; [ reflexivity | ].
     cbn [foldLM List.fold_left]. intros.

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -17,35 +17,37 @@
 Require Import Coq.Vectors.Vector.
 Require Import ExtLib.Data.List.
 Require Import ExtLib.Data.Vector.
-Require Import ExtLib.Data.Monads.IdentityMonad.
 Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.MonadLaws.
 Require Import ExtLib.Structures.Traversable.
 Require Import Cava.VectorUtils.
 
+(* Identity monad *)
+Definition ident (T : Type) := T.
+Instance Monad_ident : Monad ident :=
+  { ret := fun _ t => t;
+    bind := fun _ _ x f => f x }.
+
+Instance MonadLaws_ident : MonadLaws Monad_ident.
+Proof. econstructor; intros; exact eq_refl. Defined.
+
 Section MapT.
   Lemma mapT_vector_ident {A B n} (f : A -> ident B) (v : Vector.t A n) :
-    unIdent (mapT_vector f v) = Vector.map (fun a => unIdent (f a)) v.
+    mapT_vector f v = Vector.map f v.
   Proof.
     induction v; intros; [ reflexivity | ].
     cbn. rewrite IHv. reflexivity.
   Qed.
+
   (* Alternate form of the above with the Traversable wrapper not simplified *)
   Lemma mapT_vident {A B n} (f : A -> ident B) (v : Vector.t A n) :
-    unIdent (Traversable.mapT
-               (Traversable:=Traversable_vector)
-               f v) = Vector.map (fun a => unIdent (f a)) v.
+    mapT (Traversable:=Traversable_vector) f v = Vector.map f v.
   Proof. apply mapT_vector_ident. Qed.
 
   Lemma mapT_lident {A B} (f : A -> ident B) (l : list A) :
-    unIdent (Traversable.mapT
-               (Traversable:=Traversable_list)
-               f l) = List.map (fun a => unIdent (f a)) l.
+    mapT (Traversable:=Traversable_list) f l = List.map f l.
   Proof.
     simpl. induction l; [ reflexivity | ].
     simpl. rewrite IHl. reflexivity.
   Qed.
 End MapT.
-
-Instance MonadLaws_ident : MonadLaws Monad_ident.
-Proof. econstructor; intros; exact eq_refl. Defined.

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -14,28 +14,18 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
 Require Import Coq.Vectors.Vector.
-Require Import Coq.micromega.Lia.
-Require Import coqutil.Tactics.Tactics.
+Require Import ExtLib.Data.List.
+Require Import ExtLib.Data.Vector.
+Require Import ExtLib.Data.Monads.IdentityMonad.
 Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.MonadLaws.
-Require Import Cava.Signal.
-Require Import Cava.Tactics.
-Require Import Cava.ListUtils.
+Require Import ExtLib.Structures.Traversable.
 Require Import Cava.VectorUtils.
-Require Import Cava.Lib.BitVectorOps.
-Require Import Cava.Acorn.CavaClass.
-Require Import Cava.Acorn.Combinational.
-Require Import Cava.Acorn.Combinators.
-Import VectorNotations ListNotations.
-Open Scope list_scope.
-
-Existing Instance CombinationalSemantics.
 
 Section MapT.
   Lemma mapT_vector_ident {A B n} (f : A -> ident B) (v : Vector.t A n) :
-    unIdent (mapT_vector f v) = map (fun a => unIdent (f a)) v.
+    unIdent (mapT_vector f v) = Vector.map (fun a => unIdent (f a)) v.
   Proof.
     induction v; intros; [ reflexivity | ].
     cbn. rewrite IHv. reflexivity.
@@ -44,12 +34,12 @@ Section MapT.
   Lemma mapT_vident {A B n} (f : A -> ident B) (v : Vector.t A n) :
     unIdent (Traversable.mapT
                (Traversable:=Traversable_vector)
-               f v) = map (fun a => unIdent (f a)) v.
+               f v) = Vector.map (fun a => unIdent (f a)) v.
   Proof. apply mapT_vector_ident. Qed.
 
   Lemma mapT_lident {A B} (f : A -> ident B) (l : list A) :
     unIdent (Traversable.mapT
-               (Traversable:=List.Traversable_list)
+               (Traversable:=Traversable_list)
                f l) = List.map (fun a => unIdent (f a)) l.
   Proof.
     simpl. induction l; [ reflexivity | ].
@@ -59,13 +49,3 @@ End MapT.
 
 Instance MonadLaws_ident : MonadLaws Monad_ident.
 Proof. econstructor; intros; exact eq_refl. Defined.
-
-(* Automation to help simplify expressions using the identity monad *)
-Create HintDb simpl_ident discriminated.
-Hint Rewrite @mapT_vector_ident @mapT_vident @mapT_lident using solve [eauto] : simpl_ident.
-Ltac simpl_ident :=
-  repeat
-    first [ progress autorewrite with simpl_ident
-          | progress cbn [fst snd bind ret Monad_ident monad
-                              unpackV packV constant
-                              CombinationalSemantics unIdent] ].

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -30,24 +30,3 @@ Instance Monad_ident : Monad ident :=
 
 Instance MonadLaws_ident : MonadLaws Monad_ident.
 Proof. econstructor; intros; exact eq_refl. Defined.
-
-Section MapT.
-  Lemma mapT_vector_ident {A B n} (f : A -> ident B) (v : Vector.t A n) :
-    mapT_vector f v = Vector.map f v.
-  Proof.
-    induction v; intros; [ reflexivity | ].
-    cbn. rewrite IHv. reflexivity.
-  Qed.
-
-  (* Alternate form of the above with the Traversable wrapper not simplified *)
-  Lemma mapT_vident {A B n} (f : A -> ident B) (v : Vector.t A n) :
-    mapT (Traversable:=Traversable_vector) f v = Vector.map f v.
-  Proof. apply mapT_vector_ident. Qed.
-
-  Lemma mapT_lident {A B} (f : A -> ident B) (l : list A) :
-    mapT (Traversable:=Traversable_list) f l = List.map f l.
-  Proof.
-    simpl. induction l; [ reflexivity | ].
-    simpl. rewrite IHl. reflexivity.
-  Qed.
-End MapT.

--- a/cava/Cava/Acorn/Simulation.v
+++ b/cava/Cava/Acorn/Simulation.v
@@ -45,11 +45,11 @@ Lemma simulate_compose {A B C} (c1 : Circuit A B) (c2 : Circuit B C) (input : li
 Proof.
   clear.
   cbv [simulate]. destruct input as [|i0 input]; [ reflexivity | ].
-  repeat destruct_pair_let; simpl_ident.
+  repeat destruct_pair_let.
   destruct input as [|i1 input]; [ cbn; repeat destruct_pair_let; reflexivity | ].
   rewrite !fold_left_accumulate_cons_full.
   cbn [fst snd map step reset_state circuit_state].
-  repeat first [ destruct_pair_let | progress simpl_ident ].
+  repeat destruct_pair_let. cbn [fst snd].
   rewrite <-!surjective_pairing.
   rewrite fold_left_accumulate_map.
   rewrite fold_left_accumulate_fold_left_accumulate.
@@ -60,7 +60,7 @@ Proof.
                (y : C * (circuit_state c1 * circuit_state c2)) =>
                y = (fst (snd x), (snd (fst x), snd (snd x)))).
   { reflexivity. }
-  { intros. repeat first [ destruct_pair_let | progress simpl_ident ].
+  { intros. repeat destruct_pair_let.
     subst. cbn [fst snd]. reflexivity. }
   { intros. subst; destruct_products. cbn [fst snd] in *.
     match goal with H : Forall2 _ _ _ |- _ =>
@@ -71,13 +71,13 @@ Qed.
 Hint Rewrite @simulate_compose using solve [eauto] : push_simulate.
 
 Lemma simulate_comb {A B} (c : A -> ident B) (input : list A) :
-  simulate (Comb c) input = map (fun a => unIdent (c a)) input.
+  simulate (Comb c) input = map c input.
 Proof.
   clear.
   cbv [simulate]. destruct input as [|i0 input]; [ reflexivity | ].
-  repeat destruct_pair_let; simpl_ident.
+  repeat destruct_pair_let.
   cbn [fst snd map step reset_state circuit_state].
-  simpl_ident. rewrite fold_left_accumulate_to_map.
+  rewrite fold_left_accumulate_to_map.
   cbn [map fst]. rewrite map_map. cbn [fst].
   reflexivity.
 Qed.

--- a/cava/Cava/Acorn/XilinxAdder.v
+++ b/cava/Cava/Acorn/XilinxAdder.v
@@ -75,21 +75,21 @@ Section WithCombinational.
 
   (* A quick sanity check of the Xilinx adder with carry in and out *)
   Example xilinx_add_17_52:
-    unIdent (xilinxAdderWithCarry
-                  (false, (N2Bv_sized 8 17, N2Bv_sized 8 52))) =
-                  (N2Bv_sized 8 69, false).
+    xilinxAdderWithCarry
+      (false, (N2Bv_sized 8 17, N2Bv_sized 8 52)) =
+    (N2Bv_sized 8 69, false).
   Proof. vm_compute. reflexivity. Qed.
 
   (* A quick sanity check of the Xilinx adder with no bit-growth *)
   Example xilinx_no_growth_add_17_52:
-    unIdent (xilinxAdder (N2Bv_sized 8 17) (N2Bv_sized 8 52)) =
-                  (N2Bv_sized 8 69).
+    xilinxAdder (N2Bv_sized 8 17) (N2Bv_sized 8 52) =
+    (N2Bv_sized 8 69).
   Proof. reflexivity. Qed.
 
   (* A proof that the the full-adder is correct. *)
   Lemma xilinxFullAdder_behaviour :
     forall (a : bool) (b : bool) (cin : bool),
-          unIdent (xilinxFullAdder (cin, (a, b)))
+          xilinxFullAdder (cin, (a, b))
           = (xorb cin (xorb a b),
              (a && b) || (b && cin) || (a && cin)).
   Proof.

--- a/cava/Cava/Lib/FullAdder.v
+++ b/cava/Cava/Lib/FullAdder.v
@@ -55,14 +55,14 @@ Section Combinational.
   (* A proof that the half-adder is correct. *)
   Lemma halfAdder_behaviour :
     forall (a : bool) (b : bool),
-      unIdent (halfAdder (a, b)) = (xorb a b, a && b).
+      halfAdder (a, b) = (xorb a b, a && b).
   Proof.
     auto.
   Qed.
 
   (* A proof that the the full-adder is correct. *)
   Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
-                              unIdent (fullAdder (cin, (a, b)))
+                              fullAdder (cin, (a, b))
                                 = (xorb cin (xorb a b),
                                   (a && b) || (b && cin) || (a && cin)).
   Proof.

--- a/cava/Cava/Lib/FullAdder.v
+++ b/cava/Cava/Lib/FullAdder.v
@@ -17,7 +17,6 @@
 Require Import Coq.Lists.List.
 Require Import Coq.Bool.Bool.
 Require Import ExtLib.Structures.Monads.
-Require Export ExtLib.Data.Monads.IdentityMonad.
 Import ListNotations MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.

--- a/cava/Cava/Lib/MultiplexersProperties.v
+++ b/cava/Cava/Lib/MultiplexersProperties.v
@@ -22,12 +22,12 @@ Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Lib.Multiplexers.
 
 Lemma mux2_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
-  unIdent (mux2 sel (i0, i1)) = if sel then i1 else i0.
+  mux2 sel (i0, i1) = if sel then i1 else i0.
 Proof. destruct sel; reflexivity. Qed.
 Hint Rewrite @mux2_correct using solve [eauto] : simpl_ident.
 
 Lemma mux4_correct {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :
-  unIdent (mux4 (i0,i1,i2,i3) sel) =
+  mux4 (i0,i1,i2,i3) sel =
   if Vector.hd (Vector.tl sel)
   then if Vector.hd sel then i3 else i2
   else if Vector.hd sel then i1 else i0.

--- a/cava/Cava/Lib/UnsignedAdderProofs.v
+++ b/cava/Cava/Lib/UnsignedAdderProofs.v
@@ -20,7 +20,6 @@ Import ListNotations.
 Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
-Require Export ExtLib.Data.Monads.IdentityMonad.
 Require Import ExtLib.Structures.MonadLaws.
 Import MonadNotation.
 Open Scope monad_scope.
@@ -89,7 +88,7 @@ Proof.
 
   (* Rearrange to match inductive hypothesis *)
   rewrite <-app_comm_cons.
-  cbn [unIdent] in *. rewrite list_bits_to_nat_cons.
+  rewrite list_bits_to_nat_cons.
 
   (* Finally we have the right expression to use IHa *)
   rewrite IHa by lia.

--- a/cava/Cava/Lib/UnsignedAdderProofs.v
+++ b/cava/Cava/Lib/UnsignedAdderProofs.v
@@ -40,7 +40,7 @@ Local Open Scope N_scope.
 (* First prove the full-adder correct. *)
 
 Lemma fullAdder_correct (cin a b : bool) :
-  unIdent (fullAdder (cin, (a, b))) =
+  fullAdder (cin, (a, b)) =
   let sum := N.b2n a + N.b2n b + N.b2n cin in
   (N.testbit sum 0, N.testbit sum 1).
 Proof. destruct cin, a, b; reflexivity. Qed.
@@ -65,7 +65,7 @@ Hint Rewrite @bind_of_return @bind_associativity
 (* Correctness of the list based adder. *)
 Lemma addLCorrect (cin : bool) (a b : list bool) :
   length a = length b ->
-  list_bits_to_nat (unIdent (addLWithCinL cin a b)) =
+  list_bits_to_nat (addLWithCinL cin a b) =
   list_bits_to_nat a + list_bits_to_nat b + N.b2n cin.
 Proof.
   cbv zeta. cbv [addLWithCinL adderWithGrowthL unsignedAdderL colL].
@@ -144,7 +144,7 @@ Proof.
 Qed.
 
 Lemma colL_length {A B C} circuit a bs :
-  length (fst (unIdent (@colL ident _ A B C circuit (a,bs))))
+  length (fst (@colL ident _ A B C circuit (a,bs)))
   = length bs.
 Proof.
   cbv [colL]; cbn [fst snd].
@@ -157,7 +157,7 @@ Qed.
 Hint Rewrite @colL_length using solve [length_hammer] : push_length.
 
 Lemma addVCorrect (cin : bool) (n : nat) (a b : Vector.t bool n) :
-  unIdent (addLWithCinV cin a b) =
+  addLWithCinV cin a b =
   (N2Bv_sized (n+1) (Bv2N a + Bv2N b + (N.b2n cin))).
 Proof.
   apply Bv2N_inj. rewrite Bv2N_N2Bv_sized.

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -19,7 +19,6 @@ Import ListNotations.
 Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
-Require Export ExtLib.Data.Monads.IdentityMonad.
 Import MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.

--- a/cava/Cava/Lib/VecProperties.v
+++ b/cava/Cava/Lib/VecProperties.v
@@ -29,72 +29,72 @@ Existing Instance CombinationalSemantics.
 Local Ltac crush :=
   (* inline Vec definition *)
   lazymatch goal with
-  | |- unIdent ?x = _ =>
+  | |- ?x = _ =>
     let f := app_head x in cbv [f]
   end;
-  simpl_ident; eauto using map_id_ext.
+  simpl_ident; eauto.
 
 
 Lemma bitvec_literal_correct n (v : Vector.t bool n) :
-  unIdent (Vec.bitvec_literal v) = v.
-Proof. crush. Qed.
+  Vec.bitvec_literal v = v.
+Proof. crush. apply map_id_ext; eauto. Qed.
 Hint Rewrite @bitvec_literal_correct using solve [eauto] : simpl_ident.
 
 Lemma nil_correct A :
-  unIdent (@Vec.nil _ _ A) = [].
+  @Vec.nil _ _ A = [].
 Proof. crush. Qed.
 Hint Rewrite @nil_correct using solve [eauto] : simpl_ident.
 
 Lemma cons_correct A n x (v : combType (Vec A n)) :
-  unIdent (Vec.cons x v) = (x :: v).
+  Vec.cons x v = (x :: v).
 Proof. crush. Qed.
 Hint Rewrite @cons_correct using solve [eauto] : simpl_ident.
 
 Lemma tl_correct A n (v : combType (Vec A (S n))) :
-  unIdent (Vec.tl v) = Vector.tl v.
+  Vec.tl v = Vector.tl v.
 Proof. crush. Qed.
 Hint Rewrite @tl_correct using solve [eauto] : simpl_ident.
 
 Lemma hd_correct A n (v : combType (Vec A (S n))) :
-  unIdent (Vec.hd v) = Vector.hd v.
+  Vec.hd v = Vector.hd v.
 Proof. crush. Qed.
 Hint Rewrite @hd_correct using solve [eauto] : simpl_ident.
 
 Lemma const_correct A (x : combType A) n :
-  unIdent (Vec.const x n) = Vector.const x n.
+  Vec.const x n = Vector.const x n.
 Proof. crush. Qed.
 Hint Rewrite @const_correct using solve [eauto] : simpl_ident.
 
 Lemma rev_correct A n (v : combType (Vec A (S n))) :
-  unIdent (Vec.rev v) = Vector.rev v.
+  Vec.rev v = Vector.rev v.
 Proof. crush. Qed.
 Hint Rewrite @rev_correct using solve [eauto] : simpl_ident.
 
 Lemma last_correct A n (v : combType (Vec A (S n))) :
-  unIdent (Vec.last v) = Vector.last v.
+  Vec.last v = Vector.last v.
 Proof. crush. Qed.
 Hint Rewrite @last_correct using solve [eauto] : simpl_ident.
 
 Lemma shiftin_correct A n x (v : combType (Vec A n)) :
-  unIdent (Vec.shiftin x v) = (Vector.shiftin x v).
+  Vec.shiftin x v = (Vector.shiftin x v).
 Proof. crush. Qed.
 Hint Rewrite @shiftin_correct using solve [eauto] : simpl_ident.
 
 Lemma shiftout_correct A n (v : combType (Vec A (S n))) :
-  unIdent (Vec.shiftout v) = Vector.shiftout v.
+  Vec.shiftout v = Vector.shiftout v.
 Proof. crush. Qed.
 Hint Rewrite @shiftout_correct using solve [eauto] : simpl_ident.
 
 Lemma transpose_correct A n m (v : combType (Vec (Vec A n) m)) :
-  unIdent (Vec.transpose v) = transpose v.
+  Vec.transpose v = transpose v.
 Proof.
   crush. rewrite !Vector.map_id; reflexivity.
 Qed.
 Hint Rewrite @transpose_correct using solve [eauto] : simpl_ident.
 
 Lemma fold_left_correct A B n f b v :
-  unIdent (@Vec.fold_left _ _ A B f n v b)
-  = Vector.fold_left (fun x y => unIdent (f (x,y))) b v.
+  @Vec.fold_left _ _ A B f n v b
+  = Vector.fold_left (fun x y => f (x,y)) b v.
 Proof.
   revert v b; induction n; intros;
     [ apply Vector.case0 with (v:=v); reflexivity | ].
@@ -106,8 +106,8 @@ Qed.
 Hint Rewrite @fold_left_correct using solve [eauto] : simpl_ident.
 
 Lemma fold_left2_correct A B C n f c va vb :
-  unIdent (@Vec.fold_left2 _ _ A B C f n va vb c)
-  = Vector.fold_left2 (fun x y z => unIdent (f (x,y,z))) c va vb.
+  @Vec.fold_left2 _ _ A B C f n va vb c
+  = Vector.fold_left2 (fun x y z => f (x,y,z)) c va vb.
 Proof.
   revert va vb c; induction n; intros;
     [ apply Vector.case0 with (v:=va);
@@ -121,14 +121,13 @@ Qed.
 Hint Rewrite @fold_left2_correct using solve [eauto] : simpl_ident.
 
 Lemma map_correct A B n f v :
-  unIdent (@Vec.map _ _ A B n f v)
-  = Vector.map (fun x => unIdent (f x)) v.
+  @Vec.map _ _ A B n f v = Vector.map f v.
 Proof. crush. Qed.
 Hint Rewrite @map_correct using solve [eauto] : simpl_ident.
 
 Lemma map2_correct A B C n f va vb :
-  unIdent (@Vec.map2 _ _ A B C n f va vb)
-  = Vector.map2 (fun x y => unIdent (f (x,y))) va vb.
+  @Vec.map2 _ _ A B C n f va vb
+  = Vector.map2 (fun x y => f (x,y)) va vb.
 Proof.
   crush. rewrite map_vcombine_map2.
   reflexivity.

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -25,7 +25,6 @@ Require Import Coq.Init.Nat Coq.micromega.Lia.
 
 Require Import ExtLib.Structures.Applicative.
 Require Import ExtLib.Structures.Traversable.
-Require Export ExtLib.Data.Monads.IdentityMonad.
 
 Require Cava.ListUtils.
 

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -55,7 +55,6 @@ library
                      Datatypes
                      FullAdder
                      HexString
-                     IdentityMonad
                      List
                      ListUtils
                      Logic
@@ -90,6 +89,7 @@ library
                      Decimal
                      Functor
                      Hexadecimal
+                     Identity
                      Numeral
                      Specif
                      MonadExc

--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -87,13 +87,13 @@ Local Ltac solve_side_conditions :=
   cbv zeta; intros;
   lazymatch goal with
   | |- ?x = ?x => reflexivity
-  | |- context [unIdent (aes_add_round_key _ _) = _] =>
+  | |- context [aes_add_round_key _ _ = _] =>
     eapply add_round_key_equiv
-  | |- context [unIdent (aes_sub_bytes _ _) = _] =>
+  | |- context [aes_sub_bytes _ _ = _] =>
     eapply sub_bytes_equiv
-  | |- context [unIdent (aes_shift_rows _ _) = _] =>
+  | |- context [aes_shift_rows _ _ = _] =>
     eapply shift_rows_equiv
-  | |- context [unIdent (aes_mix_columns _ _) = _] =>
+  | |- context [aes_mix_columns _ _ = _] =>
     eapply mix_columns_equiv
   | |- context [_ < 2 ^ 4] => change (2 ^ 4)%nat with 16; Lia.lia
   | |- map fst (all_keys _ _ _) = _ => solve [eauto]

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
@@ -53,7 +53,7 @@ Section Equivalence.
   Qed.
 
   Lemma add_round_key_equiv (k : key) (st : state) :
-    unIdent (aes_add_round_key k st)
+    aes_add_round_key k st
     = AES256.aes_add_round_key_circuit_spec k st.
   Proof.
     cbv [AES256.aes_add_round_key_circuit_spec

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyTests.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyTests.v
@@ -38,7 +38,7 @@ Section FIPSTests.
          fun st =>
            let input := from_flat st in
            let k := from_flat key in
-           let output := unIdent (aes_add_round_key k input) in
+           let output := aes_add_round_key k input in
            to_flat output
        | _ => aes_impl step key
        end).

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -198,7 +198,7 @@ Section WithCava.
     (xs: Vector.t (cipher_control_signals cava_signal) n)
     : cipher_control_signals (vector_cava_signal n) :=
     match xs with
-    | [] => Build_cipher_control_signals _
+    | [] => Build_cipher_control_signals (vector_cava_signal 0)
       (ret []) (ret []) (ret []) (ret []) (ret []) (ret []) (ret [])
       (ret []) (ret []) (ret []) (ret []) (ret []) (ret []) (ret [])
       (ret []) (ret []) (ret []) (ret []) (ret []) (ret [])

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -83,16 +83,16 @@ Section WithSubroutines.
           (add_round_key_spec : state -> key -> state).
   Context
     (sub_bytes_correct : forall (is_decrypt : bool) (st : state),
-        unIdent (sub_bytes is_decrypt st)
+        sub_bytes is_decrypt st
         = if is_decrypt then inv_sub_bytes_spec st else sub_bytes_spec st)
     (shift_rows_correct : forall (is_decrypt : bool) (st : state),
-        unIdent (shift_rows is_decrypt st)
+        shift_rows is_decrypt st
         = if is_decrypt then inv_shift_rows_spec st else shift_rows_spec st)
     (mix_columns_correct : forall (is_decrypt : bool) (st : state),
-        unIdent (mix_columns is_decrypt st)
+        mix_columns is_decrypt st
         = if is_decrypt then inv_mix_columns_spec st else mix_columns_spec st)
     (add_round_key_correct :
-       forall k (st : state), unIdent (add_round_key k st) = add_round_key_spec st k).
+       forall k (st : state), add_round_key k st = add_round_key_spec st k).
 
   (* Formula for each round based on index *)
   Let round_spec (Nr : nat) (is_decrypt : bool) (k : key) (st : state) (i : nat) : state :=
@@ -133,13 +133,13 @@ Section WithSubroutines.
                      then if Nat.eqb i 0 then false
                           else if Nat.eqb i Nr then false else true
                      else false) ->
-    unIdent (cipher_round
-               (key:=Vec (Vec (Vec Bit 8) 4) 4)
-               (state:=Vec (Vec (Vec Bit 8) 4) 4)
-               (round_index:=Vec Bit 4)
-               sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-               is_decrypt k add_round_key_in_sel round_key_sel
-               (nat_to_bitvec_sized _ i) data)
+    cipher_round
+      (key:=Vec (Vec (Vec Bit 8) 4) 4)
+      (state:=Vec (Vec (Vec Bit 8) 4) 4)
+      (round_index:=Vec Bit 4)
+      sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
+      is_decrypt k add_round_key_in_sel round_key_sel
+      (nat_to_bitvec_sized _ i) data
     = round_spec Nr is_decrypt k data i.
   Proof.
     cbv zeta; intros. subst_lets. subst. destruct_products.
@@ -156,14 +156,13 @@ Section WithSubroutines.
     1 < Nr < 2 ^ 4 -> i <= Nr ->
     num_regular_rounds = nat_to_bitvec_sized _ Nr ->
     is_first_round = (i =? 0)%nat ->
-    unIdent
-      (cipher_step
-         (key:=Vec (Vec (Vec Bit 8) 4) 4)
-         (state:=Vec (Vec (Vec Bit 8) 4) 4)
-         (round_index:=Vec Bit 4)
-         sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
-         is_decrypt is_first_round num_regular_rounds
-         k (nat_to_bitvec_sized _ i) data)
+    cipher_step
+      (key:=Vec (Vec (Vec Bit 8) 4) 4)
+      (state:=Vec (Vec (Vec Bit 8) 4) 4)
+      (round_index:=Vec Bit 4)
+      sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
+      is_decrypt is_first_round num_regular_rounds
+      k (nat_to_bitvec_sized _ i) data
     = round_spec Nr is_decrypt k data i.
   Proof.
     cbv zeta; intro Hall_keys; intros. subst.

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -23,7 +23,6 @@ Import VectorNotations.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
-Open Scope monad_scope.
 
 Require Import coqutil.Tactics.Tactics.
 Require Import Cava.BitArithmetic.
@@ -44,7 +43,9 @@ Require Import AesSpec.Cipher.
 Require Import AesSpec.CipherProperties.
 Require Import AcornAes.CipherCircuit.
 
-Existing Instance Combinational.CombinationalSemantics.
+Local Open Scope list_scope.
+Local Open Scope monad_scope.
+Existing Instance CombinationalSemantics.
 
 Local Notation byte := (Vector.t bool 8).
 Local Notation state := (Vector.t (Vector.t byte 4) 4) (only parsing).

--- a/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
@@ -48,7 +48,7 @@ Section Equivalence.
   Local Notation key := (Vector.t (Vector.t byte 4) 4) (only parsing).
 
   Lemma aes_transpose_correct n m (v : combType (Vec (Vec (Vec Bit 8) n) m)) :
-    unIdent (aes_transpose v) = transpose v.
+    aes_transpose v = transpose v.
   Proof. cbv [aes_transpose]; simpl_ident; reflexivity. Qed.
 
   Lemma poly_to_byte_to_bitvec p :
@@ -65,7 +65,7 @@ Section Equivalence.
   Qed.
 
   Lemma xorV_is_add (b1 b2 : byte) :
-    unIdent (xorV (n:=8) (b1, b2))
+    xorV (n:=8) (b1, b2)
     = byte_to_bitvec (Polynomial.fadd (bitvec_to_byte b1)
                                       (bitvec_to_byte b2)).
   Proof.
@@ -79,13 +79,13 @@ Section Equivalence.
   Qed.
 
   Lemma xorv_is_add (b1 b2 : byte) :
-    unIdent (xorv (n:=8) b1 b2)
+    xorv (n:=8) b1 b2
     = byte_to_bitvec (Polynomial.fadd (bitvec_to_byte b1)
                                       (bitvec_to_byte b2)).
   Proof. apply xorV_is_add. Qed.
 
   Lemma aes_mul2_correct (b : byte) :
-    unIdent (aes_mul2 b)
+    aes_mul2 b
     = byte_to_bitvec (Polynomial.fmul Byte.x02
                                       (bitvec_to_byte b)).
   Proof.
@@ -93,7 +93,7 @@ Section Equivalence.
   Qed.
 
   Lemma aes_mul4_correct (b : byte) :
-    unIdent (aes_mul4 b)
+    aes_mul4 b
     = byte_to_bitvec (Polynomial.fmul Byte.x04
                                       (bitvec_to_byte b)).
   Proof.
@@ -107,7 +107,7 @@ Section Equivalence.
 
   Local Open Scope poly_scope.
 
-  Lemma zero_byte_correct : bitvec_to_byte (unIdent zero_byte) = fzero.
+  Lemma zero_byte_correct : bitvec_to_byte zero_byte = fzero.
   Proof. reflexivity. Qed.
   Hint Rewrite zero_byte_correct using solve [eauto] : simpl_ident.
 
@@ -130,7 +130,7 @@ Section Equivalence.
   Add Ring bytering : MixColumns.ByteTheory (preprocess [prering]).
 
   Lemma mix_single_column_equiv (is_decrypt : bool) (col : Vector.t byte 4) :
-    unIdent (aes_mix_single_column is_decrypt col)
+    aes_mix_single_column is_decrypt col
     = if is_decrypt
        then map byte_to_bitvec
                 (MixColumns.inv_mix_single_column (map bitvec_to_byte col))
@@ -162,7 +162,7 @@ Section Equivalence.
   Qed.
 
   Lemma mix_columns_equiv (is_decrypt : bool) (st : state) :
-    unIdent (aes_mix_columns is_decrypt st)
+    aes_mix_columns is_decrypt st
     = AES256.aes_mix_columns_circuit_spec is_decrypt st.
   Proof.
     cbv [aes_mix_columns mcompose]. simpl_ident.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsTests.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsTests.v
@@ -37,12 +37,12 @@ Section FIPSTests.
        | MixColumns =>
          fun st =>
            let input := from_flat st in
-           let output := unIdent (aes_mix_columns false input) in
+           let output := aes_mix_columns false input in
            to_flat output
        | InvMixColumns =>
          fun st =>
            let input := from_flat st in
-           let output := unIdent (aes_mix_columns true input) in
+           let output := aes_mix_columns true input in
            to_flat output
        | _ => aes_impl step key
        end).
@@ -93,7 +93,7 @@ Proof. vm_compute. reflexivity. Qed.
 
 Local Open Scope list_scope.
 
-Definition o1 : Vector.t (Vector.t (Vector.t bool 8) 4) 4 := unIdent (aes_mix_columns false i1).
+Definition o1 : Vector.t (Vector.t (Vector.t bool 8) 4) 4 := aes_mix_columns false i1.
 
 Local Open Scope vector_scope.
 

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsEquivalence.v
@@ -42,7 +42,7 @@ Section Equivalence.
   Local Notation key := (Vector.t (Vector.t byte 4) 4) (only parsing).
 
   Lemma shift_rows_equiv (is_decrypt : bool) (st : state) :
-    unIdent (aes_shift_rows is_decrypt st)
+    aes_shift_rows is_decrypt st
     = AES256.aes_shift_rows_circuit_spec is_decrypt st.
   Proof.
     (* simplify RHS (specification) *)

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsTests.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsTests.v
@@ -34,12 +34,12 @@ Section FIPSTests.
        | ShiftRows =>
          fun st =>
            let input := from_flat st in
-           let output := unIdent (aes_shift_rows false input) in
+           let output := aes_shift_rows false input in
            to_flat output
        | InvShiftRows =>
          fun st =>
            let input := from_flat st in
-           let output := unIdent (aes_shift_rows true input) in
+           let output := aes_shift_rows true input in
            to_flat output
        | _ => aes_impl step key
        end).

--- a/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
@@ -44,7 +44,7 @@ Section Equivalence.
 
   Lemma sub_bytes_fwd_bytewise:
     forall (b : byte),
-    unIdent (aes_sbox_lut false b) = byte_to_bitvec (Sbox.forward_sbox (bitvec_to_byte b)).
+    aes_sbox_lut false b = byte_to_bitvec (Sbox.forward_sbox (bitvec_to_byte b)).
   Proof.
     intros.
     repeat match goal with
@@ -57,7 +57,7 @@ Section Equivalence.
 
   Lemma sub_bytes_inv_bytewise:
     forall (b : byte),
-    unIdent (aes_sbox_lut true b) = byte_to_bitvec (Sbox.inverse_sbox (bitvec_to_byte b)).
+    aes_sbox_lut true b = byte_to_bitvec (Sbox.inverse_sbox (bitvec_to_byte b)).
   Proof.
     intros.
     repeat match goal with
@@ -68,8 +68,8 @@ Section Equivalence.
     end; vm_compute; reflexivity.
   Qed.
 
-  Lemma sub_bytes_bytewise is_decrypt (b : byte):
-    unIdent (aes_sbox_lut is_decrypt b)
+  Lemma sub_bytes_bytewise (is_decrypt : bool) (b : byte):
+    aes_sbox_lut is_decrypt b
     = byte_to_bitvec
          ((if is_decrypt then Sbox.inverse_sbox else Sbox.forward_sbox)
             (bitvec_to_byte b)).
@@ -79,8 +79,8 @@ Section Equivalence.
 
   Lemma sub_bytes_equiv :
     forall (is_decrypt : bool) (st : state),
-      unIdent (aes_sub_bytes is_decrypt st)
-    = AES256.aes_sub_bytes_circuit_spec is_decrypt st.
+      aes_sub_bytes is_decrypt st
+      = AES256.aes_sub_bytes_circuit_spec is_decrypt st.
   Proof.
     intros.
 

--- a/silveroak-opentitan/aes/Acorn/SubBytesTests.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesTests.v
@@ -34,12 +34,12 @@ Section FIPSTests.
        | SubBytes =>
          fun st =>
            let input := from_flat st in
-           let output := unIdent (aes_sub_bytes false input) in
+           let output := aes_sub_bytes false input in
            to_flat output
        | InvSubBytes =>
          fun st =>
            let input := from_flat st in
-           let output := unIdent (aes_sub_bytes true input) in
+           let output := aes_sub_bytes true input in
            to_flat output
        | _ => aes_impl step key
        end).

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -52,7 +52,7 @@ Definition accumulatingAdderEnableSpec
     i ([], bvzero).
 
 Lemma addNCorrect n (a b : Vector.t bool n) :
-  unIdent (addN (a, b)) = bvadd a b.
+  addN (a, b) = bvadd a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : simpl_ident.
 

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -55,7 +55,7 @@ Definition addWithDelaySpecF
     end.
 
 Lemma addNCorrect n (a b : combType (Vec Bit n)) :
-  unIdent (addN (a, b)) = bvadd a b.
+  addN (a, b) = bvadd a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : simpl_ident.
 

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -45,7 +45,7 @@ Definition countBySpec (i : list (Bvector 8)) : list (Bvector 8) :=
   map (fun t => bvsum (firstn t i)) (seq 1 (length i)).
 
 Lemma addNCorrect n (a b : Bvector n) :
-  unIdent (addN (a, b)) = bvadd a b.
+  addN (a, b) = bvadd a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : simpl_ident.
 

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -64,17 +64,17 @@ Definition double_count_by_spec (i : list (Vector.t bool 8)) : list (Vector.t bo
   map (fun t => boolsum (firstn t (map snd (count_by_spec i)))) (seq 1 (length i)).
 
 Lemma addN_correct {n} (x y : combType (Vec Bit n)) :
-  unIdent (addN (x, y)) = bvadd x y.
+  addN (x, y) = bvadd x y.
 Admitted.
 Hint Rewrite @addN_correct : simpl_ident.
 
 Lemma ltV_correct {n m} x y :
-  unIdent (ltV (n:=n) (m:=m) (x, y)) = (Bv2N x <? Bv2N y)%N.
+  ltV (n:=n) (m:=m) (x, y) = (Bv2N x <? Bv2N y)%N.
 Admitted.
 Hint Rewrite @ltV_correct : simpl_ident.
 
 Lemma addC_correct {n} (x y : combType (Vec Bit n)) :
-  unIdent (addC (x, y)) = bvaddc x y.
+  addC (x, y) = bvaddc x y.
 Proof.
   cbv [addC bvaddc]. cbv [CombinationalSemantics].
   simpl_ident. cbv [bvadd].
@@ -84,7 +84,7 @@ Qed.
 Hint Rewrite @addC_correct : simpl_ident.
 
 Lemma incrN_correct {n} (x : combType (Vec Bit (S n))) :
-  unIdent (incrN x) = N2Bv_sized (S n) (Bv2N x + 1).
+  incrN x = N2Bv_sized (S n) (Bv2N x + 1).
 Proof.
   cbv [incrN].
   cbn [CombinationalSemantics unpackV packV unsignedAdd unsignedAddBool constant].

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -104,16 +104,16 @@ Definition v6 := N2Bv_sized 8 240.
 Definition v7 := N2Bv_sized 8  42.
 Definition v4to7 : Vector.t (Bvector 8) 4 := [v4; v5; v6; v7].
 
-Example m5: unIdent (muxBus (v0to3, [false; false]%vector)) = v0.
+Example m5: muxBus (v0to3, [false; false]%vector) = v0.
 Proof. reflexivity. Qed.
 
-Example m6: unIdent (muxBus (v0to3, [true; false]%vector)) = v1.
+Example m6: muxBus (v0to3, [true; false]%vector) = v1.
 Proof. reflexivity. Qed.
 
-Example m7: unIdent (muxBus (v0to3, [false; true]%vector)) = v2.
+Example m7: muxBus (v0to3, [false; true]%vector) = v2.
 Proof. reflexivity. Qed.
 
-Example m8: unIdent (muxBus (v0to3, [true; true]%vector)) = v3.
+Example m8: muxBus (v0to3, [true; true]%vector) = v3.
 Proof. reflexivity. Qed.
 
 Local Close Scope vector_scope.

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -46,11 +46,11 @@ Definition bv3_7  := N2Bv_sized 3  7.
 Definition bv5_15 := N2Bv_sized 5 15.
 
 (* Check 3 * 5 = 30 *)
-Example mult3_5 : unIdent (multiplier (bv2_3, bv3_5)) = bv5_15.
+Example mult3_5 : multiplier (bv2_3, bv3_5) = bv5_15.
 Proof. reflexivity. Qed.
 
 (* Check 3 * 5 = 30 *)
-Example mult3_5_top : unIdent (multiplier (bv2_3, bv3_5)) = bv5_15.
+Example mult3_5_top : multiplier (bv2_3, bv3_5) = bv5_15.
 Proof. reflexivity. Qed.
 
 (******************************************************************************)


### PR DESCRIPTION
Resolves #591 

Cleans up our lemma statements and single-step simulations of combinational circuits by using our own identity monad that does not have a wrapper record type.