### PR TITLE
Renaming and tweaks to trees

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -46,21 +46,21 @@ Section WithCava.
   (* An adder-tree with no bit-growth. *)
   Definition adderTree {sz: nat}
              (n: nat)
-    : signal (Vec (Vec Bit sz) (2^(S n))) ->
+    : signal (Vec (Vec Bit sz) (2^n)) ->
       cava (signal (Vec Bit sz)) :=
-    unpackV >=> treeS addN.
+    tree addN.
 
   (* An adder tree with 2 inputs. *)
   Definition adderTree2 {sz: nat}
                         (v : signal (Vec (Vec Bit sz) 2))
                         : cava (signal (Vec Bit sz))
-    := adderTree 0 v.
+    := adderTree 1 v.
 
   (* An adder tree with 4 inputs. *)
   Definition adderTree4 {sz: nat}
                         (v : signal (Vec (Vec Bit sz) 4))
                         : cava (signal (Vec Bit sz))
-    := adderTree 1 v.
+    := adderTree 2 v.
 
 End WithCava.
 
@@ -79,7 +79,7 @@ Local Open Scope string_scope.
 Local Open Scope vector_scope.
 
 Definition v0_v1 := [v0; v1].
-Definition v0_plus_v1 : Bvector 8 := adderTree 0 v0_v1.
+Definition v0_plus_v1 : Bvector 8 := adderTree 1 v0_v1.
 
 Example sum_vo_v1 : adderTree2 v0_v1 = N2Bv_sized 8 21.
 Proof. reflexivity. Qed.
@@ -123,7 +123,7 @@ Definition adder_tree32_8Interface
   := adder_tree_Interface "adder_tree32_8" 32 8.
 
 Definition adder_tree32_8Netlist
-  := makeNetlist adder_tree32_8Interface (adderTree 4).
+  := makeNetlist adder_tree32_8Interface (adderTree 5).
 
 (* Create netlist and test-bench for a 64-input adder tree. *)
 
@@ -131,7 +131,7 @@ Definition adder_tree64_8Interface
   := adder_tree_Interface "adder_tree64_8" 64 8.
 
 Definition adder_tree64_8Netlist
-  := makeNetlist adder_tree64_8Interface (adderTree 5).
+  := makeNetlist adder_tree64_8Interface (adderTree 6).
 
 Definition adder_tree64_8_tb_inputs
   := map (Vector.map (N2Bv_sized 8))
@@ -139,7 +139,7 @@ Definition adder_tree64_8_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_8_tb_expected_outputs
-  := simulate (Comb (adderTree 5)) adder_tree64_8_tb_inputs.
+  := simulate (Comb (adderTree 6)) adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "adder_tree64_8_tb" adder_tree64_8Interface
@@ -150,7 +150,7 @@ Definition adder_tree64_8_tb :=
 Definition adder_tree64_128Interface := adder_tree_Interface "adder_tree64_128" 64 128.
 
 Definition adder_tree64_128Netlist
-  := makeNetlist adder_tree64_128Interface (adderTree 5).
+  := makeNetlist adder_tree64_128Interface (adderTree 6).
 
 Definition adder_tree64_128_tb_inputs
   := map (Vector.map (N2Bv_sized 128))
@@ -158,7 +158,7 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := simulate (Comb (adderTree 5)) adder_tree64_128_tb_inputs.
+  := simulate (Comb (adderTree 6)) adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "adder_tree64_128_tb" adder_tree64_128Interface

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -41,9 +41,9 @@ Section WithCava.
   (****************************************************************************)
   Definition adderTree {sz: nat}
              (n: nat)
-    : signal (Vec (Vec Bit sz) (2^(S n))) ->
+    : signal (Vec (Vec Bit sz) (2^n)) ->
       cava (signal (Vec Bit sz)) :=
-    unpackV >=> tree defaultSignal n xilinxAdder.
+    tree (fun '(x,y) => xilinxAdder x y).
 
   (****************************************************************************)
   (* An adder tree with 2 inputs.                                             *)
@@ -51,7 +51,7 @@ Section WithCava.
   Definition adderTree2 {sz: nat}
                         (v : signal (Vec (Vec Bit sz) 2))
                         : cava (signal (Vec Bit sz))
-    := adderTree 0 v.
+    := adderTree 1 v.
 
   (******************************************************************************)
   (* An adder tree with 4 inputs.                                               *)
@@ -59,7 +59,7 @@ Section WithCava.
   Definition adderTree4 {sz: nat}
                         (v : signal (Vec (Vec Bit sz) 4))
                         : cava (signal (Vec Bit sz))
-    := adderTree 1 v.
+    := adderTree 2 v.
 
 End WithCava.
 
@@ -131,21 +131,21 @@ Proof. reflexivity. Qed.
 Definition adder_tree32_8Interface := adder_tree_Interface "xadder_tree32_8" 32 8.
 
 Definition adder_tree32_8Netlist
-  := makeNetlist adder_tree32_8Interface (adderTree 4).
+  := makeNetlist adder_tree32_8Interface (adderTree 5).
 
 (* Create netlist and test-bench for a 64-input adder tree. *)
 
 Definition adder_tree64_8Interface := adder_tree_Interface "xadder_tree64_8" 64 8.
 
 Definition adder_tree64_8Netlist
-  := makeNetlist adder_tree64_8Interface (adderTree 5).
+  := makeNetlist adder_tree64_8Interface (adderTree 6).
 
 Definition adder_tree64_8_tb_inputs
   := map (fun i => Vector.map (N2Bv_sized 8) (Vector.map N.of_nat i))
      [vseq 0 64; vseq 64 64; vseq 128 64].
 
 Definition adder_tree64_8_tb_expected_outputs
-  := simulate (Comb (adderTree 5)) adder_tree64_8_tb_inputs.
+  := simulate (Comb (adderTree 6)) adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "xadder_tree64_8_tb" adder_tree64_8Interface
@@ -158,7 +158,7 @@ Definition adder_tree64_8_tb :=
 Definition adder_tree64_128Interface := adder_tree_Interface "xadder_tree64_128" 64 128.
 
 Definition adder_tree64_128Netlist
-  := makeNetlist adder_tree64_128Interface (adderTree 5).
+  := makeNetlist adder_tree64_128Interface (adderTree 6).
 
 Definition adder_tree64_128_tb_inputs
   := map (fun i => Vector.map (N2Bv_sized 128) i)
@@ -166,7 +166,7 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := simulate (Comb (adderTree 5)) adder_tree64_128_tb_inputs.
+  := simulate (Comb (adderTree 6)) adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "xadder_tree64_128_tb" adder_tree64_128Interface
@@ -179,7 +179,7 @@ Definition adder_tree64_128_tb :=
 Definition adder_tree128_256Interface := adder_tree_Interface "xadder_tree128_256" 128 256.
 
 Definition adder_tree128_256Netlist
-  := makeNetlist adder_tree128_256Interface (adderTree 6).
+  := makeNetlist adder_tree128_256Interface (adderTree 7).
 
 Definition adder_tree128_256_tb_inputs : list (Vector.t (Bvector 256) 128)
   := map (fun i => Vector.map (N2Bv_sized 256) i)
@@ -188,7 +188,7 @@ Definition adder_tree128_256_tb_inputs : list (Vector.t (Bvector 256) 128)
 
 Definition adder_tree128_256_tb_expected_outputs
            : list (Bvector 256)
-  := simulate (Comb (adderTree 6)) adder_tree128_256_tb_inputs.
+  := simulate (Comb (adderTree 7)) adder_tree128_256_tb_inputs.
 
 Definition adder_tree128_256_tb :=
   testBench "xadder_tree128_256_tb" adder_tree128_256Interface

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -402,18 +402,18 @@ Section WithCava.
     Vector.t A (2 ^ n) * Vector.t A (2 ^ n) :=
     splitat _ (@resize_default A (2 ^ (S n)) default (2 ^ n + 2 ^ n) v).
 
-  Fixpoint tree {T: Type} {m} `{Monad m}
-                          (default : T) (n : nat)
-                          (circuit: T -> T -> m T)
-                          (v : Vector.t T (2^(S n))) :
-                          m T :=
-    match n, v return m T with
-    | O, v2 => circuit (@Vector.nth_order _ 2 v2 0 (ltac:(lia)))
-                      (@Vector.nth_order _ 2 v2 1 (ltac:(lia)))
-    | S n', vR => let '(vL, vH) := divide default vR in
-                  aS <- tree default n' circuit vL ;;
-                  bS <- tree default n' circuit vH ;;
-                  circuit aS bS
+  Fixpoint pow2tree_generic {T: Type} {m} `{Monad m}
+                         (default : T) (n : nat)
+                         (circuit: T -> T -> m T)
+                         : Vector.t T (2^n) -> m T :=
+    match n as n return Vector.t T (2^n) -> m T with
+    | O => fun v : Vector.t T 1 => ret (Vector.hd v)
+    | S n'=>
+      fun vR =>
+        let '(vL, vH) := divide default vR in
+        aS <- pow2tree_generic default n' circuit vL ;;
+        bS <- pow2tree_generic default n' circuit vH ;;
+        circuit aS bS
     end.
 
   Lemma append_divide {A} d n H (v : t A (2 ^ (S n))) :
@@ -431,18 +431,19 @@ Section WithCava.
     reflexivity.
   Qed.
 
-  (* A specialization of tree that is constrained to take Cava signal types
-    i.e. only types that we support as values over wires for Cava circuits.
-    This allows the default value to be computed automatically. *)
-  Definition treeS {t: SignalType} {n}
+  (* A specialization of pow2tree_generic that is constrained to take Cava
+    signal types i.e. only types that we support as values over wires for Cava
+    circuits. This allows the default value to be computed automatically. *)
+  Definition pow2tree {t: SignalType} n
                    (circuit: signal t * signal t -> cava (signal t))
-                   (v : Vector.t (signal t) (2^(S n))) :
+                   (v : signal (Vec t (2^n))) :
                    cava (signal t) :=
-  tree defaultSignal n (fun a b => circuit (a, b)) v.
+    v <- unpackV v ;;
+    pow2tree_generic defaultSignal n (fun a b => circuit (a, b)) v.
 
   Local Open Scope nat_scope.
 
-  Lemma tree_equiv'
+  Lemma pow2tree_generic_equiv'
         {T}  {monad_laws : MonadLaws monad} (valid : T -> Prop)
         (id : T)
         (op : T -> T -> T)
@@ -460,16 +461,15 @@ Section WithCava.
         (default : T) (n : nat) :
     forall v,
       ForallV valid v ->
-      tree default n circuit v = ret (Vector.fold_left op id v).
+      pow2tree_generic default n circuit v = ret (Vector.fold_left op id v).
   Proof.
     induction n; intros.
-    { change (2 ^ 1) with 2 in *.
-      cbn [tree]. autorewrite with push_vector_fold vsimpl.
-      rewrite hd_0. autorewrite with vsimpl. cbn [ForallV] in *.
-      rewrite circuit_equiv, op_id_left; try tauto; [ ].
-      constant_vector_simpl v. cbn; tauto. }
-    { cbn [tree]. destruct_pair_let.
-      assert (2 ^ (S (S n)) = 2 ^ (S n) + 2 ^ (S n)) as Heq
+    { change (2 ^ 0) with 1 in *.
+      cbn [pow2tree_generic ForallV] in *.
+      autorewrite with push_vector_fold vsimpl.
+      rewrite op_id_left by tauto. reflexivity. }
+    { cbn [pow2tree_generic]. destruct_pair_let.
+      assert (2 ^ (S n) = 2 ^ n + 2 ^ n) as Heq
         by abstract (rewrite Nat.pow_succ_r by lia; lia).
       lazymatch goal with
       | _ : ForallV ?P ?v |- context [divide ?d ?v] =>
@@ -489,7 +489,7 @@ Section WithCava.
       rewrite fold_left_resize. reflexivity. }
   Qed.
 
-  Lemma tree_equiv
+  Lemma pow2tree_generic_equiv
         {T}  {monad_laws : MonadLaws monad}
         (id : T)
         (op : T -> T -> T)
@@ -503,9 +503,9 @@ Section WithCava.
           forall a b : T, circuit a b = ret (op a b))
         (default : T) (n : nat) :
     forall v,
-      tree default n circuit v = ret (Vector.fold_left op id v).
+      pow2tree_generic default n circuit v = ret (Vector.fold_left op id v).
   Proof.
-    intros. apply tree_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
+    intros. apply pow2tree_generic_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
   Qed.
 
   (* Version of tree combinator that accepts all sizes by creating a tree out of
@@ -520,19 +520,24 @@ Section WithCava.
 
      ...instead of &-ing i4 and i5 together before combining them with the
      tree. *)
-  Definition tree_all_sizes {m} {monad : Monad m} {A}
+  Definition tree_generic {m} {monad : Monad m} {A}
              (default : A) (circuit : A -> A -> m A) {n} (v : Vector.t A n) : m A :=
     let '(v1, v2) := Vector.splitat (2 ^ Nat.log2 n)
                                     (resize_default
                                        default (2 ^ Nat.log2 n + (n - 2 ^ Nat.log2 n))
                                        v) in
-    tree_result <- (match Nat.log2 n as n0 return Vector.t A (2 ^ n0) -> m A with
-                   | 0 => fun v : Vector.t A 1 => ret (Vector.hd v)
-                   | S n' => fun v : Vector.t A (2 ^ S n') => tree default n' circuit v
-                   end) v1 ;;
+    tree_result <- pow2tree_generic default (Nat.log2 n) circuit v1 ;;
     foldLM circuit (to_list v2) tree_result.
 
-  Lemma tree_all_sizes_equiv' {T} {monad_laws : MonadLaws.MonadLaws monad}:
+  (* specialized to signal so default value can be automatically inferred *)
+  Definition tree {m} {monad : Monad m} {t n}
+                   (circuit: signal t * signal t -> cava (signal t))
+                   (v : signal (Vec t n)) :
+                   cava (signal t) :=
+    v <- unpackV v ;;
+    tree_generic defaultSignal (fun x y => circuit (x,y)) v.
+
+  Lemma tree_generic_equiv' {T} {monad_laws : MonadLaws.MonadLaws monad}:
     forall (id : T) (op : T -> T -> T) (valid : T -> Prop),
       valid id ->
       (forall a b, valid a -> valid b -> valid (op a b)) ->
@@ -544,9 +549,9 @@ Section WithCava.
         (forall a b : T, valid a -> valid b -> circuit a b = ret (op a b)) ->
         forall (default : T) (n : nat) (v : t T n),
           n <> 0 -> ForallV valid v ->
-          tree_all_sizes default circuit v = ret (Vector.fold_left op id v).
+          tree_generic default circuit v = ret (Vector.fold_left op id v).
   Proof.
-    cbv [tree_all_sizes]; intros. repeat destruct_pair_let.
+    cbv [tree_generic]; intros. repeat destruct_pair_let.
     assert (n = 2 ^ Nat.log2 n + (n - 2 ^ Nat.log2 n))
       by (apply Minus.le_plus_minus, Nat.log2_spec; Lia.lia).
     (* change the vector expression on the RHS to match LHS *)
@@ -572,8 +577,7 @@ Section WithCava.
     repeat match goal with H : _ /\ _ |- _ => destruct H end.
     destruct n;[ subst; cbn in *; rewrite MonadLaws.bind_of_return by auto;
                  match goal with H : _ |- _ => rewrite H; solve [auto] end | ].
-    destruct_one_match; [ Lia.lia | ].
-    erewrite tree_equiv' with (valid0:=valid) (id0:=id); eauto; [ | ].
+    erewrite pow2tree_generic_equiv' with (valid0:=valid) (id0:=id); eauto; [ | ].
     { rewrite MonadLaws.bind_of_return by auto.
       rewrite !fold_left_to_list, to_list_resize_default, to_list_append by lia.
       autorewrite with push_list_fold.
@@ -595,7 +599,7 @@ Section WithCava.
       apply ForallV_resize. cbn [ForallV] in *; auto. }
   Qed.
 
-  Lemma tree_all_sizes_equiv {T} {monad_laws : MonadLaws.MonadLaws monad}:
+  Lemma tree_generic_equiv {T} {monad_laws : MonadLaws.MonadLaws monad}:
     forall (id : T) (op : T -> T -> T),
       (forall a : T, op id a = a) ->
       (forall a : T, op a id = a) ->
@@ -604,14 +608,16 @@ Section WithCava.
         (forall a b : T, circuit a b = ret (op a b)) ->
         forall (default : T) (n : nat) (v : t T n),
           n <> 0 ->
-          tree_all_sizes default circuit v = ret (Vector.fold_left op id v).
+          tree_generic default circuit v = ret (Vector.fold_left op id v).
   Proof.
-    intros. apply tree_all_sizes_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
+    intros. apply tree_generic_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
   Qed.
 
   Definition all {n} (v : signal (Vec Bit n)) : cava (signal Bit) :=
-    v <- unpackV v ;;
-    tree_all_sizes one (fun x y => and2 (x,y)) v.
+    match n with
+    | 0 => ret one
+    | _ => tree and2 v
+    end.
 
   Fixpoint eqb {t : SignalType} : signal t -> signal t -> cava (signal Bit) :=
     match t as t0 return signal t0 -> signal t0 -> cava (signal Bit) with

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -32,6 +32,7 @@ Require Import Cava.Acorn.Acorn.
 Require Import Cava.Acorn.Combinational.
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.Combinators.
+Require Import Cava.Acorn.Identity.
 Require Import Cava.Acorn.NetlistGeneration.
 Require Import Cava.Acorn.XilinxAdder.
 Require Import Cava.Acorn.CavaPrelude.
@@ -49,6 +50,7 @@ Recursive Extraction Library Acorn.
 Recursive Extraction Library Circuit.
 Recursive Extraction Library Combinational.
 Recursive Extraction Library Combinators.
+Recursive Extraction Library Identity.
 Recursive Extraction Library Simulation.
 Recursive Extraction Library NetlistGeneration.
 

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -55,6 +55,7 @@ library
                      Datatypes
                      FullAdder
                      HexString
+                     Identity
                      List
                      ListUtils
                      Logic
@@ -89,7 +90,6 @@ library
                      Decimal
                      Functor
                      Hexadecimal
-                     Identity
                      Numeral
                      Specif
                      MonadExc


### PR DESCRIPTION
Side quest for #609

The motivation for this change is to clean up tree naming/input types before I write a tree example for the Cava tutorial.

- Tree combinators have been renamed:
  - `pow2tree_generic` (formerly `tree`) : generic over any Coq type, requires default value, input vector must have size `2^n`
  - `pow2tree` (formerly `treeS`) : specialized to `signal`, input vector must have size `2^n`
  - `tree_generic` (formerly `tree_all_sizes`) : generic over any Coq type, requires default value, input vector can have any size
  - `tree` (formerly did not exist) : specialized to `signal`, input vector can have any size
- `pow2tree*` combinators now accept vectors with size `2^n` instead of `2 ^(S n)`