### PR TITLE
Concise imports

### DIFF
--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -29,7 +29,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 
 Existing Instance CombinationalSemantics.

--- a/acorn-examples/AdderTree.v
+++ b/acorn-examples/AdderTree.v
@@ -14,26 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Bool.Bool Coq.Init.Nat.
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.NArith.NArith.
-
-Require Import Coq.Vectors.Vector.
-Require Import Coq.Bool.Bvector.
-Import VectorNotations.
-
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
-
-Existing Instance CombinationalSemantics.
-Existing Instance CavaCombinationalNet.
+Local Open Scope N_scope.
+Local Open Scope vector_scope.
 
 (******************************************************************************)
 (* A generic description of all adder trees made from a syntheszable adder    *)
@@ -72,11 +55,6 @@ Definition v0 := N2Bv_sized 8  4.
 Definition v2 := N2Bv_sized 8  6.
 Definition v1 := N2Bv_sized 8 17.
 Definition v3 := N2Bv_sized 8  3.
-
-Local Open Scope N_scope.
-Local Open Scope string_scope.
-
-Local Open Scope vector_scope.
 
 Definition v0_v1 := [v0; v1].
 Definition v0_plus_v1 : Bvector 8 := adderTree 1 v0_v1.

--- a/acorn-examples/Examples.v
+++ b/acorn-examples/Examples.v
@@ -16,9 +16,7 @@
 
 (* Experiments with the primitives that form the core of Cava. *)
 
-Require Import Coq.Lists.List.
 Require Import Cava.Cava.
-Import ListNotations.
 
 (* Experiments with the primitive Cava gates. *)
 

--- a/acorn-examples/Examples.v
+++ b/acorn-examples/Examples.v
@@ -17,7 +17,7 @@
 (* Experiments with the primitives that form the core of Cava. *)
 
 Require Import Coq.Lists.List.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Import ListNotations.
 
 (* Experiments with the primitive Cava gates. *)

--- a/acorn-examples/FullAdderExample.v
+++ b/acorn-examples/FullAdderExample.v
@@ -21,7 +21,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.FullAdder.
 Require Import Cava.Lib.XilinxAdder.
 

--- a/acorn-examples/FullAdderExample.v
+++ b/acorn-examples/FullAdderExample.v
@@ -13,19 +13,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Bool.Bool.
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.FullAdder.
-Require Import Cava.Lib.XilinxAdder.
-
-Existing Instance CavaCombinationalNet.
 
 Section WithCava.
   Context {signal} `{Cava signal}.

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -14,24 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
-Require Import Coq.micromega.Lia.
-Require Import Coq.NArith.NArith.
 Require Import Coq.Vectors.Vector.
-Require Import coqutil.Tactics.Tactics.
-Require Import ExtLib.Structures.Monad.
 Require Import Cava.Cava.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Util.Identity.
-Require Import Cava.Util.BitArithmetic.
-Require Import Cava.Util.Nat.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Util.Vector.
-Require Import Cava.Lib.VecProperties.
-Require Cava.Lib.Vec.
-Import VectorNotations ListNotations MonadNotation.
+Require Import Cava.CavaProperties.
 Open Scope monad_scope.
-Open Scope list_scope.
 
 Section WithCava.
   Context `{semantics: Cava}.
@@ -154,9 +140,9 @@ Section Proofs.
   Proof.
     revert carry input; induction sz; intros; [ cbn; f_equal; solve [apply nil_eq] | ].
     cbn [incr']. simpl_ident.
-    rewrite (eta input). autorewrite with vsimpl. repeat destruct_pair_let.
+    rewrite (Vector.eta input). autorewrite with vsimpl.
     rewrite IHsz. rewrite Bv2N_cons.
-    destruct carry, (hd input); boolsimpl;
+    destruct carry, (Vector.hd input); boolsimpl;
       rewrite ?N.add_0_r, ?N.double_succ_double, ?N.succ_double_succ;
       rewrite ?N2Bv_sized_double, ?N2Bv_sized_succ_double;
       reflexivity.

--- a/acorn-examples/IncrDecr.v
+++ b/acorn-examples/IncrDecr.v
@@ -20,7 +20,7 @@ Require Import Coq.NArith.NArith.
 Require Import Coq.Vectors.Vector.
 Require Import coqutil.Tactics.Tactics.
 Require Import ExtLib.Structures.Monad.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Util.Identity.
 Require Import Cava.Util.BitArithmetic.

--- a/acorn-examples/NandGate.v
+++ b/acorn-examples/NandGate.v
@@ -15,21 +15,7 @@
 (****************************************************************************)
 
 
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-Open Scope monad_scope.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
-Existing Instance CavaCombinationalNet.
 
 Section WithCava.
   Context `{semantics:Cava}.

--- a/acorn-examples/NandGate.v
+++ b/acorn-examples/NandGate.v
@@ -24,7 +24,7 @@ Export MonadNotation.
 Open Scope monad_scope.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -27,7 +27,7 @@ Import VectorNotations.
 
 Require Import Coq.Arith.PeanoNat Coq.NArith.NArith.
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.Multiplexers.
 Existing Instance CavaCombinationalNet.
 

--- a/acorn-examples/Sorter.v
+++ b/acorn-examples/Sorter.v
@@ -14,25 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import ExtLib.Structures.Monads.
-
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import Coq.Vectors.Vector.
-Require Import Coq.Bool.Bvector.
-Import VectorNotations.
-
-Require Import Coq.Arith.PeanoNat Coq.NArith.NArith.
-Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.Multiplexers.
-Existing Instance CavaCombinationalNet.
-
 Require Import Coq.micromega.Lia.
-
+Require Import Cava.Cava.
 Local Open Scope vector_scope.
 
 Section WithCava.
@@ -94,7 +77,7 @@ Lemma twoSorterCorrect {bw : nat} (v : Vector.t (Bvector bw) 2) :
   @twoSorter combType _ _ v = twoSorterSpec v.
 Proof.
   constant_vector_simpl v.
-  cbv [twoSorterSpec twoSorter nth_order].
+  cbv [twoSorterSpec twoSorter Vector.nth_order].
   simpl.
   destruct (Bv2N _ <=? Bv2N _)%N; try reflexivity.
 Qed.

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -14,17 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.NArith.NArith.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
 
 (******************************************************************************)
 (* Some handy test vectors                                                   *)
@@ -99,9 +89,6 @@ Proof. reflexivity. Qed.
 (******************************************************************************)
 (* Generate a 4-bit unsigned adder with 5-bit output.                         *)
 (******************************************************************************)
-
-Local Open Scope nat_scope.
-Existing Instance CavaCombinationalNet.
 
 Definition adder4Interface
   := combinationalInterface "adder4"

--- a/acorn-examples/UnsignedAdderExamples.v
+++ b/acorn-examples/UnsignedAdderExamples.v
@@ -23,7 +23,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 
 (******************************************************************************)

--- a/acorn-examples/bits.v
+++ b/acorn-examples/bits.v
@@ -1,3 +1,19 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
 Require Import Lists.List.
 Import ListNotations.
 Require Import Init.Nat Arith.Arith micromega.Lia.

--- a/acorn-examples/xilinx/NandLUT.v
+++ b/acorn-examples/xilinx/NandLUT.v
@@ -21,7 +21,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Existing Instance CavaCombinationalNet.
 
 Definition lutNAND {signal} `{Cava signal}

--- a/acorn-examples/xilinx/XilinxAdderExamples.v
+++ b/acorn-examples/xilinx/XilinxAdderExamples.v
@@ -22,7 +22,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.XilinxAdder.
 Existing Instance CavaCombinationalNet.
 

--- a/acorn-examples/xilinx/XilinxAdderExamples.v
+++ b/acorn-examples/xilinx/XilinxAdderExamples.v
@@ -14,17 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.NArith.NArith.
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.XilinxAdder.
-Existing Instance CavaCombinationalNet.
 
 (****************************************************************************)
 (* A few tests to check the unsigned adder.        *)

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -14,23 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Bool.Bool Coq.Init.Nat.
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.NArith.NArith.
-
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import Coq.Vectors.Vector.
-Require Import Coq.Bool.Bvector.
-Import VectorNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.XilinxAdder.
-Existing Instance CavaCombinationalNet.
+Local Open Scope N_scope.
+Local Open Scope vector_scope.
 
 Section WithCava.
   Context {signal} `{Cava signal}.
@@ -72,22 +58,15 @@ Definition v1 := N2Bv_sized 8 17.
 Definition v2 := N2Bv_sized 8  6.
 Definition v3 := N2Bv_sized 8  3.
 
-Local Open Scope nat_scope.
-Local Open Scope vector_scope.
-
 Definition v0_v1 : Vector.t (Bvector 8) 2 := [v0; v1].
 Definition v0_plus_v1 : Bvector 8 := adderTree2 v0_v1.
 Example sum_vo_v1 : v0_plus_v1 = N2Bv_sized 8 21.
 Proof. reflexivity. Qed.
 
-Local Open Scope N_scope.
-
 Definition v0_v1_v2_v3 := [v0; v1; v2; v3].
 Example sum_v0_v1_v2_v3 :
   Bv2N (adderTree4 v0_v1_v2_v3) = 30.
 Proof. reflexivity. Qed.
-
-Local Open Scope nat_scope.
 
 Definition adder_tree_Interface name nrInputs bitSize
   := combinationalInterface name
@@ -101,8 +80,6 @@ Definition adder_tree4_8Interface := adder_tree_Interface "xadder_tree4_8" 4 8.
 
 Definition adder_tree4_8Netlist
   := makeNetlist adder_tree4_8Interface adderTree4.
-
-Local Open Scope N_scope.
 
 Definition adder_tree4_8_tb_inputs
   := map (fun i => Vector.map (N2Bv_sized 8) i)

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -28,7 +28,7 @@ Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.XilinxAdder.
 Existing Instance CavaCombinationalNet.
 

--- a/cava/Cava/Cava.v
+++ b/cava/Cava/Cava.v
@@ -18,6 +18,19 @@
 (**** Import this file for everything you need to define and test circuits with
       Cava. ****)
 
+(* Some pieces of the standard library that are helpful for defining circuits
+   and creating test cases *)
+Require Export Coq.Arith.PeanoNat.
+Require Export Coq.Bool.Bvector.
+Require Export Coq.NArith.NArith.
+Require Coq.Lists.List.
+Require Coq.Vectors.Vector.
+Export List.ListNotations Vector.VectorNotations.
+
+(* String definition + notation (for netlist port/interface names) *)
+Require Export Coq.Strings.String.
+Global Open Scope string_scope.
+
 (* Monad definition + notation *)
 Require Export ExtLib.Structures.Monad.
 Export MonadNotation.
@@ -32,9 +45,6 @@ Require Export Cava.NetlistGeneration.NetlistGeneration.
 (* Library of common small circuit components (multiplexers, adders, etc) *)
 Require Export Cava.Lib.Lib.
 
-(* Cava instance for Coq semantics *)
-Require Export Cava.Semantics.Combinational.
-
 (* Circuit simulation function *)
 Require Export Cava.Semantics.Simulation.
 
@@ -43,3 +53,10 @@ Require Export Cava.Util.BitArithmetic.
 
 (* Monadic fold definitions *)
 Require Export Cava.Util.MonadFold.
+
+(* Extra definitions for standard library vectors *)
+Require Export Cava.Util.Vector.
+
+(* Make sure the netlist Cava instance has priority over the Coq semantics to
+   avoid confusing error messages *)
+Existing Instance CavaCombinationalNet.

--- a/cava/Cava/Cava.v
+++ b/cava/Cava/Cava.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2020 The Project Oak Authors                                   *)
+(* Copyright 2021 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -19,7 +19,14 @@
    Coq for the specification, implementaiton and formal verification of circuits.
 *)
 
+(* Basic infrastructure for defining circuits *)
+Require Export Cava.Core.Core.
+
+(* Cava instance + definitions for creating netlists from circuits *)
+Require Export Cava.NetlistGeneration.NetlistGeneration.
+
+(* Library of common small circuit components (multiplexers, adders, etc) *)
+Require Export Cava.Lib.Lib.
+
+(* Bit-arithmetic functions (useful for making small tests) *)
 Require Export Cava.Util.BitArithmetic.
-Require Export Cava.Core.Netlist.
-Require Export Cava.Core.Signal.
-Require Export Cava.Util.Vector.

--- a/cava/Cava/Cava.v
+++ b/cava/Cava/Cava.v
@@ -28,5 +28,8 @@ Require Export Cava.NetlistGeneration.NetlistGeneration.
 (* Library of common small circuit components (multiplexers, adders, etc) *)
 Require Export Cava.Lib.Lib.
 
+(* Circuit simulation function *)
+Require Export Cava.Semantics.Simulation.
+
 (* Bit-arithmetic functions (useful for making small tests) *)
 Require Export Cava.Util.BitArithmetic.

--- a/cava/Cava/Cava.v
+++ b/cava/Cava/Cava.v
@@ -18,6 +18,11 @@
 (**** Import this file for everything you need to define and test circuits with
       Cava. ****)
 
+(* Monad definition + notation *)
+Require Export ExtLib.Structures.Monad.
+Export MonadNotation.
+Global Open Scope monad_scope.
+
 (* Basic infrastructure for defining circuits *)
 Require Export Cava.Core.Core.
 
@@ -35,3 +40,6 @@ Require Export Cava.Semantics.Simulation.
 
 (* Bit-arithmetic functions (useful for making small tests) *)
 Require Export Cava.Util.BitArithmetic.
+
+(* Monadic fold definitions *)
+Require Export Cava.Util.MonadFold.

--- a/cava/Cava/Cava.v
+++ b/cava/Cava/Cava.v
@@ -27,6 +27,9 @@ Require Export Cava.NetlistGeneration.NetlistGeneration.
 (* Library of common small circuit components (multiplexers, adders, etc) *)
 Require Export Cava.Lib.Lib.
 
+(* Cava instance for Coq semantics *)
+Require Export Cava.Semantics.Combinational.
+
 (* Circuit simulation function *)
 Require Export Cava.Semantics.Simulation.
 

--- a/cava/Cava/CavaProperties.v
+++ b/cava/Cava/CavaProperties.v
@@ -19,6 +19,7 @@
 
 Require Export Cava.Cava.
 Require Export Cava.Lib.LibProperties.
+Require Export Cava.Semantics.Combinational.
 Require Export Cava.Semantics.CombinationalProperties.
 
 (* Proofs about the standard library datatypes that can come in useful *)
@@ -27,4 +28,10 @@ Require Export Cava.Util.Nat.
 Require Export Cava.Util.Vector.
 
 (* Generally useful tactics *)
+Require Export Coq.micromega.Lia.
+Require Export coqutil.Tactics.Tactics.
 Require Export Cava.Util.Tactics.
+
+(* Make sure the semantics Cava instance has priority over the
+netlist-generating one for proofs *)
+Existing Instance CombinationalSemantics.

--- a/cava/Cava/CavaProperties.v
+++ b/cava/Cava/CavaProperties.v
@@ -20,3 +20,11 @@
 Require Export Cava.Cava.
 Require Export Cava.Lib.LibProperties.
 Require Export Cava.Semantics.CombinationalProperties.
+
+(* Proofs about the standard library datatypes that can come in useful *)
+Require Export Cava.Util.List.
+Require Export Cava.Util.Nat.
+Require Export Cava.Util.Vector.
+
+(* Generally useful tactics *)
+Require Export Cava.Util.Tactics.

--- a/cava/Cava/CavaProperties.v
+++ b/cava/Cava/CavaProperties.v
@@ -19,5 +19,4 @@
 
 Require Export Cava.Cava.
 Require Export Cava.Lib.LibProperties.
-Require Export Cava.Semantics.Combinational.
 Require Export Cava.Semantics.CombinationalProperties.

--- a/cava/Cava/CavaProperties.v
+++ b/cava/Cava/CavaProperties.v
@@ -14,21 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+(**** Import this file for everything you need to prove properties about Cava
+      circuits. ****)
 
-(**** Import this file for everything you need to define and test circuits with
-      Cava. ****)
-
-(* Basic infrastructure for defining circuits *)
-Require Export Cava.Core.Core.
-
-(* Cava instance + definitions for creating netlists from circuits *)
-Require Export Cava.NetlistGeneration.NetlistGeneration.
-
-(* Library of common small circuit components (multiplexers, adders, etc) *)
-Require Export Cava.Lib.Lib.
-
-(* Circuit simulation function *)
-Require Export Cava.Semantics.Simulation.
-
-(* Bit-arithmetic functions (useful for making small tests) *)
-Require Export Cava.Util.BitArithmetic.
+Require Export Cava.Cava.
+Require Export Cava.Lib.LibProperties.
+Require Export Cava.Semantics.Combinational.
+Require Export Cava.Semantics.CombinationalProperties.

--- a/cava/Cava/Core/Circuit.v
+++ b/cava/Cava/Core/Circuit.v
@@ -18,10 +18,8 @@ Require Import Coq.Vectors.Vector.
 Require Import ExtLib.Structures.Monads.
 Import VectorNotations MonadNotation.
 
-Require Import Cava.Cava.
-Require Import Cava.Lib.CavaPrelude.
 Require Import Cava.Core.CavaClass.
-Require Import Cava.Lib.Combinators.
+Require Import Cava.Core.Signal.
 
 (******************************************************************************)
 (* Inductive to capture circuit's sequential structure                        *)

--- a/cava/Cava/Core/Core.v
+++ b/cava/Cava/Core/Core.v
@@ -15,6 +15,6 @@
 (****************************************************************************)
 
 Require Export Cava.Core.CavaClass.
-Require Export Cava.Core.Circuit.
 Require Export Cava.Core.Netlist.
 Require Export Cava.Core.Signal.
+Require Export Cava.Core.Circuit.

--- a/cava/Cava/Core/Core.v
+++ b/cava/Cava/Core/Core.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2020 The Project Oak Authors                                   *)
+(* Copyright 2021 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -14,11 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Export Cava.Core.Signal.
 Require Export Cava.Core.CavaClass.
-Require Export Cava.Lib.CavaPrelude.
 Require Export Cava.Core.Circuit.
-Require Export Cava.Semantics.Combinational.
-Require Export Cava.Lib.Combinators.
-Require Export Cava.NetlistGeneration.NetlistGeneration.
-Require Export Cava.Semantics.Simulation.
+Require Export Cava.Core.Netlist.
+Require Export Cava.Core.Signal.

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -34,6 +34,7 @@ Recursive Extraction Library Circuit.
 Recursive Extraction Library Combinational.
 Recursive Extraction Library Combinators.
 Recursive Extraction Library Identity.
+Recursive Extraction Library Simulation.
 Recursive Extraction Library NetlistGeneration.
 
 Recursive Extraction Library Netlist.

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -24,34 +24,16 @@ Extraction Language Haskell.
 Set Extraction KeepSingleton.
 Set Extraction File Comment "Auto-generated from Cava/Coq. Please do not hand edit.".
 
-Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Cava.
-Require Import Cava.Core.Signal.
 Require Import Cava.Util.Vector.
-Require Import Cava.Acorn.Acorn.
 Require Import Cava.Semantics.Combinational.
-Require Import Cava.Core.CavaClass.
-Require Import Cava.Lib.Combinators.
-Require Import Cava.Util.Identity.
-Require Import Cava.NetlistGeneration.NetlistGeneration.
-Require Import Cava.Lib.XilinxAdder.
-Require Import Cava.Lib.CavaPrelude.
-Require Import Cava.Core.Circuit.
-
-Require Import Cava.Lib.BitVectorOps.
-Require Import Cava.Lib.FullAdder.
-Require Import Cava.Lib.Multiplexers.
-Require Import Cava.Lib.UnsignedAdders.
-Require Import Cava.Lib.Vec.
 
 Recursive Extraction Library BitArithmetic.
 Recursive Extraction Library Cava.
-Recursive Extraction Library Acorn.
 Recursive Extraction Library Circuit.
 Recursive Extraction Library Combinational.
 Recursive Extraction Library Combinators.
 Recursive Extraction Library Identity.
-Recursive Extraction Library Simulation.
 Recursive Extraction Library NetlistGeneration.
 
 Recursive Extraction Library Netlist.

--- a/cava/Cava/Lib/Combinators.v
+++ b/cava/Cava/Lib/Combinators.v
@@ -31,6 +31,7 @@ Require Import Cava.Core.CavaClass.
 Require Import Cava.Util.Identity.
 Require Import Cava.Util.Vector.
 Require Import Cava.Util.List.
+Require Import Cava.Util.MonadFold.
 Require Import Cava.Core.Signal.
 Require Import Cava.Util.Tactics.
 Require Import Cava.Lib.CavaPrelude.
@@ -78,68 +79,6 @@ Section WithCava.
     b' <- unpackV b ;;
     v <- mapT f (vcombine a' b') ;;
     packV v.
-
-  (* A list-based left monadic-fold. *)
-  Fixpoint foldLM {m} `{Monad m} {A B : Type}
-                  (f : B -> A -> m B)
-                  (input : list A)
-                  (accum : B)
-                  : m B :=
-    match input with
-    | [] => ret accum
-    | k::ks => st' <- f accum k  ;;
-               foldLM f ks st'
-    end.
-
-  Lemma foldLM_fold_right {A B}
-        (bind_ext : forall {A B} x (f g : A -> cava B),
-            (forall y, f y = g y) -> bind x f = bind x g)
-        (f : B -> A -> cava B) (input : list A) (accum : B) :
-    foldLM f input accum =
-    List.fold_right
-      (fun k continuation v => bind (f v k) continuation)
-      ret input accum.
-  Proof.
-    revert accum; induction input; intros; [ reflexivity | ].
-    cbn [foldLM List.fold_right].
-    eapply bind_ext; intros.
-    rewrite IHinput. reflexivity.
-  Qed.
-
-  Lemma foldLM_of_ret_valid {m} `{Monad m} `{MonadLaws.MonadLaws m} {A B}
-        (validA : A -> Prop) (validB : B -> Prop)
-        (f : B -> A -> m B) (g : B -> A -> B) input accum :
-    (forall b a, validA a -> validB b -> f b a = ret (g b a)) ->
-    (forall b a, validA a -> validB b -> validB (g b a)) ->
-    validB accum -> Forall validA input ->
-    foldLM f input accum = ret (fold_left g input accum).
-  Proof.
-    intro Hfg; revert accum; induction input; intros; [ reflexivity | ].
-    cbn [foldLM fold_left].
-    match goal with H : Forall _ (_ :: _) |- _ => inversion H; subst; clear H end.
-    rewrite Hfg, MonadLaws.bind_of_return; auto.
-  Qed.
-
-
-  Lemma foldLM_of_ret {m} `{Monad m} `{MonadLaws.MonadLaws m} {A B}
-        (f : B -> A -> m B) (g : B -> A -> B) input accum :
-    (forall b a, f b a = ret (g b a)) ->
-    foldLM f input accum = ret (fold_left g input accum).
-  Proof.
-    intro Hfg; revert accum; induction input; intros; [ reflexivity | ].
-    cbn [foldLM fold_left]. rewrite Hfg, MonadLaws.bind_of_return by auto.
-    apply IHinput.
-  Qed.
-
-  Lemma foldLM_ident_fold_left
-        {A B} (f : B -> A -> ident B) ls b :
-    foldLM f ls b = List.fold_left f ls b.
-  Proof.
-    revert b; induction ls; [ reflexivity | ].
-    cbn [foldLM List.fold_left]. intros.
-    cbn [bind ret Monad_ident].
-    rewrite IHls. reflexivity.
-  Qed.
 
   (* Below combinator
 

--- a/cava/Cava/Lib/FullAdder.v
+++ b/cava/Cava/Lib/FullAdder.v
@@ -21,8 +21,9 @@ Import ListNotations MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.
 
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
 Require Import Cava.Util.List.
-Require Import Cava.Acorn.Acorn.
 
 Section WithCava.
   Context `{semantics:Cava}.

--- a/cava/Cava/Lib/Lib.v
+++ b/cava/Cava/Lib/Lib.v
@@ -20,5 +20,8 @@ Require Export Cava.Lib.Combinators.
 Require Export Cava.Lib.FullAdder.
 Require Export Cava.Lib.Multiplexers.
 Require Export Cava.Lib.UnsignedAdders.
-Require Export Cava.Lib.Vec.
 Require Export Cava.Lib.XilinxAdder.
+
+(* Vec has a lot of name collisions with lists and standard library vectors;
+   don't import it, just require it so that e.g. map is still Vec.map. *)
+Require Cava.Lib.Vec.

--- a/cava/Cava/Lib/Lib.v
+++ b/cava/Cava/Lib/Lib.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2020 The Project Oak Authors                                   *)
+(* Copyright 2021 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -14,28 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-Local Open Scope vector_scope.
-
-Require Import ExtLib.Structures.Monads.
-Require Import ExtLib.Structures.Traversable.
-Export MonadNotation.
-Open Scope monad_scope.
-
-Require Import Cava.Core.Core.
-Require Import Cava.Core.CavaClass.
-Require Import Cava.Lib.Combinators.
-
-Section WithCava.
-  Context {signal} `{Cava signal}.
-
-  (* A circuit to xor two bit-vectors *)
-  Definition xorV {n : nat} (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
-    cava (signal (Vec Bit n)) :=
-    zipWith xor2 (fst ab) (snd ab).
-
-  (* Make a curried version of xorV *)
-  Definition xorv {n} (a b : signal (Vec Bit n)) : cava (signal (Vec Bit n)) := xorV (a, b).
-
-End WithCava.
+Require Export Cava.Lib.BitVectorOps.
+Require Export Cava.Lib.CavaPrelude.
+Require Export Cava.Lib.Combinators.
+Require Export Cava.Lib.FullAdder.
+Require Export Cava.Lib.Multiplexers.
+Require Export Cava.Lib.UnsignedAdders.
+Require Export Cava.Lib.Vec.
+Require Export Cava.Lib.XilinxAdder.

--- a/cava/Cava/Lib/LibProperties.v
+++ b/cava/Cava/Lib/LibProperties.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2020 The Project Oak Authors                                   *)
+(* Copyright 2021 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -14,28 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-Local Open Scope vector_scope.
-
-Require Import ExtLib.Structures.Monads.
-Require Import ExtLib.Structures.Traversable.
-Export MonadNotation.
-Open Scope monad_scope.
-
-Require Import Cava.Core.Core.
-Require Import Cava.Core.CavaClass.
-Require Import Cava.Lib.Combinators.
-
-Section WithCava.
-  Context {signal} `{Cava signal}.
-
-  (* A circuit to xor two bit-vectors *)
-  Definition xorV {n : nat} (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
-    cava (signal (Vec Bit n)) :=
-    zipWith xor2 (fst ab) (snd ab).
-
-  (* Make a curried version of xorV *)
-  Definition xorv {n} (a b : signal (Vec Bit n)) : cava (signal (Vec Bit n)) := xorV (a, b).
-
-End WithCava.
+Require Export Cava.Lib.Lib.
+Require Export Cava.Lib.MultiplexersProperties.
+Require Export Cava.Lib.UnsignedAdderProofs.
+Require Export Cava.Lib.VecProperties.

--- a/cava/Cava/Lib/MultiplexersProperties.v
+++ b/cava/Cava/Lib/MultiplexersProperties.v
@@ -16,10 +16,11 @@
 
 Require Import Coq.Vectors.Vector.
 
-Require Import Cava.Acorn.Acorn.
-Require Import Cava.Util.BitArithmetic.
-Require Import Cava.Semantics.CombinationalProperties.
+Require Import Cava.Core.Core.
 Require Import Cava.Lib.Multiplexers.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Semantics.CombinationalProperties.
+Require Import Cava.Util.BitArithmetic.
 
 Lemma mux2_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
   mux2 sel (i0, i1) = if sel then i1 else i0.

--- a/cava/Cava/Lib/UnsignedAdderProofs.v
+++ b/cava/Cava/Lib/UnsignedAdderProofs.v
@@ -49,19 +49,16 @@ Lemma fullAdder_correct (cin a b : bool) :
   (N.testbit sum 0, N.testbit sum 1).
 Proof. destruct cin, a, b; reflexivity. Qed.
 
-(* Lemma about how to decompose a vector of bits. *)
-Lemma Bv2N_cons n b (bs : t bool n) :
-  Bv2N (b :: bs)%vector = (N.b2n b + 2 * (Bv2N bs))%N.
-Proof.
-  cbn [Bv2N]. destruct b; cbn [N.b2n].
-  all: rewrite ?N.succ_double_spec, ?N.double_spec.
-  all:lia.
-Qed.
-
 (* Lemma about how to decompose a list of bits. *)
 Lemma list_bits_to_nat_cons b bs :
   list_bits_to_nat (b :: bs) = (N.b2n b + 2 * (list_bits_to_nat bs))%N.
-Proof. apply Bv2N_cons. Qed.
+Proof.
+  cbv [list_bits_to_nat]. cbn [of_list length].
+  rewrite Bv2N_cons.
+  destruct_one_match; cbn [N.b2n];
+    rewrite ?N.double_spec, ?N.succ_double_spec;
+    lia.
+Qed.
 
 Hint Rewrite @bind_of_return @bind_associativity
      using solve [typeclasses eauto] : monadlaws.
@@ -144,7 +141,9 @@ Lemma Bv2N_list_bits_to_nat n (v : t bool n) :
 Proof.
   induction v; intros; [ reflexivity | ].
   rewrite to_list_cons, Bv2N_cons, list_bits_to_nat_cons.
-  lia.
+  destruct_one_match; cbn [N.b2n];
+    rewrite ?N.double_spec, ?N.succ_double_spec;
+    lia.
 Qed.
 
 Lemma colL_length {A B C} circuit a bs :

--- a/cava/Cava/Lib/UnsignedAdderProofs.v
+++ b/cava/Cava/Lib/UnsignedAdderProofs.v
@@ -28,11 +28,16 @@ Open Scope type_scope.
 Require Import coqutil.Tactics.Tactics.
 Require Import Coq.micromega.Lia.
 
-Require Import Cava.Util.BitArithmetic Cava.Util.List Cava.Util.Vector Cava.Util.Tactics.
+Require Import Cava.Core.Core.
+Require Import Cava.Lib.Combinators.
 Require Import Cava.Lib.FullAdder.
 Require Import Cava.Lib.UnsignedAdders.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Util.Identity.
+Require Import Cava.Util.List.
+Require Import Cava.Util.Tactics.
+Require Import Cava.Util.Vector.
 
 Local Open Scope N_scope.
 

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -23,9 +23,11 @@ Import MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.
 
-Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Core.Core.
+Require Import Cava.Lib.CavaPrelude.
+Require Import Cava.Lib.Combinators.
 Require Import Cava.Lib.FullAdder.
+Require Import Cava.Util.Vector.
 
 Local Open Scope vector_scope.
 

--- a/cava/Cava/Lib/Vec.v
+++ b/cava/Cava/Lib/Vec.v
@@ -16,9 +16,8 @@
 
 Require Coq.Vectors.Vector.
 Require Import ExtLib.Structures.Monads.
-Require Import Cava.Cava.
+Require Import Cava.Core.Core.
 Require Import Cava.Util.Vector.
-Require Import Cava.Acorn.Acorn.
 Import MonadNotation.
 Import Vector.VectorNotations.
 Local Open Scope monad_scope.

--- a/cava/Cava/Lib/VecProperties.v
+++ b/cava/Cava/Lib/VecProperties.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Cava.Cava.
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
 Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
-Require Import Cava.Acorn.Acorn.
 Require Import Cava.Util.Identity.
 Require Coq.Vectors.Vector.
 Require Cava.Lib.Vec.

--- a/cava/Cava/Lib/XilinxAdder.v
+++ b/cava/Cava/Lib/XilinxAdder.v
@@ -29,7 +29,6 @@ Require Import Cava.Core.Core.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Lib.Combinators.
 Require Import Cava.Util.Vector.
-Require Import Cava.Util.Vector.
 
 Local Open Scope string_scope.
 Local Open Scope list_scope.

--- a/cava/Cava/Lib/XilinxAdder.v
+++ b/cava/Cava/Lib/XilinxAdder.v
@@ -23,13 +23,18 @@ Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
+Import MonadNotation.
 
-Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Lib.Combinators.
+Require Import Cava.Util.Vector.
+Require Import Cava.Util.Vector.
 
 Local Open Scope string_scope.
 Local Open Scope list_scope.
 Local Open Scope type_scope.
+Local Open Scope monad_scope.
 
 Section WithCava.
   Context {signal} {m : Cava signal}.

--- a/cava/Cava/NetlistGeneration/NetlistGeneration.v
+++ b/cava/Cava/NetlistGeneration/NetlistGeneration.v
@@ -26,9 +26,9 @@ Import VectorNotations.
 Require Import Coq.Lists.List.
 Import ListNotations.
 
-Require Import Cava.Cava.
-Require Import Cava.Core.CavaClass.
-Require Import Cava.Core.Circuit.
+Require Import Cava.Core.Core.
+Require Import Cava.Util.BitArithmetic.
+Require Import Cava.Util.Vector.
 
 (******************************************************************************)
 (* Netlist implementations for the Cava class.                                *)

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -16,16 +16,14 @@
 
 
 Require Import Coq.Vectors.Vector.
-Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
 Require Import ExtLib.Structures.Monads.
-Import ListNotations MonadNotation.
+Import MonadNotation.
 
-Require Import Cava.Cava.
-Require Import Cava.Util.List.
-Require Import Cava.Core.CavaClass.
-Require Import Cava.Core.Circuit.
+Require Import Cava.Core.Core.
+Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Util.Identity.
+Require Import Cava.Util.Vector.
 
 (******************************************************************************)
 (* A boolean combinational logic interpretation for the Cava class            *)
@@ -106,8 +104,7 @@ Fixpoint step {i o} (c : Circuit i o)
 
 (* Automation to help simplify expressions using the identity monad *)
 Create HintDb simpl_ident.
-Hint Rewrite @Combinators.foldLM_ident_fold_left using solve [eauto]
-  : simpl_ident.
+Hint Rewrite @foldLM_ident_fold_left using solve [eauto] : simpl_ident.
 Ltac simpl_ident :=
   cbn [fst snd bind ret Monad_ident monad
            packV unpackV constant

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -38,7 +38,7 @@ Definition xnorb b1 b2 : bool := negb (xorb b1 b2).
 (* interpretation.                                                            *)
 (******************************************************************************)
 
-Instance CombinationalSemantics : Cava combType :=
+Instance CombinationalSemantics : Cava combType | 10 :=
   { cava := ident;
     monad := Monad_ident;
     constant := fun x => x;

--- a/cava/Cava/Util/Identity.v
+++ b/cava/Cava/Util/Identity.v
@@ -20,6 +20,7 @@ Require Import ExtLib.Data.Vector.
 Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.MonadLaws.
 Require Import ExtLib.Structures.Traversable.
+Require Import Cava.Util.MonadFold.
 Require Import Cava.Util.Vector.
 
 (* Identity monad *)
@@ -30,3 +31,13 @@ Instance Monad_ident : Monad ident :=
 
 Instance MonadLaws_ident : MonadLaws Monad_ident.
 Proof. econstructor; intros; exact eq_refl. Defined.
+
+Lemma foldLM_ident_fold_left
+      {A B} (f : B -> A -> ident B) ls b :
+  foldLM f ls b = List.fold_left f ls b.
+Proof.
+  revert b; induction ls; [ reflexivity | ].
+  cbn [foldLM List.fold_left]. intros.
+  cbn [bind ret Monad_ident].
+  rewrite IHls. reflexivity.
+Qed.

--- a/cava/Cava/Util/MonadFold.v
+++ b/cava/Cava/Util/MonadFold.v
@@ -1,0 +1,72 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Lists.List.
+Require Import ExtLib.Structures.Monad.
+Require Import ExtLib.Structures.MonadLaws.
+Import ListNotations MonadNotation.
+Local Open Scope monad_scope.
+
+(* A list-based left monadic-fold. *)
+Fixpoint foldLM {m} `{Monad m} {A B : Type}
+         (f : B -> A -> m B)
+         (input : list A)
+         (accum : B)
+  : m B :=
+  match input with
+  | [] => ret accum
+  | k::ks => st' <- f accum k  ;;
+           foldLM f ks st'
+  end.
+
+Lemma foldLM_fold_right {m} {monad:Monad m} {A B}
+      (bind_ext : forall {A B} x (f g : A -> m B),
+          (forall y, f y = g y) -> bind x f = bind x g)
+      (f : B -> A -> m B) (input : list A) (accum : B) :
+  foldLM f input accum =
+  List.fold_right
+    (fun k continuation v => bind (f v k) continuation)
+    ret input accum.
+Proof.
+  revert accum; induction input; intros; [ reflexivity | ].
+  cbn [foldLM List.fold_right].
+  eapply bind_ext; intros.
+  rewrite IHinput. reflexivity.
+Qed.
+
+Lemma foldLM_of_ret_valid {m} `{Monad m} `{MonadLaws m} {A B}
+      (validA : A -> Prop) (validB : B -> Prop)
+      (f : B -> A -> m B) (g : B -> A -> B) input accum :
+  (forall b a, validA a -> validB b -> f b a = ret (g b a)) ->
+  (forall b a, validA a -> validB b -> validB (g b a)) ->
+  validB accum -> Forall validA input ->
+  foldLM f input accum = ret (fold_left g input accum).
+Proof.
+  intro Hfg; revert accum; induction input; intros; [ reflexivity | ].
+  cbn [foldLM fold_left].
+  match goal with H : Forall _ (_ :: _) |- _ => inversion H; subst; clear H end.
+  rewrite Hfg, MonadLaws.bind_of_return; auto.
+Qed.
+
+Lemma foldLM_of_ret {m} `{Monad m} `{MonadLaws m} {A B}
+      (f : B -> A -> m B) (g : B -> A -> B) input accum :
+  (forall b a, f b a = ret (g b a)) ->
+  foldLM f input accum = ret (fold_left g input accum).
+Proof.
+  intro Hfg; revert accum; induction input; intros; [ reflexivity | ].
+  cbn [foldLM fold_left]. rewrite Hfg, MonadLaws.bind_of_return by auto.
+  apply IHinput.
+Qed.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -92,6 +92,7 @@ library
                      Specif
                      MonadExc
                      MonadFix
+                     MonadFold
                      MonadPlus
                      MonadReader
                      MonadTrans

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -57,6 +57,7 @@ library
                      HexString
                      Identity
                      List
+                     List0
                      Logic
                      Monad
                      MonadState
@@ -67,6 +68,7 @@ library
                      Ndigits
                      PeanoNat
                      Signal
+                     Simulation
                      StateMonad
                      Traversable
                      UnsignedAdders

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -57,12 +57,10 @@ library
                      HexString
                      Identity
                      List
-                     List0
                      Logic
                      Monad
                      MonadState
                      Multiplexers
-                     Simulation
                      Netlist
                      NetlistGeneration
                      Nat

--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -14,21 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.NArith.NArith.
-Require Import Coq.Vectors.Vector.
-Require Import Coq.Lists.List.
-Require Import coqutil.Tactics.destr.
-Require Import ExtLib.Structures.Monads.
-Require Import Cava.Util.BitArithmetic.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Util.Vector.
-Require Import Cava.Cava.
-Require Import Cava.Semantics.Combinational.
-Require Import Cava.Core.Circuit.
-Require Import Cava.Util.Identity.
-Require Import Cava.Semantics.Simulation.
+Require Import Cava.CavaProperties.
 
 Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
@@ -54,8 +40,8 @@ Local Notation round_index := (Vec Bit 4) (only parsing).
 (* convenience definition for converting to/from flat keys in key * round
    constant pairs *)
 Definition flatten_key (kr : combType key * combType round_constant)
-  : t bool 128 * combType round_constant := (to_flat (fst kr), snd kr).
-Definition unflatten_key (kr : t bool 128 * combType round_constant)
+  : Vector.t bool 128 * combType round_constant := (to_flat (fst kr), snd kr).
+Definition unflatten_key (kr : Vector.t bool 128 * combType round_constant)
   : combType key * combType round_constant := (from_flat (fst kr), snd kr).
 Lemma flatten_unflatten kr : flatten_key (unflatten_key kr) = kr.
 Proof.

--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -24,7 +24,7 @@ Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Core.Circuit.
 Require Import Cava.Util.Identity.

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyCircuit.v
@@ -15,7 +15,6 @@
 (****************************************************************************)
 
 Require Import Cava.Cava.
-Require Import Cava.Lib.BitVectorOps.
 Require Import AcornAes.Pkg.
 Import Pkg.Notations.
 

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyCircuit.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.BitVectorOps.
 Require Import AcornAes.Pkg.
 Import Pkg.Notations.

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
@@ -21,7 +21,7 @@ Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
 Require Import Cava.Util.Identity.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.BitVectorOps.
 Import ListNotations.
 

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
@@ -14,17 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Require Import ExtLib.Structures.Monads.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Util.Vector.
-Require Import Cava.Util.Identity.
 Require Import Cava.Cava.
-Require Import Cava.Lib.BitVectorOps.
-Import ListNotations.
-
+Require Import Cava.CavaProperties.
 Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
 Require Import AcornAes.AddRoundKeyCircuit.
@@ -43,7 +34,7 @@ Section Equivalence.
     cbv [BigEndian.from_big_endian_bytes].
     cbv [BitArithmetic.bytevec_to_bitvec].
     autorewrite with pull_vector_map.
-    rewrite !map_map2, !map_map.
+    rewrite !Vector.map_map2, !Vector.map_map.
     rewrite !map_id_ext
       by (intros; rewrite BitArithmetic.bitvec_to_byte_to_bitvec; reflexivity).
     erewrite map2_ext with

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
@@ -14,12 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyNetlist.v
@@ -20,7 +20,7 @@ Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.TestVectors.

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyTests.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyTests.v
@@ -21,7 +21,7 @@ Import ListNotations VectorNotations.
 
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.CipherTest.

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyTests.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyTests.v
@@ -14,13 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/CipherCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherCircuit.v
@@ -14,21 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-
-Require Import ExtLib.Structures.Monads.
-Import MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Lib.CavaPrelude.
-Require Import Cava.Core.CavaClass.
-Require Import Cava.Core.Circuit.
-Require Import Cava.Lib.Combinators.
-Require Import Cava.Lib.Multiplexers.
 Import Circuit.Notations.
 
 Local Open Scope monad_scope.

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -14,36 +14,16 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-
-Require Import ExtLib.Structures.Monads.
-Import MonadNotation.
-
-From RecordUpdate Require Import RecordSet.
-
 Require Import Cava.Cava.
-Require Import Cava.Core.Circuit.
-Require Import Cava.Cava.
-Require Import Cava.Lib.Multiplexers.
-Require Import AcornAes.Pkg.
-Require Import AcornAes.SubBytesCircuit.
+Require Import ExtLib.Structures.MonadState.
+Require Import RecordUpdate.RecordSet.
 Require Import AcornAes.AddRoundKeyCircuit.
-Require Import AcornAes.ShiftRowsCircuit.
-Require Import AcornAes.MixColumnsCircuit.
 Require Import AcornAes.CipherCircuit.
+Require Import AcornAes.MixColumnsCircuit.
+Require Import AcornAes.Pkg.
+Require Import AcornAes.ShiftRowsCircuit.
+Require Import AcornAes.SubBytesCircuit.
 Import Circuit.Notations.
-Existing Instance CavaCombinationalNet.
-
-Require Import AcornAes.ShiftRowsNetlist.
-Require Import AcornAes.MixColumnsNetlist.
-Require Import AcornAes.SubBytesNetlist.
-
-Local Open Scope monad_scope.
 Local Open Scope vector_scope.
 
 Notation round_index := (Vec Bit 4) (only parsing).

--- a/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlCircuit.v
@@ -28,7 +28,7 @@ From RecordUpdate Require Import RecordSet.
 
 Require Import Cava.Cava.
 Require Import Cava.Core.Circuit.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 Require Import AcornAes.SubBytesCircuit.

--- a/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
@@ -14,14 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-Require Import ExtLib.Structures.Monads.
-Import MonadNotation.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AcornAes.CipherControlCircuit.
 Require Import AcornAes.SubBytesCircuit.
@@ -145,4 +137,3 @@ Definition aes_cipher_core := CipherControlCircuit.aes_cipher_core
 
 Definition aes_cipher_core_Netlist
   := makeCircuitNetlist aes_cipher_core_Interface aes_cipher_core.
-

--- a/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/CipherControlNetlist.v
@@ -22,7 +22,7 @@ Require Import ExtLib.Structures.Monads.
 Import MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AcornAes.CipherControlCircuit.
 Require Import AcornAes.SubBytesCircuit.
 Require Import AcornAes.MixColumnsCircuit.

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -31,7 +31,7 @@ Require Import Cava.Util.List.
 Require Import Cava.Util.Vector.
 Require Import Cava.Util.Tactics.
 
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Core.Circuit.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Semantics.CombinationalProperties.

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -14,38 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Vectors.Vector.
-Require Import Coq.Lists.List.
-Require Import Coq.NArith.NArith.
-Require Import Coq.NArith.Ndigits.
-Import VectorNotations.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-
-Require Import coqutil.Tactics.Tactics.
-Require Import Cava.Util.BitArithmetic.
-Require Import Cava.Util.Nat.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Vector.
-Require Import Cava.Util.Tactics.
-
 Require Import Cava.Cava.
-Require Import Cava.Core.Circuit.
-Require Import Cava.Semantics.Combinational.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Util.Identity.
-Require Import Cava.Semantics.Simulation.
-Require Import Cava.Lib.MultiplexersProperties.
-
+Require Import Cava.CavaProperties.
 Require Import AesSpec.Cipher.
 Require Import AesSpec.CipherProperties.
 Require Import AcornAes.CipherCircuit.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Existing Instance CombinationalSemantics.
+Local Open Scope nat_scope.
 
 Local Notation byte := (Vector.t bool 8).
 Local Notation state := (Vector.t (Vector.t byte 4) 4) (only parsing).
@@ -74,10 +48,10 @@ Proof. intros; cbv [make_cipher_signals]. length_hammer. Qed.
 Hint Rewrite @make_cipher_signals_length using solve [length_hammer] : push_length.
 
 Section WithSubroutines.
-  Context (sub_bytes:     bool -> state -> ident state)
-          (shift_rows:    bool -> state -> ident state)
-          (mix_columns:   bool -> state -> ident state)
-          (add_round_key : key -> state -> ident state).
+  Context (sub_bytes:     bool -> state -> state)
+          (shift_rows:    bool -> state -> state)
+          (mix_columns:   bool -> state -> state)
+          (add_round_key : key -> state -> state).
   Context (sub_bytes_spec shift_rows_spec mix_columns_spec inv_sub_bytes_spec
                           inv_shift_rows_spec inv_mix_columns_spec : state -> state)
           (add_round_key_spec : state -> key -> state).
@@ -319,7 +293,8 @@ Section WithSubroutines.
         init_key init_state middle_keys last_key :
     0 < Nr ->
     length middle_keys = Nr - 1 ->
-    fold_left (fun (st : t (t byte 4) 4) '(i, k) => round_spec Nr is_decrypt k st i)
+    fold_left (fun (st : Vector.t (Vector.t byte 4) 4) '(i, k) =>
+                 round_spec Nr is_decrypt k st i)
               (combine (seq 1 Nr) (middle_keys ++ [last_key]))
               (round_spec Nr is_decrypt init_key init_state 0) =
     if is_decrypt

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -14,16 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-
-Require Import ExtLib.Structures.Monads.
-Require Import ExtLib.Structures.Traversable.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.BitVectorOps.
-Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 
 Local Notation byte := (Vec Bit 8) (only parsing).

--- a/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsCircuit.v
@@ -21,7 +21,7 @@ Require Import ExtLib.Structures.Monads.
 Require Import ExtLib.Structures.Traversable.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsEquivalence.v
@@ -25,7 +25,7 @@ Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Util.Identity.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.BitVectorOps.
 Require Import Cava.Lib.MultiplexersProperties.
 Require Import Cava.Lib.VecProperties.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsNetlist.v
@@ -14,12 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsNetlist.v
@@ -20,7 +20,7 @@ Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.TestVectors.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsTests.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsTests.v
@@ -14,12 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/MixColumnsTests.v
+++ b/silveroak-opentitan/aes/Acorn/MixColumnsTests.v
@@ -20,7 +20,7 @@ Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.CipherTest.

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -23,7 +23,7 @@ Require Import ExtLib.Structures.Monads.
 Require Import ExtLib.Structures.Traversable.
 
 Require Import Cava.Util.Vector.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.BitVectorOps.
 Require Cava.Lib.Vec.
 Require Import Cava.Core.Signal.

--- a/silveroak-opentitan/aes/Acorn/Pkg.v
+++ b/silveroak-opentitan/aes/Acorn/Pkg.v
@@ -14,24 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Vectors.Vector.
-Require Import Coq.NArith.BinNat.
-Require Import Coq.NArith.Ndigits.
-Require Import Cava.Util.BitArithmetic.
-
-Require Import ExtLib.Structures.Monads.
-Require Import ExtLib.Structures.Traversable.
-
-Require Import Cava.Util.Vector.
 Require Import Cava.Cava.
-Require Import Cava.Lib.BitVectorOps.
-Require Cava.Lib.Vec.
-Require Import Cava.Core.Signal.
 Require Import AesSpec.StateTypeConversions.
 Require Import AesSpec.Tests.CipherTest.
 Require Import AesSpec.Tests.Common.
-
-Import VectorNotations.
+Local Open Scope vector_scope.
 
 Module Notations.
   Notation state := (Vec (Vec (Vec Bit 8) 4) 4) (only parsing).
@@ -61,14 +48,15 @@ Local Notation "v [@ n ]" := (indexConst v n) (at level 1, format "v [@ n ]").
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
 
-  Definition bitvec_to_signal {n : nat} (lut : t bool n) : cava (signal (Vec Bit n)) :=
+  Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : cava (signal (Vec Bit n)) :=
     Vec.bitvec_literal lut.
 
-  Definition bitvecvec_to_signal {a b : nat} (lut : t (t bool b) a) : cava (signal (Vec (Vec Bit b) a)) :=
-    v <- mapT bitvec_to_signal lut ;;
+  Definition bitvecvec_to_signal {a b : nat} (lut : Vector.t (Vector.t bool b) a)
+    : cava (signal (Vec (Vec Bit b) a)) :=
+    v <- Traversable.mapT bitvec_to_signal lut ;;
     packV v.
 
-  Definition natvec_to_signal_sized {n : nat} (size : nat) (lut : t nat n)
+  Definition natvec_to_signal_sized {n : nat} (size : nat) (lut : Vector.t nat n)
     : cava (signal (Vec (Vec Bit size) n)) :=
     bitvecvec_to_signal (Vector.map (nat_to_bitvec_sized size) lut).
 
@@ -122,8 +110,8 @@ Section WithCava.
   Definition aes_circ_byte_shift (shift: nat) (input: signal (Vec byte 4)):
     cava (signal (Vec byte 4)) :=
     let indices := [4 - shift; 5 - shift; 6 - shift; 7 - shift] in
-    let indices := map (fun x => Nat.modulo x 4) indices in
-    out <- mapT (indexConst input) indices ;;
+    let indices := Vector.map (fun x => Nat.modulo x 4) indices in
+    out <- Traversable.mapT (indexConst input) indices ;;
     packV out.
 
   Definition IDLE_S := bitvec_to_signal (nat_to_bitvec_sized 3 0).
@@ -170,6 +158,7 @@ End WithCava.
   SystemVerilog testbenches. The expected output tested in the generated test bench is created
   from the Cava semantics for AES sub components on these arbitrary inputs. *)
 Definition test_state
+  : Vector.t (Vector.t nat 4) 4
   := [[219; 19; 83; 69];
       [242; 10; 34; 92];
       [1; 1; 1; 1];
@@ -177,6 +166,7 @@ Definition test_state
   ].
 
 Definition test_key
+  : Vector.t (Vector.t nat 4) 4
   := [[219; 19; 83; 69];
       [242; 10; 34; 92];
       [1; 1; 1; 1];

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -14,14 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 
 Local Notation byte := (Vec Bit 8) (only parsing).

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsCircuit.v
@@ -20,7 +20,7 @@ Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.Multiplexers.
 Require Import AcornAes.Pkg.
 

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsEquivalence.v
@@ -23,7 +23,7 @@ Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Util.Identity.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.BitVectorOps.
 Import ListNotations VectorNotations.
 Local Open Scope list_scope.

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsEquivalence.v
@@ -14,27 +14,13 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Require Import ExtLib.Structures.Monads.
-Require Import Cava.Util.BitArithmetic.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Util.Vector.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Util.Identity.
 Require Import Cava.Cava.
-Require Import Cava.Lib.BitVectorOps.
-Import ListNotations VectorNotations.
-Local Open Scope list_scope.
-
+Require Import Cava.CavaProperties.
 Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
 Require Import AcornAes.Pkg.
 Require Import AcornAes.ShiftRowsCircuit.
 Import StateTypeConversions.LittleEndian.
-
-Existing Instance CombinationalSemantics.
 
 Section Equivalence.
   Local Notation byte := (Vector.t bool 8).
@@ -61,7 +47,7 @@ Section Equivalence.
     (* break state vector into 16 bytes *)
     constant_vector_simpl st.
     repeat match goal with
-           | v := _ : t byte 4 |- _ => constant_vector_simpl v
+           | v := _ : Vector.t byte 4 |- _ => constant_vector_simpl v
     end; clear.
 
     (* simplify LHS (implementation) *)

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsNetlist.v
@@ -14,12 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsNetlist.v
@@ -20,7 +20,7 @@ Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.TestVectors.

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsTests.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsTests.v
@@ -14,11 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/ShiftRowsTests.v
+++ b/silveroak-opentitan/aes/Acorn/ShiftRowsTests.v
@@ -19,7 +19,7 @@ Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.CipherTest.

--- a/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
@@ -21,7 +21,7 @@ Import ListNotations VectorNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.Multiplexers.
 Require Cava.Lib.Vec.
 Require Import AcornAes.Pkg.

--- a/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesCircuit.v
@@ -14,23 +14,13 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.Multiplexers.
-Require Cava.Lib.Vec.
 Require Import AcornAes.Pkg.
 Import Pkg.Notations.
-
 Local Open Scope vector_scope.
 
 Section SboxLut.
-  Definition sbox_fwd : t nat _ :=
+  Definition sbox_fwd : Vector.t nat _ :=
     [ 99; 124; 119; 123; 242; 107; 111; 197;
       48; 1; 103; 43; 254; 215; 171; 118;
 
@@ -79,7 +69,7 @@ Section SboxLut.
       140; 161; 137; 13; 191; 230; 66; 104;
       65; 153; 45; 15; 176; 84; 187; 22 ].
 
-  Definition sbox_inv : t nat _ :=
+  Definition sbox_inv : Vector.t nat _ :=
     [ 82; 9; 106; 213; 48; 54; 165; 56;
       191; 64; 163; 158; 129; 243; 215; 251;
 

--- a/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
@@ -15,27 +15,11 @@
 (****************************************************************************)
 
 Require Import Cava.Cava.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Util.Identity.
-Require Import Cava.Util.BitArithmetic.
-Require Import Cava.Lib.BitVectorOps.
-Require Import Cava.Lib.VecProperties.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Util.Vector.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Require Import ExtLib.Structures.Monads.
-Import VectorNotations.
-Close Scope vector_scope.
-Import ListNotations.
-
+Require Import Cava.CavaProperties.
 Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
 Require Import AcornAes.SubBytesCircuit.
 Import StateTypeConversions.LittleEndian.
-
-Existing Instance CombinationalSemantics.
 
 Section Equivalence.
   Local Notation byte := (Vector.t bool 8).
@@ -102,13 +86,14 @@ Section Equivalence.
 
     constant_vector_simpl st.
     repeat match goal with
-       | v : t byte 4 |- _ => constant_vector_simpl v
-    end; clear.
+       | v : Vector.t byte 4 |- _ => constant_vector_simpl v
+           end; clear.
 
-    repeat first [ progress cbn [List.map map]
+    repeat first [ progress cbn [List.map Vector.map]
+                 | progress simpl_ident
                  | progress autorewrite with push_to_list push_of_list_sized ].
     rewrite ! sub_bytes_bytewise.
     destruct is_decrypt; reflexivity.
-Qed.
+  Qed.
 
 End Equivalence.

--- a/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesEquivalence.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Util.Identity.
 Require Import Cava.Util.BitArithmetic.

--- a/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
@@ -14,12 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesNetlist.v
@@ -20,7 +20,7 @@ Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.TestVectors.

--- a/silveroak-opentitan/aes/Acorn/SubBytesTests.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesTests.v
@@ -14,11 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-
-Require Import Cava.Cava.
 Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.

--- a/silveroak-opentitan/aes/Acorn/SubBytesTests.v
+++ b/silveroak-opentitan/aes/Acorn/SubBytesTests.v
@@ -19,7 +19,7 @@ Require Import Coq.Vectors.Vector.
 Import ListNotations VectorNotations.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import AesSpec.AES256.
 Require Import AesSpec.Tests.Common.
 Require Import AesSpec.Tests.CipherTest.

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -14,22 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-
-Import List.ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-
-Open Scope monad_scope.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-
-Local Open Scope type_scope.
 Local Open Scope vector_scope.
 
 Definition width := 32.

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -27,7 +27,7 @@ Import VectorNotations.
 Open Scope monad_scope.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 
 Local Open Scope type_scope.
 Local Open Scope vector_scope.

--- a/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
+++ b/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
@@ -14,18 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import NArith.NArith Lists.List Vectors.Vector.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
-Import VectorNotations.
-Local Open Scope vector_scope.
 
 (******************************************************************************)
 (* Accumulating adder with an enable.                                         *)
@@ -75,8 +64,6 @@ End WithCava.
 (* Convenience notation for turning a list of nats into a list of bitvectors *)
 Local Notation "'#' l" := (map (fun i => N2Bv_sized 8 (N.of_nat i)) l)
                             (at level 40, only parsing).
-
-Local Open Scope list_scope.
 
 Example accumulatingAdderEnable_ex1:
   simulate accumulatingAdderEnable

--- a/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
+++ b/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
@@ -22,7 +22,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 Import VectorNotations.
 Local Open Scope vector_scope.

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -14,24 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.PeanoNat NArith.NArith Lists.List.
-Require Import Coq.micromega.Lia.
-Require Import Coq.Bool.Bvector.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
-Require Import coqutil.Tactics.Tactics.
-
 Require Import Cava.Cava.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Cava.
-Require Import Cava.Util.Identity.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Lib.UnsignedAdders.
-
+Require Import Cava.CavaProperties.
 Require Import Tests.AccumulatingAdderEnable.AccumulatingAdderEnable.
 
 Definition bvadd {n} (a b : Signal.combType (Vec Bit n)) : Signal.combType (Vec Bit n) :=

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -27,7 +27,7 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Cava.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Util.Identity.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Lib.UnsignedAdders.

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -21,8 +21,6 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
 Import Circuit.Notations.
 
 (******************************************************************************)

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -21,7 +21,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 Import Circuit.Notations.
 

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -14,12 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import NArith.NArith Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
 Import Circuit.Notations.
 
@@ -73,8 +67,6 @@ End WithCava.
 (* Convenience notation for turning a list of nats into a list of 8-bit bitvectors *)
 Local Notation "'#' l" := (map (fun i => N2Bv_sized 8 (N.of_nat i)) l)
                             (at level 40, only parsing).
-
-Local Open Scope list_scope.
 
 Example addWithDelay_ex1: simulate addWithDelay (# [0;1;2;3;4;5;6;7;8]) = # [0;0;1;2;4;6;9;12;16].
 Proof. reflexivity. Qed.

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -14,19 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.PeanoNat NArith.NArith Lists.List.
-Require Import Coq.micromega.Lia.
-Require Import Coq.Bool.Bvector.
-Import ListNotations.
-
-Require Import coqutil.Tactics.Tactics.
-
 Require Import Cava.Cava.
 Require Import Cava.CavaProperties.
-Import Circuit.Notations.
-
 Require Import Tests.AddWithDelay.AddWithDelay.
-Local Open Scope nat_scope.
+Import Circuit.Notations.
 
 Definition bvadd {n} (a b : Signal.combType (Vec Bit n)) : Signal.combType (Vec Bit n) :=
   N2Bv_sized n (Bv2N a + Bv2N b).

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -27,7 +27,7 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Cava.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Util.Identity.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Lib.UnsignedAdders.

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -19,18 +19,10 @@ Require Import Coq.micromega.Lia.
 Require Import Coq.Bool.Bvector.
 Import ListNotations.
 
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import coqutil.Tactics.Tactics.
 
 Require Import Cava.Cava.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Cava.
-Require Import Cava.Util.Identity.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Lib.UnsignedAdders.
+Require Import Cava.CavaProperties.
 Import Circuit.Notations.
 
 Require Import Tests.AddWithDelay.AddWithDelay.

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -14,34 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List.
-From Coq Require Import Strings.Ascii Strings.String Vectors.Vector.
-From Coq Require Import NArith.
-Import ListNotations.
-Import VectorNotations.
-
-Require Import ExtLib.Structures.Monads.
-Require Import ExtLib.Structures.Traversable.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
-Require Import Coq.Vectors.Vector.
-Require Import Cava.Util.Vector.
-Require Import Coq.Bool.Bvector.
-
-From Coq Require Import Bool.Bvector.
-Existing Instance CavaCombinationalNet.
+Local Open Scope vector_scope.
 
 Section WithCava.
   Context `{Cava}.
 
-  Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : cava (signal (Vec Bit n)) :=
-    packV (Vector.map constant lut).
-
   Definition array : cava (signal (Vec (Vec Bit 8) 4)) :=
-    v <- mapT (fun x => bitvec_to_signal (nat_to_bitvec_sized _ x)) [0;1;2;3] ;;
+    v <- Traversable.mapT (fun x => Vec.bitvec_literal (nat_to_bitvec_sized _ x)) [0;1;2;3] ;;
     packV v.
 
   Definition multiDimArray : cava (signal (Vec (Vec (Vec Bit 8) 4) 2)) :=
@@ -61,8 +41,6 @@ Section WithCava.
     indexConst v 0.
 
 End WithCava.
-
-Local Open Scope list_scope.
 
 Definition arrayTest_Interface
   := sequentialInterface "arrayTest"

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -25,7 +25,7 @@ Require Import ExtLib.Structures.Traversable.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 Require Import Coq.Vectors.Vector.
 Require Import Cava.Util.Vector.

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -14,17 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import NArith.NArith Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
 
 (******************************************************************************)
 (* countBy                                                                    *)
@@ -64,8 +54,6 @@ Definition b18 := N2Bv_sized 8 18.
 Definition b21 := N2Bv_sized 8 21.
 Definition b24 := N2Bv_sized 8 24.
 Definition b250 := N2Bv_sized 8 250.
-
-Local Open Scope list_scope.
 
 Example countBy_ex1: simulate countBy [b14; b7; b3; b250] = [b14; b21; b24; b18].
 Proof. reflexivity. Qed.

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -23,7 +23,7 @@ Export MonadNotation.
 
 Require Import Cava.Cava.
 Require Import Cava.Util.Tactics.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 
 (******************************************************************************)

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -14,23 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import NArith.NArith Arith.PeanoNat Lists.List.
-Require Import Coq.Bool.Bvector.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
-Require Import coqutil.Tactics.Tactics.
-
 Require Import Cava.Cava.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Cava.
-Require Import Cava.Util.Identity.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Lib.UnsignedAdders.
-
+Require Import Cava.CavaProperties.
 Require Import Tests.CountBy.CountBy.
 
 Existing Instance CombinationalSemantics.

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -26,7 +26,7 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Cava.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Util.Identity.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Lib.UnsignedAdders.

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -14,20 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import NArith.
-From Coq Require Import Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
 Import Circuit.Notations.
-
-From Coq Require Import Bool.Bvector.
 
 (******************************************************************************)
 (* A byte unit delay.                                                         *)

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -23,7 +23,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 Import Circuit.Notations.
 

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -14,21 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.String.
-Require Import Coq.NArith.NArith.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-Local Open Scope list_scope.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.UnsignedAdders.
-Require Import Cava.Lib.Multiplexers.
-Require Cava.Lib.Vec.
 Import Circuit.Notations.
 
 (******************************************************************************)

--- a/tests/DoubleCountBy/DoubleCountBy.v
+++ b/tests/DoubleCountBy/DoubleCountBy.v
@@ -25,7 +25,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.UnsignedAdders.
 Require Import Cava.Lib.Multiplexers.
 Require Cava.Lib.Vec.

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -28,7 +28,7 @@ Export MonadNotation.
 Require Import Cava.Cava.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Util.Identity.
 Require Import Cava.Semantics.CombinationalProperties.
 Require Import Cava.Lib.UnsignedAdders.

--- a/tests/DoubleCountBy/ListProofs.v
+++ b/tests/DoubleCountBy/ListProofs.v
@@ -14,29 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.NArith.NArith.
-Require Import Coq.Lists.List.
-Require Import Coq.Vectors.Vector.
-Import ListNotations VectorNotations.
-Local Open Scope list_scope.
-
-Require Import coqutil.Tactics.Tactics.
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Util.List.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Cava.
-Require Import Cava.Util.Identity.
-Require Import Cava.Semantics.CombinationalProperties.
-Require Import Cava.Lib.UnsignedAdders.
-Require Import Cava.Lib.MultiplexersProperties.
-
-Require Import DoubleCountBy.DoubleCountBy.
-
-Existing Instance CombinationalSemantics.
+Require Import Cava.CavaProperties.
+Require Import Tests.DoubleCountBy.DoubleCountBy.
 
 (* redefine simpl_ident to simplify the new semantics class *)
 Definition bvadd {n} (a b : Vector.t bool n) : Vector.t bool n :=
@@ -106,7 +86,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma bvsumc_snoc {n} xs (x : t bool n) :
+Lemma bvsumc_snoc {n} xs (x : Vector.t bool n) :
   bvsumc (xs ++ [x]) = bvaddc x (fst (bvsumc xs)).
 Proof.
   cbv [bvsumc].

--- a/tests/Instantiate.v
+++ b/tests/Instantiate.v
@@ -22,7 +22,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.

--- a/tests/Instantiate.v
+++ b/tests/Instantiate.v
@@ -14,20 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
-Existing Instance CavaCombinationalNet.
 
 Section WithCava.
   Context {signal} `{Cava signal}.

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -22,7 +22,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Require Import Cava.Lib.Multiplexers.
 
 Require Import Coq.Bool.Bvector.

--- a/tests/MuxTests.v
+++ b/tests/MuxTests.v
@@ -13,23 +13,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Bool.Bool Coq.NArith.NArith.
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Require Import Cava.Lib.Multiplexers.
-
-Require Import Coq.Bool.Bvector.
-Import Vector.VectorNotations.
-
-Local Open Scope vector_scope.
-Existing Instance CavaCombinationalNet.
 
 Section WithCava.
   Context {signal} `{Cava signal}.
@@ -50,8 +34,6 @@ Section WithCava.
     indexAt v sel.
 
 End WithCava.
-
-Local Close Scope vector_scope.
 
 (******************************************************************************)
 (* mux2 tests                                                                 *)
@@ -91,7 +73,6 @@ Definition mux2_1_tb
 (* muxBus                                                                     *)
 (******************************************************************************)
 
-Local Open Scope vector_scope.
 Definition v0 := N2Bv_sized 8   5.
 Definition v1 := N2Bv_sized 8 157.
 Definition v2 := N2Bv_sized 8 255.
@@ -115,8 +96,6 @@ Proof. reflexivity. Qed.
 
 Example m8: muxBus (v0to3, [true; true]%vector) = v3.
 Proof. reflexivity. Qed.
-
-Local Close Scope vector_scope.
 
 Definition muxBus4_8Interface
   := combinationalInterface "muxBus4_8"

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -14,17 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.NArith.NArith.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Existing Instance CavaCombinationalNet.
 
 Section WithCava.
   Context {signal} `{Cava signal}.
@@ -57,8 +47,6 @@ Proof. reflexivity. Qed.
 (* Generate an unsigned multiplier with 2 and 3 bit inputs and 5-bit result.  *)
 (******************************************************************************)
 
-Local Open Scope nat_scope.
-
 Definition mult2_3_5Interface
   := combinationalInterface "mult2_3_5"
      [mkPort "a" (Vec Bit 2); mkPort "b" (Vec Bit 3)]
@@ -77,4 +65,3 @@ Definition mult2_3_5_tb_expected_outputs
 Definition  mult2_3_5_tb
   := testBench "mult2_3_5_tb" mult2_3_5Interface
      mult2_3_5_tb_inputs mult2_3_5_tb_expected_outputs.
-

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -23,7 +23,7 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Existing Instance CavaCombinationalNet.
 
 Section WithCava.

--- a/tests/xilinx/LUTTests.v
+++ b/tests/xilinx/LUTTests.v
@@ -14,15 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Strings.Ascii Coq.Strings.String.
-Require Import Coq.Lists.List.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-
 Require Import Cava.Cava.
-Require Import Cava.Cava.
-Existing Instance CavaCombinationalNet.
 
 Section WithCava.
   Context {signal} `{Cava signal}.

--- a/tests/xilinx/LUTTests.v
+++ b/tests/xilinx/LUTTests.v
@@ -21,7 +21,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.Acorn.Acorn.
+Require Import Cava.Cava.
 Existing Instance CavaCombinationalNet.
 
 Section WithCava.


### PR DESCRIPTION
Most of #437 

Creates `cava/Cava/Cava.v` and `cava/Cava/CavaProperties.v`, and changes everything to use those imports instead of separately importing things from `Cava`. The `Cava.v` file also does some Coq standard library/extended library imports and sets notation scopes, so the many lines of imports have gotten much reduced!

Now, nothing outside of `cava/` itself imports anything other than `Cava.Cava`, `Cava.CavaProperties`, and occasionally `Cava.Util` files if they don't import the other two (this applies, for instance, to some specifications that use list/vector utilities but have no need for anything else from `Cava`).

Remaining tasks for #437, which will appear in the next PR:
- Reorganize `Lib/FullAdder.v`, `Lib/UnsignedAdders.v`, `Lib/UnsignedAdderProofs.v`, and `Lib/XilinxAdder.v` into `Lib/Adders.v` and `Lib/AddersProperties.v`
- Separate definitions and proofs in `Util/BitArithmetic.v`
- Move combinator proofs in `Semantics/CombinationalProperties` into a new file `Lib/CombinatorProperties`
- Remove remaining references to the `acorn` name, since it's now just `cava`

Some smaller secondary changes that you might notice:
- Moves `foldLM` to its own file in `Util` -- I'd have left it for later, but the changes in imports made it structurally necessary to be included here
- Removes a lemma from `UnsignedAdderProofs.v` that has a name conflict with a `BitArithmetic` lemma