### PR TITLE
Update coq-ext-lib to fix infinite looping

### DIFF
--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -21,22 +21,34 @@ all: coqutil coqtools bedrock2 extlib record-update
 update:
 	git submodule update --init --recursive
 
+no-update: build-coqtools build-coqutil build-bedrock2 build-extlib build-record-update
+
 minimize-requires: # noop
 
-# coq-tools is just python scripts; nothing to make
-coqtools: update
+# coq-tools is just python scripts; nothing to build
+build-coqtools: # noop
 
-coqutil: update
+build-coqutil:
 	$(MAKE) -C bedrock2/deps/coqutil all
 
-bedrock2: update coqutil
+build-bedrock2: build-coqutil
 	$(MAKE) -C bedrock2 bedrock2_noex
 
-extlib: update
+build-extlib:
 	$(MAKE) -C coq-ext-lib theories
 
-record-update: update
+build-record-update:
 	$(MAKE) -C coq-record-update
+
+coqtools: update build-coqtools
+
+coqutil: update build-coqutil
+
+bedrock2: update build-bedrock2
+
+extlib: update build-extlib
+
+record-update: update build-record-update
 
 install: update
 	cd bedrock2 && $(MAKE) install_coqutil && $(MAKE) install_bedrock2

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -21,12 +21,9 @@ all: coqutil coqtools bedrock2 extlib record-update
 update:
 	git submodule update --init --recursive
 
-no-update: build-coqtools build-coqutil build-bedrock2 build-extlib build-record-update
+no-update: build-coqutil build-bedrock2 build-extlib build-record-update
 
 minimize-requires: # noop
-
-# coq-tools is just python scripts; nothing to build
-build-coqtools: # noop
 
 build-coqutil:
 	$(MAKE) -C bedrock2/deps/coqutil all
@@ -40,8 +37,8 @@ build-extlib:
 build-record-update:
 	$(MAKE) -C coq-record-update
 
+# coq-tools is just python scripts; nothing to build
 coqtools: update
-	$(MAKE) build-coqtools
 
 coqutil: update
 	$(MAKE) build-coqutil

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -40,15 +40,20 @@ build-extlib:
 build-record-update:
 	$(MAKE) -C coq-record-update
 
-coqtools: update build-coqtools
+coqtools: update
+	$(MAKE) build-coqtools
 
-coqutil: update build-coqutil
+coqutil: update
+	$(MAKE) build-coqutil
 
-bedrock2: update build-bedrock2
+bedrock2: update
+	$(MAKE) build-bedrock2
 
-extlib: update build-extlib
+extlib: update
+	$(MAKE) build-extlib
 
-record-update: update build-record-update
+record-update: update
+	$(MAKE) build-record-update
 
 install: update
 	cd bedrock2 && $(MAKE) install_coqutil && $(MAKE) install_bedrock2


### PR DESCRIPTION
- Bumps `coq-ext-lib` to the latest version to capture the update we submitted that prevents an infinite loop in typeclass inference
- Adds a `no-update` target to `third_party/Makefile` to make updating submodules easier

Following up from a conversation over email. @smore-lore gave an example where he was experiencing the infinite-looping problem. I reproduced the infinite loop before the update and confirmed that the update fixed it.

The change to the `Makefile` is because I realized that it was very annoying to rebuild `third_party` after updating from the remote, because the default target always ran `git submodule update` (pulling the submodule information from our repo) and undid the remote update. Now you can run `make no-update` in `third_party` to avoid this behavior.