### PR TITLE
Cleanup of Combinators.v and Adders.v

### DIFF
--- a/cava/Cava/Lib/Adders.v
+++ b/cava/Cava/Lib/Adders.v
@@ -29,117 +29,58 @@ Section WithCava.
   Context `{semantics:Cava}.
 
   (* Build a half adder *)
-  Definition halfAdder '(a, b) :=
-    partial_sum <- xor2 (a, b) ;;
-    carry <- and2 (a, b) ;;
+  Definition halfAdder '(x, y) :=
+    partial_sum <- xor2 (x, y) ;;
+    carry <- and2 (x, y) ;;
     ret (partial_sum, carry).
 
   (* A full adder *)
-  Definition fullAdder '(cin, (a, b))
+  Definition fullAdder '(cin, (x, y))
                        : cava (signal Bit * signal Bit) :=
-    '(abl, abh) <- halfAdder (a, b) ;;
-    '(abcl, abch) <- halfAdder (abl, cin) ;;
-    cout <- or2 (abh, abch) ;;
-    ret (abcl, cout).
+    '(xyl, xyh) <- halfAdder (x, y) ;;
+    '(xycl, xych) <- halfAdder (xyl, cin) ;;
+    cout <- or2 (xyh, xych) ;;
+    ret (xycl, cout).
 
   (* Unsigned adder for n-bit vectors with carry bits both in and out *)
-  Definition unsignedAdderV {n : nat}
-            (inputs: signal Bit * (Vector.t (signal Bit * signal Bit)) n) :
-            cava (Vector.t (signal Bit) n * signal Bit) :=
-    colV fullAdder inputs.
+  Definition addC {n : nat}
+             (inputs : signal (Vec Bit n) * signal (Vec Bit n) * signal Bit) :
+    cava (signal (Vec Bit n) * signal Bit) :=
+    let '(x, y, cin) := inputs in
+    x <- unpackV x ;;
+    y <- unpackV y ;;
+    col fullAdder cin (vcombine x y).
 
-  (* Adder with a pair of inputs of the same size and no bit-growth. *)
+  (* Unsigned adder for n-bit vectors with bit-growth and no carry bits in or out *)
   Definition addN {n : nat}
-            (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
+            (xy: signal (Vec Bit n) * signal (Vec Bit n)) :
     cava (signal (Vec Bit n)) :=
-    a <- unpackV (fst ab) ;;
-    b <- unpackV (snd ab) ;;
-    '(sum, _) <- unsignedAdderV (constant false, vcombine a b) ;;
-    packV sum.
-
-  Definition adderWithGrowthV {n : nat}
-                              (inputs: signal Bit * (Vector.t (signal Bit * signal Bit)) n) :
-                              cava (Vector.t (signal Bit) (n + 1)) :=
-    '(sum, cout) <- unsignedAdderV inputs ;;
-    ret (sum ++ [cout])%vector.
-
-  Definition adderWithGrowthNoCarryInV {n : nat}
-            (inputs: Vector.t (signal Bit * signal Bit) n) :
-            cava (Vector.t (signal Bit) (n + 1)) :=
-    adderWithGrowthV (constant false, inputs).
-
-  Definition addLWithCinV {n : nat}
-                          (cin : signal Bit)
-                          (a b : Vector.t (signal Bit) n) :
-                          cava (Vector.t (signal Bit) (n + 1)) :=
-    adderWithGrowthV (cin, vcombine a b).
-
-  (* Curried add with no carry in *)
-  Definition addV {n : nat}
-            (a b: Vector.t (signal Bit) n) :
-            cava (Vector.t (signal Bit) (n + 1)) :=
-    adderWithGrowthNoCarryInV (vcombine a b).
-
-  (* A 3-input adder *)
-  Definition adder_3input {aSize bSize cSize}
-                          (a : signal (Vec Bit aSize))
-                          (b : signal (Vec Bit bSize))
-                          (c : signal (Vec Bit cSize)) :
-                          cava (signal (Vec Bit (1 + max (1 + max aSize bSize) cSize)))
-                          :=
-    a_plus_b <- unsignedAdd (a, b) ;;
-    sum <- unsignedAdd (a_plus_b, c) ;;
+    '(sum, _) <- addC (xy, zero) ;;
     ret sum.
-
-  (* List version *)
-  Definition unsignedAdderL (inputs: signal Bit * (list (signal Bit * signal Bit))) :
-                            cava (list (signal Bit) * signal Bit) :=
-    colL fullAdder inputs.
-
-  Definition adderWithGrowthL (inputs: signal Bit * (list (signal Bit * signal Bit))) :
-                              cava (list (signal Bit)) :=
-    '(sum, cout) <- unsignedAdderL inputs ;;
-    ret (sum ++ [cout])%list.
-
-  Definition adderWithGrowthNoCarryInL
-            (inputs: list (signal Bit * signal Bit)) :
-            cava (list (signal Bit)) :=
-    adderWithGrowthL (zero, inputs).
-
-  Definition addLWithCinL (cin : signal Bit)
-                          (a b : list (signal Bit)) :
-                          cava (list (signal Bit)) :=
-    adderWithGrowthL (cin, combine a b).
-
-  Definition addL (a b : list (signal Bit)) :
-                  cava (list (signal Bit)) :=
-    adderWithGrowthNoCarryInL (combine a b).
 
   Section XilinxAdders.
     (* Build a full-adder with explicit use of Xilinx FPGA fast carry logic *)
-    Definition xilinxFullAdder '(cin, (a, b))
+    Definition xilinxFullAdder '(cin, (x, y))
     : cava (signal Bit * signal Bit) :=
-      part_sum <- xor2 (a, b) ;;
+      part_sum <- xor2 (x, y) ;;
       sum <- xorcy (part_sum, cin) ;;
-      cout <- muxcy part_sum cin a  ;;
+      cout <- muxcy part_sum cin x  ;;
       ret (sum, cout).
 
     (* An unsigned adder built using the fast carry full-adder.*)
     Definition xilinxAdderWithCarry {n: nat}
-               (cinab : signal Bit * (signal (Vec Bit n) * signal (Vec Bit n)))
+               (xyc : signal (Vec Bit n) * signal (Vec Bit n) * signal Bit)
       : cava (signal (Vec Bit n) * signal Bit)
-      := let '(cin, (a, b)) := cinab in
-         a0 <- unpackV a ;;
-         b0 <- unpackV b ;;
-         '(sum, cout) <- colV xilinxFullAdder (cin, vcombine a0 b0) ;;
-         sum <- packV sum ;;
-         ret (sum, cout).
+      := let '(x, y, cin) := xyc in
+         x <- unpackV x ;;
+         y <- unpackV y ;;
+         col xilinxFullAdder cin (vcombine x y).
 
-    (* An unsigned adder with no bit-growth and no carry in *)
+    (* An unsigned adder with no bit-growth and no carry in or out *)
     Definition xilinxAdder {n: nat}
-               (a b: signal (Vec Bit n))
+               (x y : signal (Vec Bit n))
       : cava (signal (Vec Bit n)) :=
-      '(sum, carry) <- xilinxAdderWithCarry (constant false, (a, b)) ;;
+      '(sum, carry) <- xilinxAdderWithCarry (x, y, zero) ;;
       ret sum.
   End XilinxAdders.
 End WithCava.

--- a/cava/Cava/Lib/AddersProperties.v
+++ b/cava/Cava/Lib/AddersProperties.v
@@ -23,15 +23,18 @@ Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.MonadLaws.
 Require Import Cava.Core.Core.
 Require Import Cava.Lib.Adders.
+Require Import Cava.Lib.CavaPrelude.
 Require Import Cava.Lib.Combinators.
-Require Import Cava.Lib.CombinationalProperties.
+Require Import Cava.Lib.CombinatorsProperties.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Util.BitArithmeticProperties.
 Require Import Cava.Util.Identity.
 Require Import Cava.Util.List.
+Require Import Cava.Util.Nat.
 Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
+Import VectorNotations.
 Local Open Scope N_scope.
 
 (* A proof that the half-adder is correct. *)
@@ -55,152 +58,58 @@ Proof.
   all : reflexivity.
 Qed.
 
-(* First prove the full-adder correct. *)
-
-Lemma fullAdder_correct (cin a b : bool) :
-  fullAdder (cin, (a, b)) =
+Lemma fullAdder_correct inputs :
+  let cin := fst inputs in
+  let a := fst (snd inputs) in
+  let b := snd (snd inputs) in
   let sum := N.b2n a + N.b2n b + N.b2n cin in
-  (N.testbit sum 0, N.testbit sum 1).
-Proof. destruct cin, a, b; reflexivity. Qed.
+  fullAdder inputs = (N.testbit sum 0, N.testbit sum 1).
+Proof. destruct inputs as [cin [a b]]; destruct cin, a, b; reflexivity. Qed.
 
-(* Lemma about how to decompose a list of bits. *)
-Lemma list_bits_to_nat_cons b bs :
-  N.of_list_bits (b :: bs) = (N.b2n b + 2 * (N.of_list_bits bs))%N.
+Lemma addC_correct n inputs :
+  let x := fst (fst inputs) in
+  let y := snd (fst inputs) in
+  let sum := Bv2N x + Bv2N y + N.b2n (snd inputs) in
+  addC (n:=n) inputs = (N2Bv_sized n sum, N.testbit_nat sum n).
 Proof.
-  cbv [N.of_list_bits]. cbn [of_list length].
-  rewrite Bv2N_cons.
-  destruct_one_match; cbn [N.b2n];
-    rewrite ?N.double_spec, ?N.succ_double_spec;
-    lia.
+  cbv [addC]. repeat destruct_pair_let. simpl_ident.
+  destruct inputs as [[x y] cin]. cbn [fst snd].
+  revert x y cin; induction n; intros;
+    [ apply case0 with (v:=x); apply case0 with (v:=y);
+      destruct cin; reflexivity | ].
+  rewrite col_step, fullAdder_correct. cbn [fst snd].
+  rewrite (Vector.eta x), (Vector.eta y).
+  rewrite vcombine_cons. autorewrite with vsimpl.
+  rewrite !Bv2N_cons. cbn [fst snd]. rewrite IHn.
+  repeat destruct_one_match; destruct cin;
+    repeat lazymatch goal with |- context [N.testbit ?n ?i] =>
+                               compute_expr (N.testbit n i) end;
+    cbn [N.b2n fst snd].
+  all:rewrite <-?N2Bv_sized_double, <-?N2Bv_sized_succ_double.
+  all:repeat lazymatch goal with
+             | |- context [N.double ?x] => rewrite (N.double_spec x)
+             | |- context [N.succ_double ?x] => rewrite (N.succ_double_spec x)
+             end.
+  all:apply f_equal2; [ f_equal; lia | ].
+  all:rewrite <-Ndiv2_correct, N.div2_div.
+  all:f_equal; [ ].
+  all:first [ apply N.div_unique with (r:=0); lia
+            | apply N.div_unique with (r:=1); lia ].
 Qed.
 
-Hint Rewrite @bind_of_return @bind_associativity
-     using solve [typeclasses eauto] : monadlaws.
-
-(* Correctness of the list based adder. *)
-Lemma addLCorrect (cin : bool) (a b : list bool) :
-  length a = length b ->
-  N.of_list_bits (addLWithCinL cin a b) =
-  N.of_list_bits a + N.of_list_bits b + N.b2n cin.
+Lemma addN_correct n inputs :
+  let sum := Bv2N (fst inputs) + Bv2N (snd inputs) in
+  addN (n:=n) inputs = N2Bv_sized n sum.
 Proof.
-  cbv zeta. cbv [addLWithCinL adderWithGrowthL unsignedAdderL colL].
-  cbn [fst snd].
-  (* get rid of pair-let because it will cause problems in the inductive case *)
-  simpl_ident. repeat destruct_pair_let.
-
-  (* start induction; eliminate cases where length b <> length a and solve base
-     case immediately *)
-  revert dependent cin. revert dependent b.
-  induction a; (destruct b; cbn [length]; try lia; [ ]); intros;
-    [ destruct cin; reflexivity | ].
-
-  (* inductive case only now; simplify *)
-  cbn [combine colL']. rewrite !list_bits_to_nat_cons.
-  simpl_ident.
-
-  (* use fullAdder_correct to replace fullAdder call with addition + testbit *)
-  rewrite fullAdder_correct. cbv zeta.
-  (cbn match beta). repeat destruct_pair_let; simpl_ident.
-
-  (* Rearrange to match inductive hypothesis *)
-  rewrite <-app_comm_cons.
-  rewrite list_bits_to_nat_cons.
-
-  (* Finally we have the right expression to use IHa *)
-  rewrite IHa by lia.
-
-  (* Now that the recursive part matches, we can just compute all 8 cases for
-     the first step (a + b + cin) *)
-  destruct a, b, cin; cbv [N.b2n].
-  all:repeat match goal with
-             | |- context [N.testbit ?x ?n] =>
-               let b := eval compute in (N.testbit x n) in
-                   change (N.testbit x n) with b
-             end; (cbn match).
-  all:lia.
-Qed.
-
-(* Correctness of the vector based adder. *)
-
-Lemma Bv2N_resize m n (Hmn : n = m) (v : t bool n) :
-  Bv2N v = Bv2N (Vector.resize_default false m v).
-Proof.
-  subst. rewrite Vector.resize_default_id.
-  reflexivity.
-Qed.
-
-Lemma colV_colL {A B C} {n} circuit inputs d :
-  @colV _ CombinationalSemantics A B C n circuit inputs =
-  (let inputL := (fst inputs, to_list (snd inputs)) in
-   rL <- colL circuit inputL ;;
-      let rV := Vector.resize_default
-                  d _ (Vector.of_list (fst rL)) in
-      ret (rV, snd rL)).
-Proof.
-  cbv [colV colL]. destruct inputs as [a bs]. cbn [fst snd].
-  revert a; induction bs; intros.
-  { cbn [colL' colV' to_list fst snd].
-    autorewrite with monadlaws; reflexivity. }
-  { rewrite !to_list_cons. cbn [colL' colV'].
-    simpl_ident. repeat destruct_pair_let.
-    simpl_ident. rewrite IHbs. clear IHbs.
-    simpl_ident. cbn [fst snd of_list length].
-    cbn [Vector.resize_default].
-    autorewrite with vsimpl.
-    reflexivity. }
-Qed.
-
-Lemma Bv2N_list_bits_to_nat n (v : t bool n) :
-  Bv2N v = N.of_list_bits (to_list v).
-Proof.
-  induction v; intros; [ reflexivity | ].
-  rewrite to_list_cons, Bv2N_cons, list_bits_to_nat_cons.
-  destruct_one_match; cbn [N.b2n];
-    rewrite ?N.double_spec, ?N.succ_double_spec;
-    lia.
-Qed.
-
-Lemma colL_length {A B C} circuit a bs :
-  length (fst (@colL ident _ A B C circuit (a,bs)))
-  = length bs.
-Proof.
-  cbv [colL]; cbn [fst snd].
-  revert a; induction bs; intros; [ reflexivity | ].
-  cbn [colL']. simpl_ident. repeat destruct_pair_let.
-  simpl_ident. cbn [fst snd length].
-  rewrite IHbs. reflexivity.
-Qed.
-
-Hint Rewrite @colL_length using solve [length_hammer] : push_length.
-
-Lemma addVCorrect (cin : bool) (n : nat) (a b : Vector.t bool n) :
-  addLWithCinV cin a b =
-  (N2Bv_sized (n+1) (Bv2N a + Bv2N b + (N.b2n cin))).
-Proof.
-  apply Bv2N_inj. rewrite Bv2N_N2Bv_sized.
-  (* prove bounds side condition *)
-  2:{
-    pose proof (Bv2N_upper_bound _ a).
-    pose proof (Bv2N_upper_bound _ b).
-    rewrite <-!Nshiftl_equiv_nat in *.
-    rewrite N.shiftl_1_l in *.
-    rewrite PeanoNat.Nat.add_1_r.
-    rewrite Nat2N.inj_succ, N.pow_succ_r by lia.
-    destruct cin; cbv [N.b2n]; lia. }
-  rewrite !Bv2N_list_bits_to_nat.
-  rewrite <-addLCorrect by (rewrite !to_list_length; reflexivity).
-  cbv [addLWithCinV adderWithGrowthV unsignedAdderV
-       addLWithCinL adderWithGrowthL unsignedAdderL].
-  rewrite colV_colL with (d:=false). simpl_ident.
-  repeat destruct_pair_let. simpl_ident.
-  autorewrite with push_to_list.
-  reflexivity.
+  cbv [addN zero]. simpl_ident. repeat destruct_pair_let.
+  rewrite addC_correct. cbn [fst snd N.b2n].
+  rewrite N.add_0_r. reflexivity.
 Qed.
 
 (* A quick sanity check of the Xilinx adder with carry in and out *)
 Example xilinx_add_17_52:
   xilinxAdderWithCarry
-    (false, (N2Bv_sized 8 17, N2Bv_sized 8 52)) =
+    (N2Bv_sized 8 17, N2Bv_sized 8 52, false) =
   (N2Bv_sized 8 69, false).
 Proof. vm_compute. reflexivity. Qed.
 

--- a/cava/Cava/Lib/BitVectorOps.v
+++ b/cava/Cava/Lib/BitVectorOps.v
@@ -25,7 +25,7 @@ Open Scope monad_scope.
 
 Require Import Cava.Core.Core.
 Require Import Cava.Core.CavaClass.
-Require Import Cava.Lib.Combinators.
+Require Cava.Lib.Vec.
 
 Section WithCava.
   Context {signal} `{Cava signal}.
@@ -33,7 +33,7 @@ Section WithCava.
   (* A circuit to xor two bit-vectors *)
   Definition xorV {n : nat} (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
     cava (signal (Vec Bit n)) :=
-    zipWith xor2 (fst ab) (snd ab).
+    Vec.map2 xor2 (fst ab) (snd ab).
 
   (* Make a curried version of xorV *)
   Definition xorv {n} (a b : signal (Vec Bit n)) : cava (signal (Vec Bit n)) := xorV (a, b).

--- a/cava/Cava/Lib/CavaPreludeProperties.v
+++ b/cava/Cava/Lib/CavaPreludeProperties.v
@@ -1,0 +1,95 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.micromega.Lia.
+Require Import Coq.Vectors.Vector.
+Require Import coqutil.Tactics.Tactics.
+Require Import Cava.Core.Core.
+Require Import Cava.Lib.CavaPrelude.
+Require Import Cava.Lib.CombinationalProperties.
+Require Import Cava.Lib.CombinatorsProperties.
+Require Import Cava.Lib.VecProperties.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Util.BitArithmetic.
+Require Import Cava.Util.BitArithmeticProperties.
+Require Import Cava.Util.Nat.
+Require Import Cava.Util.Tactics.
+Require Import Cava.Util.Vector.
+
+Lemma all_correct {n} v :
+  all (n:=n) v = Vector.fold_left andb true v.
+Proof.
+  destruct n; [ eapply case0 with (v:=v); reflexivity | ].
+  cbv [all]. simpl_ident.
+  eapply (tree_equiv (t:=Bit));
+    intros; boolsimpl; try reflexivity; try lia;
+      auto using Bool.andb_assoc.
+Qed.
+Hint Rewrite @all_correct using solve [eauto] : simpl_ident.
+
+Lemma eqb_correct {t} (x y : combType t) :
+  eqb x y = combType_eqb x y.
+Proof.
+  revert x y.
+  induction t;
+    cbn [eqb and2 xnor2 one
+             CombinationalSemantics] in *;
+    intros; simpl_ident; repeat destruct_pair_let;
+    (* handle easy cases first *)
+    repeat lazymatch goal with
+           | x : unit |- _ => destruct x
+           | x : combType Bit |- _ => destruct x
+           | |- (?x = ?x <-> ?y = ?y) => split; reflexivity
+           | _ => first [ progress cbn [List.map combine fst snd xnorb xorb negb]
+                       | split; (congruence || reflexivity) ]
+           end.
+  { (* Vector case *)
+    simpl_ident. cbn [combType_eqb].
+    rewrite eqb_fold. apply f_equal.
+    auto using map2_ext. }
+Qed.
+
+Lemma eqb_eq {t} (x y : combType t) :
+  eqb x y = true <-> x = y.
+Proof.
+  rewrite eqb_correct. split.
+  { inversion 1. apply combType_eqb_true_iff. auto. }
+  { intros; subst. f_equal.
+    apply combType_eqb_true_iff. reflexivity. }
+Qed.
+
+Lemma eqb_refl {t} (x : combType t) : eqb x x = true.
+Proof. apply eqb_eq. reflexivity. Qed.
+
+Lemma eqb_neq {t} (x y : combType t) : x <> y ->  eqb x y = false.
+Proof.
+  rewrite eqb_correct; intros. f_equal.
+  apply Bool.not_true_is_false.
+  rewrite combType_eqb_true_iff. auto.
+Qed.
+
+Lemma eqb_nat_to_bitvec_sized sz n m :
+  n < 2 ^ sz -> m < 2 ^ sz ->
+  eqb (t:=Vec Bit sz) (nat_to_bitvec_sized sz n)
+      (nat_to_bitvec_sized sz m)
+  = if Nat.eqb n m then true else false.
+Proof.
+  intros; destruct_one_match; subst; [ solve [apply (eqb_refl (t:=Vec Bit sz))] | ].
+  apply (eqb_neq (t:=Vec Bit sz)). cbv [nat_to_bitvec_sized].
+  rewrite N2Bv_sized_eq_iff with (n:=sz) by auto using N.size_nat_le_nat.
+  lia.
+Qed.

--- a/cava/Cava/Lib/Combinators.v
+++ b/cava/Cava/Lib/Combinators.v
@@ -14,44 +14,49 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Coq.Vectors.Vector.
-Import VectorNotations.
-
-Require Import Coq.Lists.List Coq.micromega.Lia.
-Import ListNotations.
-
-Require Import ExtLib.Structures.Monads.
-Require Import ExtLib.Structures.Traversable.
-Require Import coqutil.Tactics.Tactics.
 Require Import Coq.Arith.PeanoNat.
-
-Export MonadNotation.
-
-Require Import Cava.Core.CavaClass.
-Require Import Cava.Util.Identity.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Lists.List.
+Require Import ExtLib.Structures.Monads.
+Require Import Cava.Core.Core.
 Require Import Cava.Util.Vector.
-Require Import Cava.Util.List.
-Require Import Cava.Util.MonadFold.
-Require Import Cava.Core.Signal.
-Require Import Cava.Util.Tactics.
-Require Import Cava.Lib.CavaPrelude.
-
-Generalizable All Variables.
-
-Require Import ExtLib.Structures.MonadLaws.
-
+Require Cava.Lib.Vec.
+Import ListNotations MonadNotation.
 Local Open Scope monad_scope.
-Local Open Scope type_scope.
+
+(****************************************************************************)
+(* Lava-style circuit combinators.                                          *)
+(****************************************************************************)
 
 Section WithCava.
   Context {signal} {semantics: Cava signal}.
   Existing Instance monad. (* make sure cava Monad instance takes precedence *)
 
   (****************************************************************************)
-  (* Lava-style circuit combinators.                                          *)
+  (* Forks in wires                                                           *)
   (****************************************************************************)
 
-  (* Operations over the first or second element of a pair of inputs. *)
+  Definition fork2 {A} (a:A) := ret (a, a).
+
+  (****************************************************************************)
+  (* Operations over pairs.                                                   *)
+  (****************************************************************************)
+
+  Definition first {A B C} (f : A -> cava C) (ab : A * B) : cava (C * B) :=
+    let '(a, b) := ab in
+    c <- f a ;;
+    ret (c, b).
+
+  Definition second {A B C} (f : B -> cava C) (ab : A * B) : cava (A * C) :=
+    let '(a, b) := ab in
+    c <- f b ;;
+    ret (a, c).
+
+  Definition swap {A B}
+                  (i : signal A * signal B)
+                  : cava (signal B * signal A) :=
+    let (a, b) := i in
+    ret (b, a).
 
   (* pairLeft takes an input with shape (a, (b, c)) and re-organizes
       it as ((a, b), c) *)
@@ -69,16 +74,10 @@ Section WithCava.
    let '((a, b), c) := i in
    ret (a, (b, c)).
 
-  (* Use a circuit to zip together two vectors. *)
-  Definition zipWith {A B C : SignalType} {n : nat}
-           (f : signal A * signal B -> cava (signal C))
-           (a : signal (Vec A n))
-           (b : signal (Vec B n))
-           : cava (signal (Vec C n)) :=
-    a' <- unpackV a ;;
-    b' <- unpackV b ;;
-    v <- mapT f (vcombine a' b') ;;
-    packV v.
+
+  (****************************************************************************)
+  (* 4-sided tile combinators                                                 *)
+  (****************************************************************************)
 
   (* Below combinator
 
@@ -116,20 +115,14 @@ Section WithCava.
               (r : A * B -> cava (D * G))
               (s : G * C -> cava (E * F))
               (abc : A * (B * C)) : cava ((D * E) * F) :=
-    let (a, bc) := abc in
-    let (b, c) := bc in
-    dg <- r (a, b) ;;
-    let (d, g) := dg : D * G in
-    ef <- s (g, c) ;;
-    let (e, f) := ef : E * F in
+    let '(a, (b, c)) := abc in
+    '(d, g) <- r (a, b) ;;
+    '(e, f) <- s (g, c) ;;
     ret ((d, e), f).
 
   (* The col combinator takes a 4-sided circuit element and replicates it by
     composing each element in a chain.
 
-  -----------------------------------------------------------------------------
-  -- 4-Sided Tile Combinators
-  -----------------------------------------------------------------------------
   -- COL r
   --            a
   --            ^
@@ -166,405 +159,64 @@ Section WithCava.
 
   *)
 
-  (* colV is a col combinator that works over Vector.t of signals.
-    The input tuple is split into separate arguments so Coq can recognize
-    the decreasing vector element.
-  *)
-
-  Local Open Scope vector_scope.
-
-  Fixpoint colV' {A B C} {n : nat}
-                (circuit : A * B -> cava (C * A))
-                (aIn: A) (bIn: Vector.t B n) :
-                cava (Vector.t C n * A) :=
-    match bIn with
-    | [] => ret ([], aIn)
-    | x::xs => '(b0, aOut) <- circuit (aIn, x) ;;
-               '(bRest, aFinal) <- colV' circuit aOut xs ;;
-                ret (b0::bRest, aFinal)
+  Fixpoint col_generic {A B C}
+             (circuit : A * B -> cava (C * A))
+             (a : A) (b : list B)
+    : cava (list C * A) :=
+    match b with
+    | [] => ret ([], a)
+    | b0 :: b =>
+      '(c0, a) <- circuit (a, b0) ;;
+      '(c, a) <- col_generic circuit a b ;;
+      ret (c0 :: c, a)
     end.
 
-  Definition colV {A B C} {n : nat}
-                  (circuit : A * B -> cava (C * A))
-                  (inputs: A * Vector.t B n) :
-                  cava (Vector.t C n * A) :=
-  colV' circuit (fst inputs) (snd inputs).
+  Definition col {A B C}
+             (circuit : A * B -> cava (signal C * A))
+             (a : A) {n : nat} (b : Vector.t B n)
+    : cava (signal (Vec C n) * A) :=
+    '(c, a) <- col_generic circuit a (to_list b) ;;
+    c <- packV (of_list_sized defaultSignal n c) ;;
+    ret (c, a).
 
   (****************************************************************************)
-  (* Make the Cava signal-level col combinator use the vector-based colV      *)
-  (* under the hood.                                                          *)
+  (* A binary tree combinator.                                                *)
   (****************************************************************************)
 
-  Definition col {A B C} {n : nat}
-               (circuit : signal A * signal B -> cava (signal C * signal A))
-               (aIn: signal A) (bIn: signal (Vec B n)) :
-               cava (signal (Vec C n) * signal A) :=
-  b <- unpackV bIn ;;
-  '(c, a) <- colV circuit (aIn, b) ;;
-  cOut <- packV c ;;
-  ret (cOut, a).
-
-  Local Close Scope vector_scope.
-
-  (* List Variant *)
-
-  Local Open Scope list_scope.
-
-  Fixpoint colL' {m} `{Monad m} {A B C}
-                (circuit : A * B -> m (C * A))
-                (aIn: A) (bIn: list B) :
-                m (list C * A) :=
-    match bIn with
-    | [] => ret ([], aIn)
-    | x::xs => '(b0, aOut) <- circuit (aIn, x) ;;
-              '(bRest, aFinal) <- colL' circuit aOut xs ;;
-                ret (b0::bRest, aFinal)
-    end.
-
-  Definition colL {m} `{Monad m} {A B C}
-                  (circuit : A * B -> m (C * A))
-                  (inputs: A * list B) :
-                  m (list C * A) :=
-  colL' circuit (fst inputs) (snd inputs).
-
-  Local Close Scope vector_scope.
-
-  (****************************************************************************)
-  (* Forks in wires                                                           *)
-  (****************************************************************************)
-
-  Definition fork2 {A} (a:A) := ret (a, a).
-
-  (****************************************************************************)
-  (* Operations over pairs.                                                   *)
-  (****************************************************************************)
-
-  Definition first {A B C} (f : A -> cava C) (ab : A * B) : cava (C * B) :=
-    let '(a, b) := ab in
-    c <- f a ;;
-    ret (c, b).
-
-  Definition second {A B C} (f : B -> cava C) (ab : A * B) : cava (A * C) :=
-    let '(a, b) := ab in
-    c <- f b ;;
-    ret (a, c).
-
-  (* Project out the first element of a pair. *)
-  Definition projFst {A B} (ab : A * B) : cava A :=
-    let '(a, _) := ab in
-    ret a.
-
-  (* Project out the second element of a pair. *)
-  Definition projSnd {A B} (ab : A * B) : cava B :=
-    let '(_, b) := ab in
-    ret b.
-
-  (****************************************************************************)
-  (* Swap                                                                     *)
-  (****************************************************************************)
-
-  Definition swap {A B}
-                  (i : signal A * signal B) 
-                  : cava (signal B * signal A) :=
-    let (a, b) := i in
-    ret (b, a).
-
-  (****************************************************************************)
-  (* Split a bus into two halves.                                             *)
-  (****************************************************************************)
-
-  Definition halve {A} (l : list A) : list A * list A :=
-    let mid := (length l) / 2 in
-    (firstn mid l, skipn mid l).
-
-  (****************************************************************************)
-  (* A binary tree combinator, list version.                                                *)
-  (****************************************************************************)
-
-  Fixpoint treeList {T: Type} {m} `{Monad m}
-                    (circuit: T -> T -> m T) (def: T)
-                    (n : nat) (v: list T) : m T :=
+  (* n should be the maximum depth of the tree, inputs must not be empty *)
+  Fixpoint tree_generic {T: Type}
+           (circuit: T -> T -> cava T) (error: T)
+           (n : nat) (inputs : list T) : cava T :=
     match n with
-    | O => match v return m T with
-          | [a; b]=> circuit a b
-          | _ => ret def
-          end
-    | S n' => let '(vL, vH) := halve v in
-            aS <- treeList circuit def n' vL ;;
-            bS <- treeList circuit def n' vH ;;
-            circuit aS bS
-    end.
-
-  Definition treeWithList {T: Type} {m} `{Monad m}
-                          (circuit: T -> T -> m T) (def: T)
-                          (n : nat) (v: Vector.t T (2^(n+1))) : m T :=
-    treeList circuit def n (to_list v).
-
-  Lemma treeList_equiv
-        {T} {cava} {monad' : Monad cava}
-        {monad_laws : MonadLaws monad'}
-        (id : T)
-        (op : T -> T -> T)
-        (op_id_left : forall a : T, op id a = a)
-        (op_id_right : forall a : T, op a id = a)
-        (op_assoc :
-          forall a b c : T,
-            op a (op b c) = op (op a b) c)
-        (circuit : T -> T -> cava T)
-        (circuit_equiv :
-          forall a b : T, circuit a b = ret (op a b))
-        (def : T) (n : nat) :
-    forall v,
-      length v = 2 ^ (S n) ->
-      treeList circuit def n v = ret (List.fold_left op v id).
-  Proof.
-    induction n; intros; [ | ].
-    { (* n = 0 *)
-      change (2 ^ 1) with 2 in *.
-      destruct_lists_by_length. cbn [treeList fold_left].
-      rewrite op_id_left, circuit_equiv.
-      reflexivity. }
-    { (* n = S n' *)
-      cbn [treeList halve]. rewrite !Nat.pow_succ_r in * by lia.
-      erewrite <-Nat.div_unique_exact by eauto.
-      rewrite !IHn by (rewrite ?firstn_length, ?skipn_length; lia).
-      rewrite !bind_of_return, circuit_equiv by typeclasses eauto.
-      rewrite <-fold_left_assoc, <-fold_left_app by eauto.
-      rewrite firstn_skipn. reflexivity. }
-  Qed.
-
-  (****************************************************************************)
-  (* A binary tree combinator, Vector version.                                                  *)
-  (****************************************************************************)
-
-  Definition divide {A n} (default : A) (v : Vector.t A (2 ^ (S n))) :
-    Vector.t A (2 ^ n) * Vector.t A (2 ^ n) :=
-    splitat _ (@resize_default A (2 ^ (S n)) default (2 ^ n + 2 ^ n) v).
-
-  Fixpoint pow2tree_generic {T: Type} {m} `{Monad m}
-                         (default : T) (n : nat)
-                         (circuit: T -> T -> m T)
-                         : Vector.t T (2^n) -> m T :=
-    match n as n return Vector.t T (2^n) -> m T with
-    | O => fun v : Vector.t T 1 => ret (Vector.hd v)
-    | S n'=>
-      fun vR =>
-        let '(vL, vH) := divide default vR in
-        aS <- pow2tree_generic default n' circuit vL ;;
-        bS <- pow2tree_generic default n' circuit vH ;;
-        circuit aS bS
-    end.
-
-  Lemma append_divide {A} d n H (v : t A (2 ^ (S n))) :
-    (fst (divide d v) ++ snd (divide d v))%vector = resize _ H v.
-  Proof.
-    cbv [divide].
-    let H := fresh in
-    match goal with
-    | |- context [splitat ?n ?v] =>
-      pose proof (surjective_pairing (splitat n v)) as H
-    end;
-      apply append_splitat in H;
-      rewrite <-H; clear H.
-    rewrite resize_default_eq with (d0:=d).
-    reflexivity.
-  Qed.
-
-  (* A specialization of pow2tree_generic that is constrained to take Cava
-    signal types i.e. only types that we support as values over wires for Cava
-    circuits. This allows the default value to be computed automatically. *)
-  Definition pow2tree {t: SignalType} n
-                   (circuit: signal t * signal t -> cava (signal t))
-                   (v : signal (Vec t (2^n))) :
-                   cava (signal t) :=
-    v <- unpackV v ;;
-    pow2tree_generic defaultSignal n (fun a b => circuit (a, b)) v.
-
-  Local Open Scope nat_scope.
-
-  Lemma pow2tree_generic_equiv'
-        {T}  {monad_laws : MonadLaws monad} (valid : T -> Prop)
-        (id : T)
-        (op : T -> T -> T)
-        (valid_id : valid id)
-        (op_preserves_valid : forall a b, valid a -> valid b -> valid (op a b))
-        (op_id_left : forall a : T, valid a -> op id a = a)
-        (op_id_right : forall a : T, valid a -> op a id = a)
-        (op_assoc :
-           forall a b c : T,
-             valid a -> valid b -> valid c ->
-             op a (op b c) = op (op a b) c)
-        (circuit : T -> T -> cava T)
-        (circuit_equiv :
-          forall a b : T, valid a -> valid b -> circuit a b = ret (op a b))
-        (default : T) (n : nat) :
-    forall v,
-      ForallV valid v ->
-      pow2tree_generic default n circuit v = ret (Vector.fold_left op id v).
-  Proof.
-    induction n; intros.
-    { change (2 ^ 0) with 1 in *.
-      cbn [pow2tree_generic ForallV] in *.
-      autorewrite with push_vector_fold vsimpl.
-      rewrite op_id_left by tauto. reflexivity. }
-    { cbn [pow2tree_generic]. destruct_pair_let.
-      assert (2 ^ (S n) = 2 ^ n + 2 ^ n) as Heq
-        by abstract (rewrite Nat.pow_succ_r by lia; lia).
-      lazymatch goal with
-      | _ : ForallV ?P ?v |- context [divide ?d ?v] =>
-        let H' := fresh in
-        assert (ForallV P (fst (divide d v) ++ snd (divide d v))%vector) as H'
-            by (rewrite @append_divide with (H:=Heq);
-                apply ForallV_resize; auto);
-          apply ForallV_append in H'; destruct H'
-      end.
-      rewrite !IHn by eauto.
-      rewrite !bind_of_return by eauto.
-      rewrite circuit_equiv by (apply fold_left_preserves_valid; solve [eauto]).
-      erewrite <-fold_left_S_assoc' with (valid0:=valid); auto;
-        [ | apply fold_left_preserves_valid; solve [eauto] ].
-      rewrite <-fold_left_append by eauto.
-      rewrite @append_divide with (H:=Heq).
-      rewrite fold_left_resize. reflexivity. }
-  Qed.
-
-  Lemma pow2tree_generic_equiv
-        {T}  {monad_laws : MonadLaws monad}
-        (id : T)
-        (op : T -> T -> T)
-        (op_id_left : forall a : T, op id a = a)
-        (op_id_right : forall a : T, op a id = a)
-        (op_assoc :
-          forall a b c : T,
-            op a (op b c) = op (op a b) c)
-        (circuit : T -> T -> cava T)
-        (circuit_equiv :
-          forall a b : T, circuit a b = ret (op a b))
-        (default : T) (n : nat) :
-    forall v,
-      pow2tree_generic default n circuit v = ret (Vector.fold_left op id v).
-  Proof.
-    intros. apply pow2tree_generic_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
-  Qed.
-
-  (* Version of tree combinator that accepts all sizes by creating a tree out of
-     the elements based on the closest power of two, and then tacking on the
-     remaining elements one by one.
-
-     The result will not be maximally efficient for non-powers of two; for
-     example, for an and-tree with 6 elements i0..i5, this definition will
-     produce:
-
-     (((i0 & i1) & (i2 & i3)) & i4) & i5
-
-     ...instead of &-ing i4 and i5 together before combining them with the
-     tree. *)
-  Definition tree_generic {m} {monad : Monad m} {A}
-             (default : A) (circuit : A -> A -> m A) {n} (v : Vector.t A n) : m A :=
-    let '(v1, v2) := Vector.splitat (2 ^ Nat.log2 n)
-                                    (resize_default
-                                       default (2 ^ Nat.log2 n + (n - 2 ^ Nat.log2 n))
-                                       v) in
-    tree_result <- pow2tree_generic default (Nat.log2 n) circuit v1 ;;
-    foldLM circuit (to_list v2) tree_result.
-
-  (* specialized to signal so default value can be automatically inferred *)
-  Definition tree {m} {monad : Monad m} {t n}
-                   (circuit: signal t * signal t -> cava (signal t))
-                   (v : signal (Vec t n)) :
-                   cava (signal t) :=
-    v <- unpackV v ;;
-    tree_generic defaultSignal (fun x y => circuit (x,y)) v.
-
-  Lemma tree_generic_equiv' {T} {monad_laws : MonadLaws.MonadLaws monad}:
-    forall (id : T) (op : T -> T -> T) (valid : T -> Prop),
-      valid id ->
-      (forall a b, valid a -> valid b -> valid (op a b)) ->
-      (forall a : T, valid a -> op id a = a) ->
-      (forall a : T, valid a -> op a id = a) ->
-      (forall a b c : T, valid a -> valid b -> valid c ->
-                    op a (op b c) = op (op a b) c) ->
-      forall circuit : T -> T -> cava T,
-        (forall a b : T, valid a -> valid b -> circuit a b = ret (op a b)) ->
-        forall (default : T) (n : nat) (v : t T n),
-          n <> 0 -> ForallV valid v ->
-          tree_generic default circuit v = ret (Vector.fold_left op id v).
-  Proof.
-    cbv [tree_generic]; intros. repeat destruct_pair_let.
-    assert (n = 2 ^ Nat.log2 n + (n - 2 ^ Nat.log2 n))
-      by (apply Minus.le_plus_minus, Nat.log2_spec; Lia.lia).
-    (* change the vector expression on the RHS to match LHS *)
-    lazymatch goal with
-      |- ?lhs = ?rhs =>
-      lazymatch lhs with
-        context [splitat ?n (resize_default ?d (?n + ?m) ?v)] =>
-          let rhsF := lazymatch (eval pattern v in rhs) with
-                      | ?F _ => F end in
-          transitivity
-            (rhsF
-               (resize_default
-                  d _
-                  ((fst (splitat n (resize_default d (n + m) v)))
-                      ++ snd (splitat n (resize_default d (n + m) v)))%vector))
+    | O =>
+      (* for a depth of 0, only a singleton list is possible *)
+      match inputs with
+      | [t]%list => ret t
+      | _ => ret error (* should not get here *)
       end
-    end.
-    2:{ erewrite <-append_splitat by (rewrite <-surjective_pairing; reflexivity).
-        rewrite resize_default_resize_default, resize_default_id by Lia.lia.
-        reflexivity. }
-    pose proof (Nat.log2_pos n).
-    destruct n; [ congruence | ]. cbn [ForallV] in *.
-    repeat match goal with H : _ /\ _ |- _ => destruct H end.
-    destruct n;[ subst; cbn in *; rewrite MonadLaws.bind_of_return by auto;
-                 match goal with H : _ |- _ => rewrite H; solve [auto] end | ].
-    erewrite pow2tree_generic_equiv' with (valid0:=valid) (id0:=id); eauto; [ | ].
-    { rewrite MonadLaws.bind_of_return by auto.
-      rewrite !fold_left_to_list, to_list_resize_default, to_list_append by lia.
-      autorewrite with push_list_fold.
-      erewrite foldLM_of_ret_valid with (validA:=valid) (validB:=valid);
-        eauto; [ | ].
-      { apply fold_left_invariant with (I:=valid); auto; [ ].
-        intros *. rewrite InV_to_list_iff. intros.
-        match goal with H : forall a b, _ -> _ -> valid (op a b) |- _ => apply H end;
-          auto; [ ].
-        eapply ForallV_forall; [ | solve [eauto]].
-        intros. apply ForallV_splitat1.
-        erewrite <-(resize_default_eq _ _ _ (ltac:(eassumption))).
-        apply ForallV_resize. cbn [ForallV] in *; auto. }
-      { apply ForallV_to_list_iff, ForallV_splitat2.
-        erewrite <-(resize_default_eq _ _ _ (ltac:(eassumption))).
-        apply ForallV_resize. cbn [ForallV] in *; auto. } }
-    { intros. apply ForallV_splitat1.
-      erewrite <-(resize_default_eq _ _ _ (ltac:(eassumption))).
-      apply ForallV_resize. cbn [ForallV] in *; auto. }
-  Qed.
-
-  Lemma tree_generic_equiv {T} {monad_laws : MonadLaws.MonadLaws monad}:
-    forall (id : T) (op : T -> T -> T),
-      (forall a : T, op id a = a) ->
-      (forall a : T, op a id = a) ->
-      (forall a b c : T, op a (op b c) = op (op a b) c) ->
-      forall circuit : T -> T -> cava T,
-        (forall a b : T, circuit a b = ret (op a b)) ->
-        forall (default : T) (n : nat) (v : t T n),
-          n <> 0 ->
-          tree_generic default circuit v = ret (Vector.fold_left op id v).
-  Proof.
-    intros. apply tree_generic_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
-  Qed.
-
-  Definition all {n} (v : signal (Vec Bit n)) : cava (signal Bit) :=
-    match n with
-    | 0 => ret one
-    | _ => tree and2 v
+    | S n' =>
+      if (1 <? length inputs)
+      then
+        (* if there are at least 2 elements, halve the input list *)
+        let mid := (length inputs) / 2 in
+        let iL := firstn mid inputs in
+        let iR := skipn mid inputs in
+        aS <- tree_generic circuit error n' iL ;;
+        bS <- tree_generic circuit error n' iR ;;
+        circuit aS bS
+      else
+        (* same as 0-depth case -- only a singleton list is possible *)
+        match inputs with
+        | [t]%list => ret t
+        | _ => ret error (* should not get here *)
+        end
     end.
 
-  Fixpoint eqb {t : SignalType} : signal t -> signal t -> cava (signal Bit) :=
-    match t as t0 return signal t0 -> signal t0 -> cava (signal Bit) with
-    | Void => fun _ _ => ret one
-    | Bit => fun x y => xnor2 (x, y)
-    | ExternalType s => fun x y => ret one
-    | Vec a n => fun x y : signal (Vec a n) =>
-                  eq_results <- zipWith (fun '(a, b) => eqb a b) x y ;;
-                  all eq_results
-    end.
+  Definition tree {t : SignalType}
+             (circuit: signal t * signal t -> cava (signal t))
+             {n} (v : signal (Vec t n)) : cava (signal t) :=
+    v <- unpackV v ;;
+    tree_generic (fun a b => circuit (a,b))
+                 defaultSignal (Nat.log2_up n) (to_list v).
+
  End WithCava.

--- a/cava/Cava/Lib/LibProperties.v
+++ b/cava/Cava/Lib/LibProperties.v
@@ -17,6 +17,7 @@
 Require Export Cava.Lib.Lib.
 Require Export Cava.Lib.AddersProperties.
 Require Export Cava.Lib.BitVectorOpsProperties.
+Require Export Cava.Lib.CavaPreludeProperties.
 Require Export Cava.Lib.CombinationalProperties.
 Require Export Cava.Lib.CombinatorsProperties.
 Require Export Cava.Lib.MultiplexersProperties.

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -106,8 +106,12 @@ Fixpoint step {i o} (c : Circuit i o)
 Create HintDb simpl_ident.
 Hint Rewrite @foldLM_ident_fold_left using solve [eauto] : simpl_ident.
 Ltac simpl_ident :=
+  (* simplify identity monad and most projections from Cava *)
   cbn [fst snd bind ret Monad_ident monad
-           packV unpackV constant
+           packV unpackV constant buf_gate
+           inv and2 nand2 or2 nor2 xor2 xnor2
+           lut1 lut2 lut3 lut4 lut5 lut6
+           xorcy muxcy
            CombinationalSemantics ];
   repeat lazymatch goal with
          | |- context [(@Traversable.mapT

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -91,7 +91,6 @@ library
                      Specif
                      MonadExc
                      MonadFix
-                     MonadFold
                      MonadPlus
                      MonadReader
                      MonadTrans

--- a/examples/UnsignedAdderExamples.v
+++ b/examples/UnsignedAdderExamples.v
@@ -66,7 +66,9 @@ Section WithCava.
                                   signal (Vec Bit bSize)*
                                   signal (Vec Bit cSize)) :
                            cava (signal (Vec Bit (1 + max (1 + max aSize bSize) cSize))) :=
-  let '(a, b, c) := abc in adder_3input a b c.
+    let '(a, b, c) := abc in
+    ab <- unsignedAdd (a, b) ;;
+    unsignedAdd (ab, c).
 
 End WithCava.
 

--- a/examples/xilinx/XilinxAdderExamples.v
+++ b/examples/xilinx/XilinxAdderExamples.v
@@ -33,23 +33,23 @@ Definition v44  := N2Bv_sized 8 44.
 
 (* Perform a few basic checks to make sure the adder works. *)
 
-Example xadd_17_52_0 : xilinxAdderWithCarry (false, (v17, v52)) =
+Example xadd_17_52_0 : xilinxAdderWithCarry (v17, v52, false) =
                        (v69, false).
 Proof. reflexivity. Qed.
 
-Example xadd_17_52_1 : xilinxAdderWithCarry (true, (v17, v52)) =
+Example xadd_17_52_1 : xilinxAdderWithCarry (v17, v52, true) =
                        (v70, false).
 Proof. reflexivity. Qed.
 
-Example xadd_1_255_1 : xilinxAdderWithCarry (false, (v1, v255)) =
+Example xadd_1_255_1 : xilinxAdderWithCarry (v1, v255, false) =
                        (v0, true).
 Proof. reflexivity. Qed.
 
-Example xadd_0_255_1 : xilinxAdderWithCarry (true, (v0, v255)) =
+Example xadd_0_255_1 : xilinxAdderWithCarry (v0, v255, true) =
                        (v0, true).
 Proof. reflexivity. Qed.
 
-Example xadd_200_100_0 : xilinxAdderWithCarry (false, (v200, v100)) =
+Example xadd_200_100_0 : xilinxAdderWithCarry (v200, v100, false) =
                          (v44, true).
 Proof. reflexivity. Qed.
 
@@ -60,33 +60,27 @@ Proof. reflexivity. Qed.
 
 Definition adder8Interface
   := combinationalInterface "adder8"
-     [mkPort "cin" Bit; mkPort "a" (Vec Bit 8); mkPort "b" (Vec Bit 8)]
+     [mkPort "a" (Vec Bit 8); mkPort "b" (Vec Bit 8); mkPort "cin" Bit]
      [mkPort "sum" (Vec Bit 8); mkPort "cout" Bit]
      [].
 
-(* Produce a version of the xilinxAdderWithCarry with a flat-tuple input. *)
-Definition xilinxAdderWithCarryFlat {signal} `{Cava signal} {n}
-                                    '(cin, a, b)
-                                    : cava (signal (Vec Bit n) * signal Bit) :=
-  xilinxAdderWithCarry (cin, (a, b)).
-
 Definition adder8Netlist
-  := makeNetlist adder8Interface xilinxAdderWithCarryFlat.
+  := makeNetlist adder8Interface xilinxAdderWithCarry.
 
 Local Open Scope N_scope.
 
 Definition adder8_tb_inputs :=
-  map (fun '(cin, (a, b))
-       => (n2bool cin, N2Bv_sized 8 a, N2Bv_sized 8 b))
-  [(0, (7, 3));
-   (1, (115, 67));
-   (0, (92, 18));
-   (0, (50, 200));
-   (0, (255, 255));
-   (1, (255, 255))].
+  map (fun '(a, b, cin)
+       => (N2Bv_sized 8 a, N2Bv_sized 8 b, n2bool cin))
+  [(7, 3, 0);
+   (115, 67, 1);
+   (92, 18, 0);
+   (50, 200, 0);
+   (255, 255, 0);
+   (255, 255, 1)].
 
 Definition adder8_tb_expected_outputs :=
-  simulate (Comb xilinxAdderWithCarryFlat) adder8_tb_inputs.
+  simulate (Comb xilinxAdderWithCarry) adder8_tb_inputs.
 
 Definition adder8_tb :=
   testBench "adder8_tb" adder8Interface

--- a/silveroak-opentitan/aes/Impl/AddRoundKeyCircuit.v
+++ b/silveroak-opentitan/aes/Impl/AddRoundKeyCircuit.v
@@ -25,11 +25,11 @@ Section WithCava.
   Definition xor4xV
       (ab : signal (Vec (Vec Bit 8) 4) * signal (Vec (Vec Bit 8) 4))
       : cava (signal (Vec (Vec Bit 8) 4)) :=
-    zipWith xorV (fst ab) (snd ab).
+    Vec.map2 xorV (fst ab) (snd ab).
 
   (* Perform the bitwise XOR of two 4x4 matrices of 8-bit values. *)
   Definition xor4x4V (a b : signal state) : cava (signal state) :=
-    zipWith xor4xV a b.
+    Vec.map2 xor4xV a b.
 
   Definition aes_add_round_key (k : signal key) (st : signal state)
     : cava (signal state) := xor4x4V k st.

--- a/silveroak-opentitan/aes/Impl/AddRoundKeyEquivalence.v
+++ b/silveroak-opentitan/aes/Impl/AddRoundKeyEquivalence.v
@@ -57,7 +57,7 @@ Section Equivalence.
     rewrite map2_to_cols_bits, map2_to_flat.
     autorewrite with conversions.
 
-    repeat (cbv [zipWith vcombine];
+    repeat (cbv [Vec.map2 vcombine];
             simpl_ident;
             rewrite map_map2;
             rewrite map2_swap;


### PR DESCRIPTION
Part of #639 

A set of interconnected changes that, together, hopefully make our combinators and adders more presentable, browsable, and usable.

- Remove all experimental code from `Combinators.v` and `Adders.v` -- we now have `tree` and `col` instead of six different trees and three different `col` combinators, and our adders are just `addN` (no carries) and `addC` (carries both in and out)
- Make `tree` combinator create binary trees of optimal depth for all input sizes, not just powers of 2
- Organize `Combinators.v` into logical sections
- Make xilinx adder take its carry on the right of the tuple instead of the left so that the tuple is flat (removes need for `xilinxAdderCarryFlat` in the tests to work with the netlist interface)
- Move proofs from `Combinators.v` to `CombinatorProperties.v`
- Move `eqb` and `all`, which are not really combinators, from `Combinators.v` to `CavaPrelude.v`
- Remove `zipWith` (also not a combinator, and duplicate of `Vec.map2`)
- Create new file `CavaPreludeProperties.v` to house `eqb` and `all` proofs, remove them from `CombinatorProperties.v`
- Change some adder argument names from `a`, `b`, and `cin` to `x`, `y` and `cin`, to make the distinction between the operands and the carry bit clearer
- Add correctness lemmas for the `col` combinator, use them to prove adders correct