### PR TITLE
Add missing combinator proofs

### DIFF
--- a/cava/Cava/Lib/Combinators.v
+++ b/cava/Cava/Lib/Combinators.v
@@ -36,44 +36,49 @@ Section WithCava.
   (* Forks in wires                                                           *)
   (****************************************************************************)
 
+  (* forks a wire into two *)
   Definition fork2 {A} (a:A) := ret (a, a).
 
   (****************************************************************************)
   (* Operations over pairs.                                                   *)
   (****************************************************************************)
 
+  (* applies f to the first element of a pair *)
   Definition first {A B C} (f : A -> cava C) (ab : A * B) : cava (C * B) :=
     let '(a, b) := ab in
     c <- f a ;;
     ret (c, b).
 
+  (* applies f to the second element of a pair *)
   Definition second {A B C} (f : B -> cava C) (ab : A * B) : cava (A * C) :=
     let '(a, b) := ab in
     c <- f b ;;
     ret (a, c).
 
-  Definition swap {A B}
-                  (i : signal A * signal B)
-                  : cava (signal B * signal A) :=
+  (* reverses elements of a pair *)
+  Definition swap {A B} (i : A * B) : cava (B * A) :=
     let (a, b) := i in
     ret (b, a).
 
-  (* pairLeft takes an input with shape (a, (b, c)) and re-organizes
+  (* drops right element of a pair *)
+  Definition dropr {A B} (i : A * B) : cava A :=
+    ret (fst i).
+
+  (* drops left element of a pair *)
+  Definition dropl {A B} (i : A * B) : cava B :=
+    ret (snd i).
+
+  (* pair_left takes an input with shape (a, (b, c)) and re-organizes
       it as ((a, b), c) *)
-   Definition pairLeft {A B C : SignalType}
-                       (i : signal A * (signal B * signal C)) :
-                       cava ((signal A * signal B) * signal C) :=
+  Definition pair_left {A B C} (i : A * (B * C)) : cava (A * B * C) :=
    let '(a, (b, c)) := i in
-   ret ((a, b), c).
+   ret (a, b, c).
 
-  (* pairRight takes an input with shape ((a, b), c) and re-organizes
+  (* pair_right takes an input with shape ((a, b), c) and re-organizes
      it as (a, (b, c)) *)
-  Definition pairRight {A B C : SignalType}
-                       (i : (signal A * signal B) * signal C) :
-                       cava (signal A * (signal B * signal C)) :=
-   let '((a, b), c) := i in
+  Definition pair_right {A B C} (i : A * B * C) : cava (A * (B * C)) :=
+   let '(a, b, c) := i in
    ret (a, (b, c)).
-
 
   (****************************************************************************)
   (* 4-sided tile combinators                                                 *)

--- a/cava/Cava/Lib/CombinatorsProperties.v
+++ b/cava/Cava/Lib/CombinatorsProperties.v
@@ -29,10 +29,57 @@ Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
 Import ListNotations VectorNotations.
 
-Lemma fork2Correct {A} (i : combType A) :
+Lemma fork2_correct {A} (i : combType A) :
  fork2 i = (i, i).
 Proof. reflexivity. Qed.
-Hint Rewrite @fork2Correct using solve [eauto] : simpl_ident.
+Hint Rewrite @fork2_correct using solve [eauto] : simpl_ident.
+
+Lemma first_correct {A B C} (f : A -> C) (i : A * B) :
+ first f i = (f (fst i), snd i).
+Proof. destruct_products; reflexivity. Qed.
+Hint Rewrite @first_correct using solve [eauto] : simpl_ident.
+
+Lemma second_correct {A B C} (f : B -> C) (i : A * B) :
+ second f i = (fst i, f (snd i)).
+Proof. destruct_products; reflexivity. Qed.
+Hint Rewrite @second_correct using solve [eauto] : simpl_ident.
+
+Lemma swap_correct {A B} (i : A * B) :
+ swap i = (snd i, fst i).
+Proof. destruct_products; reflexivity. Qed.
+Hint Rewrite @swap_correct using solve [eauto] : simpl_ident.
+
+Lemma dropr_correct {A B} (i : A * B) :
+ dropr i = fst i.
+Proof. destruct_products; reflexivity. Qed.
+Hint Rewrite @dropr_correct using solve [eauto] : simpl_ident.
+
+Lemma dropl_correct {A B} (i : A * B) :
+ dropl i = snd i.
+Proof. destruct_products; reflexivity. Qed.
+Hint Rewrite @dropl_correct using solve [eauto] : simpl_ident.
+
+Lemma pair_left_correct {A B C} (i : A * (B * C)) :
+ pair_left i = (fst i, fst (snd i), snd (snd i)).
+Proof. destruct_products; reflexivity. Qed.
+Hint Rewrite @pair_left_correct using solve [eauto] : simpl_ident.
+
+Lemma pair_right_correct {A B C} (i : A * B * C) :
+ pair_right i = (fst (fst i), (snd (fst i), snd i)).
+Proof. destruct_products; reflexivity. Qed.
+Hint Rewrite @pair_right_correct using solve [eauto] : simpl_ident.
+
+Lemma below_correct {A B C D E F G}
+      (r : A * B -> D * G) (s : G * C -> E * F)
+      (i : A * (B * C)) :
+  below r s i = let dg := r (fst i, fst (snd i)) in
+                let ef := s (snd dg, snd (snd i)) in
+                (fst dg, fst ef, snd ef).
+Proof.
+  cbv [below]. simpl_ident. repeat destruct_pair_let.
+  destruct_products; reflexivity.
+Qed.
+Hint Rewrite @below_correct using solve [eauto] : simpl_ident.
 
 (* Full description of the behavior of col_generic *)
 Lemma col_generic_correct {A B C} (circuit : A * B -> C * A)


### PR DESCRIPTION
For #639 

- Adds proofs for combinators that previously had no proofs
- Adds brief explanatory comments above each combinator (if one did not previously exist)
- Adds `dropl` and `dropr` combinators (I remember these from arrows and they were nice to have)
- Generalizes a few combinators that previously required `signal A` to work on any type `A`