### PR TITLE
Add targets to third_party .PHONY

### DIFF
--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-.PHONY:	all minimize-requires
+.PHONY:	all minimize-requires coqutil coqtools bedrock2 extlib record-update \
+	clean no-update update build-coqutil build-bedrock2 build-extlib \
+	build-record-update clean coq
 
 all: coqutil coqtools bedrock2 extlib record-update
 


### PR DESCRIPTION
See https://github.com/project-oak/silveroak/issues/268#issuecomment-800531005

Not sure if this is causing the problem, but we've been getting weird build errors on `third_party` and some subdirectory targets that should be `.PHONY` aren't. It's possible that `make` is not running those targets because it thinks they are done, since the directory exists.