### PR TITLE
Make tutorial support Mac

### DIFF
--- a/docs/demo/alectryon.css
+++ b/docs/demo/alectryon.css
@@ -354,7 +354,6 @@ In any case, make an exception for comments:
     align-items: baseline;
     display: inline-flex;
     margin: 0.15rem 0.25rem;
-    z-index: 1;
 }
 
 .alectryon-io .hyp-names {
@@ -539,6 +538,7 @@ In any case, make an exception for comments:
 
 .alectryon-standalone {
     font-family: 'IBM Plex Serif', 'PT Serif', 'Merriweather', 'DejaVu Serif', serif;
+    line-height: 1.5;
 }
 
 @media screen and (min-width: 50rem) {

--- a/docs/demo/alectryon.js
+++ b/docs/demo/alectryon.js
@@ -74,7 +74,7 @@ var Alectryon;
 
         function onkeydown(e) {
             e = e || window.event;
-            if (e.ctrlKey) {
+            if (e.ctrlKey || e.metaKey) {
                 if (e.keyCode == keys.ARROW_UP)
                     slideshow.previous();
                 else if (e.keyCode == keys.ARROW_DOWN)

--- a/docs/demo/docutils_basic.css
+++ b/docs/demo/docutils_basic.css
@@ -23,19 +23,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ******************************************************************************/
 
-code,
 kbd,
 pre,
 samp,
 tt,
+code,
+code.highlight,
 .docutils.literal {
     font-family: 'Iosevka Slab Web', 'Iosevka Web', 'Iosevka Slab', 'Iosevka', 'Fira Code', monospace;
     font-feature-settings: "XV00" 1; /* Use Coq ligatures when Iosevka is available */
 }
 
 body {
-    font-family: 'IBM Plex Serif', 'PT Serif', 'Merriweather', 'DejaVu Serif', serif;
     color: #111;
+    font-family: 'IBM Plex Serif', 'PT Serif', 'Merriweather', 'DejaVu Serif', serif;
+    line-height: 1.5;
 }
 
 div.document {

--- a/docs/demo/tutorial.html
+++ b/docs/demo/tutorial.html
@@ -12,9 +12,10 @@
 <script type="text/javascript" src="alectryon.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/IBM-type/0.5.4/css/ibm-type.min.css" integrity="sha512-sky5cf9Ts6FY1kstGOBHSybfKqdHR41M0Ldb0BjNiv3ifltoQIsg0zIaQ+wwdwgQ0w9vKFW7Js50lxH9vqNSSw==" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/firacode/5.2.0/fira_code.min.css" integrity="sha512-MbysAYimH1hH2xYzkkMHB6MqxBqfP0megxsCLknbYqHVwXTCg9IqHbk+ZP/vnhO8UEW6PaXAkKe2vQ+SWACxxA==" crossorigin="anonymous" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-<div class="alectryon-root alectryon-centered"><div class="alectryon-banner">Built with <a href="https://github.com/cpitclaudel/alectryon/">Alectryon</a>, running Coq+SerAPI v8.12.0+0.12.0. Coq sources are in this panel; goals and messages will appear in the other. Bubbles (<span class="alectryon-bubble"></span>) indicate interactive fragments: hover for details, tap to reveal contents. Use <kbd>Ctrl+↑</kbd> <kbd>Ctrl+↓</kbd> to navigate, <kbd>Ctrl+🖱️</kbd> to focus.</div><div class="document" id="tutorial">
+<div class="alectryon-root alectryon-centered"><div class="alectryon-banner">Built with <a href="https://github.com/cpitclaudel/alectryon/">Alectryon</a>, running Coq+SerAPI v8.12.0+0.12.0. Bubbles (<span class="alectryon-bubble"></span>) indicate interactive fragments: hover for details, tap to reveal contents. Use <kbd>Ctrl+↑</kbd> <kbd>Ctrl+↓</kbd> to navigate, <kbd>Ctrl+🖱️</kbd> to focus. On Mac, use <kbd>⌘</kbd> instead of <kbd>Ctrl</kbd>.</div><div class="document" id="tutorial">
 <h1 class="title">Tutorial</h1>
 
 <p>Welcome! This is a quick primer for designing circuits with Cava. We'll walk


### PR DESCRIPTION
Fixes #630 

Alectryon now supports the `Cmd` key for Mac users. This is the result of `make -C demos html` after updating my local alectryon to the newest version.