### PR TITLE
Make bedrock2 target depend on coqutil

### DIFF
--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -45,7 +45,7 @@ coqtools: update
 coqutil: update
 	$(MAKE) build-coqutil
 
-bedrock2: update
+bedrock2: update coqutil
 	$(MAKE) build-bedrock2
 
 extlib: update


### PR DESCRIPTION
See related discussion here: https://github.com/project-oak/silveroak/issues/268#issuecomment-800498955

After I ran into the `third_party` bug we'd been seeing on CI locally, I made a quick bash script to run the `make` repeatedly so I could see if the transient bug still existed. This change seems to fix the problem; I ran the bug-finding script on the current `main` and found the transient bug 7 times in 100 runs, and found it 0 times with the fix.