### PR TITLE
Add and prove an incrementer

### DIFF
--- a/cava/Cava/Lib/AddersProperties.v
+++ b/cava/Cava/Lib/AddersProperties.v
@@ -106,6 +106,32 @@ Proof.
   rewrite N.add_0_r. reflexivity.
 Qed.
 
+Lemma incrC_correct n input :
+  let sum := Bv2N input + 1 in
+  incrC input = (N2Bv_sized n sum, N.testbit_nat sum n).
+Proof.
+  cbv [incrC].
+  destruct n;
+    [ cbv [Bvector.Bvector] in *; constant_vector_simpl input;
+      reflexivity | ].
+  simpl_ident. cbn [unsignedAdd CombinationalSemantics].
+  cbv [unsignedAddBool one]. simpl_ident.
+  change (Bv2N [true]) with 1.
+
+  (* remove resize by proving lengths are equal *)
+  assert ((1 + Nat.max (S n) 1)%nat = S (S n)) as Hresize by lia.
+  generalize dependent (1 + Nat.max (S n) 1)%nat; intros; subst.
+  rewrite resize_default_id.
+
+  rewrite N2Bv_sized_shiftout, N2Bv_sized_last.
+  reflexivity.
+Qed.
+Hint Rewrite @incrC_correct using solve [eauto] : simpl_ident.
+
+Lemma incrN_correct n input :
+  incrN input = N2Bv_sized n (Bv2N input + 1).
+Proof. cbv [incrN]. simpl_ident. reflexivity. Qed.
+
 (* A quick sanity check of the Xilinx adder with carry in and out *)
 Example xilinx_add_17_52:
   xilinxAdderWithCarry

--- a/cava/Cava/Util/BitArithmeticProperties.v
+++ b/cava/Cava/Util/BitArithmeticProperties.v
@@ -374,3 +374,49 @@ Proof.
   rewrite map_map, map_id_ext by (intros; apply bitvec_to_byte_to_bitvec).
   autorewrite with vsimpl; reflexivity.
 Qed.
+
+Lemma P2Bv_sized_cons n p :
+  P2Bv_sized (S n) p = (match p with
+                        | (p0~1)%positive => true :: P2Bv_sized n p0
+                        | (p0~0)%positive => false :: P2Bv_sized n p0
+                        | 1%positive => true :: Bvector.Bvect_false n
+                        end)%vector.
+Proof. reflexivity. Qed.
+
+Lemma P2Bv_sized_shiftout n p :
+  Vector.shiftout (P2Bv_sized (S n) p) = P2Bv_sized n p.
+Proof.
+  revert p; induction n; [ destruct p; reflexivity | ].
+  intros. destruct p.
+  all:rewrite P2Bv_sized_cons with (n:=S n).
+  all:cbv [Bvector.Bvect_false].
+  all:rewrite !shiftout_cons, ?shiftout_const.
+  all:rewrite ?IHn.
+  all:reflexivity.
+Qed.
+
+Lemma N2Bv_sized_shiftout n x :
+  Vector.shiftout (N2Bv_sized (S n) x) = N2Bv_sized n x.
+Proof.
+  destruct x; [ apply shiftout_const | ].
+  apply P2Bv_sized_shiftout.
+Qed.
+
+Lemma P2Bv_sized_last n p :
+  Vector.last (P2Bv_sized (S n) p) = Pos.testbit_nat p n.
+Proof.
+  revert p; induction n; [ destruct p; reflexivity | ].
+  intros. rewrite P2Bv_sized_cons with (n:=S n).
+  destruct p.
+  all:cbv [Bvector.Bvect_false].
+  all:rewrite !last_cons, ?last_const.
+  all:rewrite ?IHn.
+  all:reflexivity.
+Qed.
+
+Lemma N2Bv_sized_last n x :
+  Vector.last (N2Bv_sized (S n) x) = N.testbit_nat x n.
+Proof.
+  destruct x; [ apply last_const | ].
+  apply P2Bv_sized_last.
+Qed.

--- a/cava/Cava/Util/Vector.v
+++ b/cava/Cava/Util/Vector.v
@@ -374,6 +374,17 @@ Section VectorFacts.
 
   Hint Rewrite @tl_cons @hd_cons using solve [eauto] : vsimpl.
 
+  Lemma const_cons {A n} (a : A) :
+    const a (S n) = Vector.cons _ a _ (const a n).
+  Proof. reflexivity. Qed.
+
+  Lemma const_nil {A n} (v : t (t A 0) n) : v = const (nil _) _.
+  Proof.
+    revert v; induction n; [ solve [vnil] | ].
+    intro v; rewrite (eta v). eapply case0 with (v:=hd v).
+    rewrite (IHn (tl v)); reflexivity.
+  Qed.
+
   Lemma eta_snoc {A n} (v : t A (S n)) :
     v = snoc (fst (unsnoc v)) (snd (unsnoc v)).
   Proof.
@@ -419,6 +430,30 @@ Section VectorFacts.
   Lemma unsnoc_tl {A} n (v : t A (S (S n))) :
     unsnoc (tl v) = (tl (fst (unsnoc v)), snd (unsnoc v)).
   Proof. destruct n; reflexivity. Qed.
+
+  Lemma shiftout_cons {A} n x (v : Vector.t A (S n)) :
+    shiftout (x :: v) = x :: shiftout v.
+  Proof. reflexivity. Qed.
+
+  Lemma shiftout_const {A} n (x : A) :
+    shiftout (const x (S n)) = const x n.
+  Proof.
+    induction n; [ reflexivity | ].
+    rewrite const_cons, shiftout_cons.
+    rewrite IHn; reflexivity.
+  Qed.
+
+  Lemma last_cons {A} n x (v : Vector.t A (S n)) :
+    Vector.last (x :: v) = Vector.last v.
+  Proof. reflexivity. Qed.
+
+  Lemma last_const {A} n (x : A) :
+    Vector.last (const x (S n)) = x.
+  Proof.
+    induction n; [ reflexivity | ].
+    rewrite const_cons, last_cons, IHn.
+    reflexivity.
+  Qed.
 
   Lemma map_0 A B (f : A -> B) (v : t A 0) :
     map f v = nil B.
@@ -832,17 +867,6 @@ Section VectorFacts.
     revert b; induction v; intros; [ reflexivity | ].
     autorewrite with vsimpl. cbn [List.fold_left].
     rewrite IHv; reflexivity.
-  Qed.
-
-  Lemma const_cons {A n} (a : A) :
-    const a (S n) = Vector.cons _ a _ (const a n).
-  Proof. reflexivity. Qed.
-
-  Lemma const_nil {A n} (v : t (t A 0) n) : v = const (nil _) _.
-  Proof.
-    revert v; induction n; [ solve [vnil] | ].
-    intro v; rewrite (eta v). eapply case0 with (v:=hd v).
-    rewrite (IHn (tl v)); reflexivity.
   Qed.
 
   Lemma reshape_flatten {A n m} (v : t (t A n) m) :


### PR DESCRIPTION
Resolves #474 

This incrementer (unlike the version in `examples/IncrDecr.v`) uses the synthesizable adder. I wanted an incrementer for a tutorial example, and it seemed like a good thing to add to our library anyway. Following the same pattern as our bit-vector adders `addN` and `addC`, there's one incrementer that has a carry bit to indicate overflow (`incrC`), and one without a carry (`incrN`).