### PR TITLE
Add comments to control circuit and small cleanup

### DIFF
--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -41,6 +41,7 @@ library
   build-Depends:     base >= 4, mtl >= 2
   exposed-Modules:   Cava2SystemVerilog
                      Adders
+                     Applicative
                      BinNat
                      BinNums
                      BinInt
@@ -79,8 +80,7 @@ library
                      TestBench
                      SystemVerilogUtils
 
-  other-Modules:     Applicative
-                     BinPos
+  other-Modules:     BinPos
                      BinNatDef
                      ByteVector
                      Byte

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -54,6 +54,7 @@ library
                      Combinational
                      Circuit
                      Datatypes
+                     Functor
                      HexString
                      Identity
                      List
@@ -85,7 +86,6 @@ library
                      ByteVector
                      Byte
                      Decimal
-                     Functor
                      Hexadecimal
                      Numeral
                      Specif

--- a/silveroak-opentitan/aes/Impl/AESExtraction.v
+++ b/silveroak-opentitan/aes/Impl/AESExtraction.v
@@ -27,6 +27,7 @@ Require Import AesImpl.ShiftRowsNetlist.
 Require Import AesImpl.SubBytesNetlist.
 Require Import AesImpl.AddRoundKeyNetlist.
 Require Import AesImpl.CipherControlNetlist.
+Require Import AesImpl.FFunctor.
 Require Import Coq.extraction.Extraction.
 Require Import Coq.extraction.ExtrHaskellZInteger.
 Require Import Coq.extraction.ExtrHaskellString.
@@ -49,3 +50,4 @@ Extraction Library SubBytesNetlist.
 Extraction Library AddRoundKeyNetlist.
 Extraction Library CipherControlNetlist.
 Extraction Library RecordSet.
+Extraction Library FFunctor.

--- a/silveroak-opentitan/aes/Impl/AESSV.hs
+++ b/silveroak-opentitan/aes/Impl/AESSV.hs
@@ -21,6 +21,7 @@ import ShiftRowsNetlist
 import SubBytesNetlist
 import AddRoundKeyNetlist
 import CipherControlNetlist
+import FFunctor
 
 main :: IO ()
 main = do writeSystemVerilog aes_mix_columns_Netlist

--- a/silveroak-opentitan/aes/Impl/CipherControlCircuit.v
+++ b/silveroak-opentitan/aes/Impl/CipherControlCircuit.v
@@ -61,7 +61,8 @@ Section WithCava.
 
   (* Use a higher kinded data definition of 'cipher_control_signals' so that
    * we can reuse the structure for multiple representations include plain
-   * signals and nondeterministic set of future states represented by a list *)
+   * signals and nondeterministic set of future states represented by a vector
+   * of possible states *)
   Record cipher_control_signals {f: SignalType -> Type} :=
     { in_ready_o : f Bit
     ; out_valid_o : f Bit
@@ -143,8 +144,8 @@ Section WithCava.
   (* 'vector_cava_signal' is the representation we use to model a set of
    * possible states for a signal to be in. We defer the choice of current state
    * so that we can build each transition individually and then choose the correct
-   * transition later. This allows us to construct the result by follow the structure
-   * of the existing imperative case statement. *)
+   * transition later. This allows us to construct the result by following the
+   * structure of the existing imperative case statement. *)
   Definition vector_cava_signal n x := cava (Vector.t (signal x) n).
   Definition empty_state_set :=
     Build_cipher_control_signals (vector_cava_signal 0)

--- a/silveroak-opentitan/aes/Impl/FFunctor.v
+++ b/silveroak-opentitan/aes/Impl/FFunctor.v
@@ -19,6 +19,7 @@ Require Import ExtLib.Structures.Applicative.
 
 (* There are multiple ways to generalize ExtLib.Functor, this is particular one
    is useful for working with "higher kinded data". *)
+(* TODO(blaxill): see if coq-ext-lib has interest in adding these definitions *)
 
 Class FFunctor {k} (F: (k -> Type) -> Type) :=
 { ffmap : forall {A B : (k -> Type)}, (forall x, A x -> B x) -> F A -> F B }.
@@ -33,7 +34,3 @@ Definition sequence {k} {T : (k -> Type) -> Type}
 
 Class FZip {k} (T: (k -> Type) -> Type): Type :=
 { fzip : forall {A B C: (k -> Type)}, (forall {x}, A x -> B x -> C x) -> T A -> T B -> T C }.
-
-(* Class FApplicative {k} (T: (k -> Type) -> Type): Type := *)
-(* { fzip : forall {A B C: (k -> Type)}, (forall {x}, A x -> B x -> C x) -> T A -> T B -> T C }. *)
-

--- a/silveroak-opentitan/aes/Impl/FFunctor.v
+++ b/silveroak-opentitan/aes/Impl/FFunctor.v
@@ -1,0 +1,39 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import ExtLib.Structures.Functor.
+Require Import ExtLib.Structures.Applicative.
+
+(* There are multiple ways to generalize ExtLib.Functor, this is particular one
+   is useful for working with "higher kinded data". *)
+
+Class FFunctor {k} (F: (k -> Type) -> Type) :=
+{ ffmap : forall {A B : (k -> Type)}, (forall x, A x -> B x) -> F A -> F B }.
+
+Class FTraversable {k} (T: (k -> Type) -> Type): Type :=
+{ fmapT : forall {A B : (k -> Type)} {F : Type -> Type} {Ap:Applicative F},
+    (forall x, A x -> F (B x)) -> T A -> F (T B) }.
+
+Definition sequence {k} {T : (k -> Type) -> Type}
+          {Tr: FTraversable T} {F : Type -> Type} {Ap:Applicative F} {A}
+: T (fun x => F (A x)) -> F (T A) := @fmapT k T _ (fun x => F (A x)) A F _ (fun _ f => f).
+
+Class FZip {k} (T: (k -> Type) -> Type): Type :=
+{ fzip : forall {A B C: (k -> Type)}, (forall {x}, A x -> B x -> C x) -> T A -> T B -> T C }.
+
+(* Class FApplicative {k} (T: (k -> Type) -> Type): Type := *)
+(* { fzip : forall {A B C: (k -> Type)}, (forall {x}, A x -> B x -> C x) -> T A -> T B -> T C }. *)
+


### PR DESCRIPTION
- Add comments to control logic definitions
- Add 'FFunctor'/etc classes, these are more generalized version of the classes from `coq-ext-lib`. I've added them to make explicit their structure that I was already using in the control logic and to clean up my adhoc naming a bit. 