### PR TITLE
Add constantV to CavaClass

### DIFF
--- a/cava/Cava/Core/CavaClass.v
+++ b/cava/Cava/Core/CavaClass.v
@@ -32,6 +32,7 @@ Class Cava (signal : SignalType -> Type) := {
   monad :> Monad cava;
   (* Constant values. *)
   constant : bool -> signal Bit;
+  constantV : forall {A} {n : nat}, Vector.t (signal A) n -> signal (Vec A n);
   (* Default values. *)
   defaultSignal : forall {t: SignalType}, signal t;
   (* SystemVerilog primitive gates *)
@@ -58,6 +59,7 @@ Class Cava (signal : SignalType -> Type) := {
   (* Converting to/from Vector.t *)
   unpackV : forall {t : SignalType} {s : nat}, signal (Vec t s) -> cava (Vector.t (signal t) s);
   packV : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> cava (signal (Vec t s));
+  (* Dynamic indexing *)
   indexAt : forall {t : SignalType} {sz isz: nat},
             signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
             signal (Vec Bit isz) ->  (* A bit-vector index of size isz bits *)

--- a/cava/Cava/Lib/Vec.v
+++ b/cava/Cava/Lib/Vec.v
@@ -34,9 +34,8 @@ Section WithCava.
   (* Convert back and forth from Cava and Coq vectors                         *)
   (****************************************************************************)
 
-  Definition bitvec_literal {n} (v : Vector.t bool n)
-    : cava (signal (Vec Bit n)) :=
-    packV (Vector.map constant v).
+  Definition bitvec_literal {n} (v : Vector.t bool n) : signal (Vec Bit n) :=
+    constantV (Vector.map constant v).
 
   Definition map_literal {A B n} (f : A -> cava (signal B)) (v : Vector.t A n)
     : cava (signal (Vec B n)) :=

--- a/cava/Cava/NetlistGeneration/NetlistGeneration.v
+++ b/cava/Cava/NetlistGeneration/NetlistGeneration.v
@@ -235,6 +235,7 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     cava := state CavaState;
     monad := Monad_state _;
     constant b := if b then Vcc else Gnd;
+    constantV A n v := VecLit v;
     defaultSignal := defaultNetSignal;
     inv := invNet;
     and2 := andNet;

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -42,6 +42,7 @@ Instance CombinationalSemantics : Cava combType | 10 :=
   { cava := ident;
     monad := Monad_ident;
     constant := fun x => x;
+    constantV := fun _ _ v => v;
     defaultSignal t := defaultCombValue t;
     inv := fun x => ret (negb x);
     and2 :=  fun '(x,y) => ret (andb x y);
@@ -107,7 +108,7 @@ Hint Rewrite @foldLM_ident_fold_left using solve [eauto] : simpl_ident.
 Ltac simpl_ident :=
   (* simplify identity monad and most projections from Cava *)
   cbn [fst snd bind ret Monad_ident monad
-           packV unpackV constant buf_gate
+           constantV packV unpackV constant buf_gate
            inv and2 nand2 or2 nor2 xor2 xnor2
            lut1 lut2 lut3 lut4 lut5 lut6
            xorcy muxcy

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -126,7 +126,11 @@ unless stated otherwise. For a more thorough introduction to Cava, check out the
 
 #### Convert to and from Vector.t
 
-- `Vec.packV : forall {A n}, Vector.t (signal A) n -> cava (signal (Vec A n))` :
+- `constantV : forall {A n}, Vector.t (signal A) n -> signal (Vec A n)` :
+  Convert a compile-time constant vector to a signal. To prevent duplication of
+  resources, use for literal constants only.
+
+- `packV : forall {A n}, Vector.t (signal A) n -> cava (signal (Vec A n))` :
   convert a Coq `Vector.t` to a Cava `Vec`
 - `Vec.packV2 : forall {A n0 n1}, Vector.t (Vector. (signal A) n0) n1 -> cava
   (signal (Vec (Vec A n0) n1))` : convert a two-dimensional Coq `Vector.t` to a
@@ -136,8 +140,8 @@ unless stated otherwise. For a more thorough introduction to Cava, check out the
 - `Vec.packV4` : convert a four-dimensional Coq `Vector.t` to a four-dimensional
   Cava`Vec`
 
-- `Vec.unpackV : forall {A n}, signal (Vec A n) -> cava (Vector.t (signal A)
-  n)` : convert a Cava `Vec` to a Coq `Vector.t`
+- `unpackV : forall {A n}, signal (Vec A n) -> cava (Vector.t (signal A) n)` :
+  convert a Cava `Vec` to a Coq `Vector.t`
 - `Vec.unpackV2 : forall {A n0 n1}, signal (Vec (Vec A n0) n1) -> cava (Vector.t
   (Vector.t (signal A) n0) n1)` : convert a two-dimensional Cava `Vec` to a
   two-dimensional Coq `Vector.t`

--- a/silveroak-opentitan/aes/Impl/Pkg.v
+++ b/silveroak-opentitan/aes/Impl/Pkg.v
@@ -48,12 +48,12 @@ Local Notation "v [@ n ]" := (indexConst v n) (at level 1, format "v [@ n ]").
 Section WithCava.
   Context {signal} {semantics : Cava signal}.
 
-  Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : cava (signal (Vec Bit n)) :=
+  Definition bitvec_to_signal {n : nat} (lut : Vector.t bool n) : signal (Vec Bit n) :=
     Vec.bitvec_literal lut.
 
   Definition bitvecvec_to_signal {a b : nat} (lut : Vector.t (Vector.t bool b) a)
     : cava (signal (Vec (Vec Bit b) a)) :=
-    Vec.map_literal bitvec_to_signal lut.
+    packV (Vector.map bitvec_to_signal lut).
 
   Definition natvec_to_signal_sized {n : nat} (size : nat) (lut : Vector.t nat n)
     : cava (signal (Vec (Vec Bit size) n)) :=

--- a/tests/Array.v
+++ b/tests/Array.v
@@ -21,8 +21,7 @@ Section WithCava.
   Context `{Cava}.
 
   Definition array : cava (signal (Vec (Vec Bit 8) 4)) :=
-    v <- Traversable.mapT (fun x => Vec.bitvec_literal (nat_to_bitvec_sized _ x)) [0;1;2;3] ;;
-    packV v.
+    packV (Vector.map (fun x => Vec.bitvec_literal (nat_to_bitvec_sized _ x)) [0;1;2;3]).
 
   Definition multiDimArray : cava (signal (Vec (Vec (Vec Bit 8) 4) 2)) :=
     arr1 <- array ;;


### PR DESCRIPTION
While trying to demonstrate loops with initial values, I noticed an inconvenient feature of our current setup. Loops and delays take `signal t` as their reset value, see here:

https://github.com/project-oak/silveroak/blob/e83fe025e5186c59ea6e31256f4c2f8f86cc5505/cava/Cava/Core/Circuit.v#L36-L42

However, in the usual circuit-definition context with a completely abstract `cava` monad, it's impossible to construct a `signal (Vec _ _)` that doesn't have a `cava` wrapped around it (since #597, `packV` wraps vectors in `cava`).

This PR introduces the ability to construct _constant_ vectors with `constantV`, similar to `constant` for bits. It comes at the cost of a new field for `CavaClass`.

@blaxill If you have a moment, it would be nice to confirm that this change doesn't affect the resource usage of our generated AES circuits.

Note: the changes to `CipherControlCircuit.v` are essentially undoing the changes to #597, where wrapping `packV` in `cava` forced a bunch of constants to be wrapped in `cava` too.