### PR TITLE
Make delay and loop reset states combType instead of signal

### DIFF
--- a/cava/Cava/Core/Circuit.v
+++ b/cava/Cava/Core/Circuit.v
@@ -34,11 +34,11 @@ Section WithCava.
   | First : forall {i o t}, Circuit i o -> Circuit (i * t) (o * t)
   | Second : forall {i o t}, Circuit i o -> Circuit (t * i) (t * o)
   | LoopInitCE :
-      forall {i o : Type} {s : SignalType} (resetval : signal s),
+      forall {i o : Type} {s : SignalType} (resetval : combType s),
         Circuit (i * signal s) (o * signal s) ->
         Circuit (i * signal Bit) o
   | DelayInitCE :
-      forall {t} (resetval : signal t),
+      forall {t} (resetval : combType t),
         Circuit (signal t * signal Bit) (signal t)
   .
 
@@ -49,8 +49,8 @@ Section WithCava.
     | Compose f g => circuit_state f * circuit_state g
     | First f => circuit_state f
     | Second f => circuit_state f
-    | @LoopInitCE i o s _ f => circuit_state f * signal s
-    | @DelayInitCE t _ => signal t
+    | @LoopInitCE i o s _ f => circuit_state f * combType s
+    | @DelayInitCE t _ => combType t
     end.
 
   (* The state of the circuit after a reset *)
@@ -65,32 +65,32 @@ Section WithCava.
     end.
 
   (* Loop with no enable; set enable to always be true *)
-  Definition LoopInit {i o s} (resetval : signal s)
+  Definition LoopInit {i o s} (resetval : combType s)
              (body : Circuit (i * signal s) (o * signal s))
     : Circuit i o :=
     Compose (Comb (fun i => ret (i, constant true))) (LoopInitCE resetval body).
   (* Delay with no enable; set enable to always be true *)
-  Definition DelayInit {t} (resetval : signal t)
+  Definition DelayInit {t} (resetval : combType t)
     : Circuit (signal t) (signal t) :=
     Compose (Comb (fun i => ret (i, constant true))) (DelayInitCE resetval).
 
   (* Loop with the default signal as its reset value *)
   Definition LoopCE {i o s}
     : Circuit (i * signal s) (o * signal s) -> Circuit (i * signal Bit) o :=
-    LoopInitCE defaultSignal.
+    LoopInitCE (defaultCombValue s).
   (* Delay with the default signal as its reset value *)
   Definition DelayCE {t}
     : Circuit (signal t * signal Bit) (signal t) :=
-    DelayInitCE defaultSignal.
+    DelayInitCE (defaultCombValue t).
 
   (* Loop with the default signal as its reset value and no enable *)
   Definition Loop {i o s}
              (body : Circuit (i * signal s) (o * signal s))
     : Circuit i o :=
-    Compose (Comb (fun i => ret (i, constant true))) (LoopInitCE defaultSignal body).
+    Compose (Comb (fun i => ret (i, constant true))) (LoopInitCE (defaultCombValue s) body).
   (* Delay with the default signal as its reset value and no enable *)
   Definition Delay {t} : Circuit (signal t) (signal t) :=
-    Compose (Comb (fun i => ret (i, constant true))) (DelayInitCE defaultSignal).
+    Compose (Comb (fun i => ret (i, constant true))) (DelayInitCE (defaultCombValue t)).
 End WithCava.
 
 Module Notations.

--- a/cava/Cava/Core/Netlist.v
+++ b/cava/Cava/Core/Netlist.v
@@ -70,10 +70,10 @@ Inductive Instance : Type :=
   | Xnor:      Signal Bit -> Signal Bit -> Signal Bit -> Instance
   | Buf:       Signal Bit -> Signal Bit -> Instance
   (* Composite delay component i.e. a register *)
-  | Delay:     forall (t : SignalType), Signal t -> Signal t -> Signal t -> Instance
+  | Delay:     forall (t : SignalType), combType t -> Signal t -> Signal t -> Instance
   (* Composite delay component with enable i.e. a register with clock enable *)
   | DelayEnable: forall (t : SignalType),
-                 Signal t -> Signal Bit -> Signal t -> Signal t -> Instance
+                 combType t -> Signal Bit -> Signal t -> Signal t -> Instance
   (* Assignment *)
   | AssignSignal: forall {k: SignalType}, Signal k -> Signal k -> Instance
   (* TODO(satnam): Switch to using tupleInterface instead of UntypedSignal *)

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -38,7 +38,7 @@ stability:           Experimental
 cabal-version:        >= 1.10
 
 library
-  build-Depends:     base >= 4, mtl >= 2
+  build-Depends:     base >= 4, mtl >= 2, ghc-prim >= 0.5.3
   exposed-Modules:   Cava2SystemVerilog
                      Adders
                      Applicative


### PR DESCRIPTION
As per https://github.com/project-oak/silveroak/pull/681#issuecomment-804307948

@satnam6502 @blaxill I'm not Haskell-literate enough to fix the `Cava2SystemVerilog` error here, could one of you help?