### PR TITLE
Add tutorial stylesheet

### DIFF
--- a/demos/tutorial.v
+++ b/demos/tutorial.v
@@ -1,4 +1,8 @@
 (*|
+.. raw:: html
+
+   <link rel="stylesheet" href="tutorial.css" type="text/css" />
+
 .. coq:: none
 |*)
 

--- a/docs/demo/tutorial.css
+++ b/docs/demo/tutorial.css
@@ -1,18 +1,16 @@
 /* Style sheet for the Cava tutorial */
 
-/* Override Alectryon's default font-family settings because they stylize Cava's >=> and >==> arrows */ 
+/* Disable font ligatures because they stylize Cava's >=> and >==> arrows */
 kbd,
 pre,
 samp,
 tt,
 code,
 code.highlight,
-.docutils.literal {
-    font-family:  monospace;
-}
+.docutils.literal
 .alectryon-coqdoc .doc .code,
 .alectryon-coqdoc .doc .comment,
 .alectryon-coqdoc .doc .inlinecode,
 pre.alectryon-io, .alectryon-toggle-label, .alectryon-banner {
-    font-family: monospace;
+    font-variant-ligatures: none;
 }

--- a/docs/demo/tutorial.css
+++ b/docs/demo/tutorial.css
@@ -1,0 +1,18 @@
+/* Style sheet for the Cava tutorial */
+
+/* Override Alectryon's default font-family settings because they stylize Cava's >=> and >==> arrows */ 
+kbd,
+pre,
+samp,
+tt,
+code,
+code.highlight,
+.docutils.literal {
+    font-family:  monospace;
+}
+.alectryon-coqdoc .doc .code,
+.alectryon-coqdoc .doc .comment,
+.alectryon-coqdoc .doc .inlinecode,
+pre.alectryon-io, .alectryon-toggle-label, .alectryon-banner {
+    font-family: monospace;
+}

--- a/docs/demo/tutorial.html
+++ b/docs/demo/tutorial.html
@@ -18,7 +18,7 @@
 <div class="alectryon-root alectryon-centered"><div class="alectryon-banner">Built with <a href="https://github.com/cpitclaudel/alectryon/">Alectryon</a>, running Coq+SerAPI v8.12.0+0.12.0. Bubbles (<span class="alectryon-bubble"></span>) indicate interactive fragments: hover for details, tap to reveal contents. Use <kbd>Ctrl+↑</kbd> <kbd>Ctrl+↓</kbd> to navigate, <kbd>Ctrl+🖱️</kbd> to focus. On Mac, use <kbd>⌘</kbd> instead of <kbd>Ctrl</kbd>.</div><div class="document" id="tutorial">
 <h1 class="title">Tutorial</h1>
 
-<p>Welcome! This is a quick primer for designing circuits with Cava. We'll walk
+<link rel="stylesheet" href="tutorial.css" type="text/css" /><p>Welcome! This is a quick primer for designing circuits with Cava. We'll walk
 through a few small examples end-to-end. This tutorial will not explain Coq
 syntax in depth, but will use the same few patterns throughout; you shouldn't
 need to know Coq to follow along.</p>


### PR DESCRIPTION
Fixes #694 

There ended up being a much simpler solution to this problem than I originally thought; I can just add a `.. raw:: html` block and a custom stylesheet that overrides the arrow-stylization.