### PR TITLE
SystemVerilog test for bsort

### DIFF
--- a/cava/Cava2SystemVerilog.hs
+++ b/cava/Cava2SystemVerilog.hs
@@ -81,7 +81,7 @@ cava2SystemVerilog cavaState@(Netlist.Coq_mkCavaState netNumber vCount' vDefs' e
      "  timeunit 1ns; timeprecision 1ns;",
      ""] ++
     declareLocalNets (fromN netNumber) ++
-    [vectorDeclaration ("v" ++ show i) k s ++ ";" | ((k, s), i) <- zip vDefs [0..]] ++
+    [vectorDeclaration ("v" ++ show i) k s ++ ";" | ((k, s), i) <- zip vDefs [0..], s > 0] ++
     [ "  " ++ t ++ " ext_" ++ show i ++ ";" | (t, i) <- zip ext [0..]] ++
     [""] ++
     [generateInstance genState inst i | (inst, i) <- zip instances [0..]] ++
@@ -233,6 +233,7 @@ generateInstance netlistState (DelayEnable t initV en d o) _
     negReset = case rstEdge of
                  PositiveEdge -> ""
                  NegativeEdge -> "!"
+generateInstance _ (AssignSignal (Vec _ 0) a b) _ = ""
 generateInstance _ (AssignSignal _ a b) _
    = "  assign " ++ showSignal a ++ " = " ++ showSignal b ++ ";"
 generateInstance _ (Not i o) instrNr = primitiveInstance "not" [o, i] instrNr

--- a/examples/BitonicSorter.v
+++ b/examples/BitonicSorter.v
@@ -159,3 +159,25 @@ Section Test.
   Proof. reflexivity. Qed.
   Close Scope N.
 End Test.
+
+Definition bsort_Interface name n bw
+  := combinationalInterface name
+     [mkPort "inputs" (Vec (Vec Bit bw) (two_pow n))]
+     [mkPort "sorted" (Vec (Vec Bit bw) (two_pow n))].
+
+Definition bsort4_8_Netlist
+  := makeNetlist (bsort_Interface "bsort4_8" 4 8) (bitonicSorter defaultSignal).
+
+Local Open Scope N_scope.
+
+Definition bsort4_8_tb_inputs := map (Vector.map (N2Bv_sized 8))
+  [ [12; 2; 11; 10; 16; 14; 6; 3; 5; 1; 7; 15; 9; 13; 4; 8]%vector
+  ]%list.
+
+Definition bsort4_8_tb_expectedOutputs := map (Vector.map (N2Bv_sized 8))
+  [ [1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15; 16]%vector
+  ]%list.
+
+Definition bsort4_8_tb :=
+  testBench "bsort4_8_tb" (bsort_Interface "bsort4_8" 4 8)
+  bsort4_8_tb_inputs bsort4_8_tb_expectedOutputs.

--- a/examples/ExamplesSV.hs
+++ b/examples/ExamplesSV.hs
@@ -22,6 +22,7 @@ import FullAdderExample
 import UnsignedAdderExamples
 import AdderTree
 import TwoSorter
+import BitonicSorter
 
 main :: IO ()
 main = do writeSystemVerilog nand2Netlist
@@ -36,3 +37,6 @@ main = do writeSystemVerilog nand2Netlist
           writeTestBench fullAdder_tb
           writeSystemVerilog two_sorter_Netlist
           writeTestBench two_sorter_tb
+          writeSystemVerilog bsort4_8_Netlist
+          writeTestBench bsort4_8_tb
+

--- a/examples/MonadExtraction.v
+++ b/examples/MonadExtraction.v
@@ -20,6 +20,7 @@ Require Import Examples.FullAdderExample.
 Require Import Examples.UnsignedAdderExamples.
 Require Import Examples.AdderTree.
 Require Import Examples.TwoSorter.
+Require Import Examples.BitonicSorter.
 Require Import Coq.extraction.Extraction.
 Require Import Coq.extraction.ExtrHaskellZInteger.
 Require Import Coq.extraction.ExtrHaskellString.
@@ -34,3 +35,4 @@ Extraction Library FullAdderExample.
 Extraction Library UnsignedAdderExamples.
 Extraction Library AdderTree.
 Extraction Library TwoSorter.
+Extraction Library BitonicSorter.


### PR DESCRIPTION
Also discard empty vectors when generating SystemVerilog.
Test passes!

```
clang++ -L/usr/local/opt/sqlite/lib    bsort4_8_tb.o verilated.o verilated_vcd_c.o Vbsort4_8_tb__ALL.a    -o Vbsort4_8_tb -lm -lstdc++
obj_dir/Vbsort4_8_tb
                  10: tick = 0,  inputs[0] = 12,  inputs[1] = 2,  inputs[2] = 11,  inputs[3] = 10,  inputs[4] = 16,  inputs[5] = 14,  inputs[6] = 6,  inputs[7] = 3,  inputs[8] = 5,  inputs[9] = 1,  inputs[10] = 7,  inputs[11] = 15,  inputs[12] = 9,  inputs[13] = 13,  inputs[14] = 4,  inputs[15] = 8, 
                                 sorted[0] = 1,  sorted[1] = 2,  sorted[2] = 3,  sorted[3] = 4,  sorted[4] = 5,  sorted[5] = 6,  sorted[6] = 7,  sorted[7] = 8,  sorted[8] = 9,  sorted[9] = 10,  sorted[10] = 11,  sorted[11] = 12,  sorted[12] = 13,  sorted[13] = 14,  sorted[14] = 15,  sorted[15] = 16
PASSED
```
CC: @smore-lore