### PR TITLE
Fix kramdown security vunrelability

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.3)
       jemoji (= 0.12.0)
-      kramdown (= 2.3.0)
+      kramdown (> 2.3.1)
       kramdown-parser-gfm (= 1.1.0)
       liquid (= 4.0.3)
       mercenary (~> 0.3)


### PR DESCRIPTION
Address:
```
1 kramdown vulnerability found in docs/Gemfile.lock 7 hours ago
Remediation
Upgrade kramdown to version 2.3.1 or later. For example:

gem "kramdown", ">= 2.3.1"
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2021-28834
high severity
Vulnerable versions: >= 1.16.0, < 2.3.1
Patched version: 2.3.1
Kramdown before 2.3.1 does not restrict Rouge formatters to the Rouge::Formatters namespace, and thus arbitrary classes can be instantiated.
```
