### PR TITLE
Incorporate some feedback on the tutorial

### DIFF
--- a/demos/tutorial.v
+++ b/demos/tutorial.v
@@ -33,8 +33,9 @@ patterns throughout; you shouldn't need to be a Coq expert to follow
 along. We'll walk through a few small examples end-to-end, showing you how to
 define, simulate, and generate netlists for circuits in Cava.
 
-This page allows you to see the Coq output for each line that has output. Try
-hovering over the following line:
+This page (thanks to the Alectryon_ system) allows you to see the Coq output for
+each line that has output. Try hovering over the following line (if on mobile,
+tap the line):
 |*)
 
 Compute (1 + 2).
@@ -107,7 +108,7 @@ we're inside the section and that every definition is parameterized over the
 Back to our inverter. Let's take a closer look at the ``inv`` primitive.
 |*)
 
-  About inv.
+  Check inv.
 
 (*|
 You can see in the type signature ``signal Bit -> cava (signal Bit)`` that
@@ -1308,6 +1309,7 @@ That concludes our tutorial! If you want to explore further, take a look at the
 ``examples`` directory in our GitHub repo_. You can also view the full source_
 for this page if you want to experiment with these examples yourself.
 
+.. _Alectryon: https://github.com/cpitclaudel/alectryon
 .. _reference: ../reference
 .. _mealy: https://en.wikipedia.org/wiki/Mealy_machine
 .. _repo: https://github.com/project-oak/silveroak

--- a/docs/demo/tutorial.html
+++ b/docs/demo/tutorial.html
@@ -23,8 +23,9 @@ tutorial will not explain Coq syntax in depth, but will use the same few
 patterns throughout; you shouldn't need to be a Coq expert to follow
 along. We'll walk through a few small examples end-to-end, showing you how to
 define, simulate, and generate netlists for circuits in Cava.</p>
-<p>This page allows you to see the Coq output for each line that has output. Try
-hovering over the following line:</p>
+<p>This page (thanks to the <a class="reference external" href="https://github.com/cpitclaudel/alectryon">Alectryon</a> system) allows you to see the Coq output for
+each line that has output. Try hovering over the following line (if on mobile,
+tap the line):</p>
 <pre class="alectryon-io"><!-- Generator: Alectryon --><span class="alectryon-sentence"><input class="alectryon-toggle" id="tutorial-v-chk0" style="display: none" type="checkbox"><label class="alectryon-input" for="tutorial-v-chk0"><span class="highlight"><span class="kn">Compute</span> (<span class="mi">1</span> + <span class="mi">2</span>).</span></label><small class="alectryon-output"><div class="alectryon-output-sticky-wrapper"><div class="alectryon-messages"><blockquote class="alectryon-message"><span class="highlight">= <span class="mi">3</span>
 : nat</span></blockquote></div></div></small></span></pre><p>See the banner at the top of the page for instructions on how to navigate the proofs.</p>
 <div class="contents topic" id="table-of-contents">
@@ -42,6 +43,7 @@ hovering over the following line:</p>
 </div>
 <div class="section" id="preliminaries">
 <h1><a class="toc-backref" href="#id1">Preliminaries</a></h1>
+<p>First you need to install Cava, see <a class="reference external" href="https://github.com/project-oak/silveroak/blob/main/README.md">https://github.com/project-oak/silveroak/blob/main/README.md</a>.</p>
 <p>To import the core Cava library you need to define and simulate circuits, just:</p>
 <pre class="alectryon-io"><!-- Generator: Alectryon --><span class="alectryon-sentence"><span class="alectryon-input"><span class="highlight"><span class="kn">Require Import</span> Cava.Cava.</span></span><span class="alectryon-wsp">
 </span></span><span class="alectryon-sentence"><span class="alectryon-input"><span class="highlight"><span class="kn">Import</span> Circuit.Notations.</span></span></span></pre><p>If you also want to do proofs about circuits, this import should have everything you need:</p>
@@ -76,15 +78,8 @@ variables, like this:</p>
 we're inside the section and that every definition is parameterized over the
 <tt class="docutils literal">signal</tt> and <tt class="docutils literal">semantics</tt> context variables.</p>
 <p>Back to our inverter. Let's take a closer look at the <tt class="docutils literal">inv</tt> primitive.</p>
-<pre class="alectryon-io"><!-- Generator: Alectryon --><span class="alectryon-wsp"><span class="highlight">  </span></span><span class="alectryon-sentence"><input class="alectryon-toggle" id="tutorial-v-chk1" style="display: none" type="checkbox"><label class="alectryon-input" for="tutorial-v-chk1"><span class="highlight"><span class="kn">About</span> inv.</span></label><small class="alectryon-output"><div class="alectryon-output-sticky-wrapper"><div class="alectryon-messages"><blockquote class="alectryon-message"><span class="highlight">inv :
-<span class="kr">forall</span> {<span class="nv">signal</span> : SignalType -&gt; <span class="kt">Type</span>}
-  {<span class="nv">Cava</span> : Cava signal},
-signal Bit -&gt; cava (signal Bit)
-
-inv <span class="kr">is</span> not universe polymorphic
-<span class="kn">Arguments</span> inv {signal}%function_scope {Cava}
-inv <span class="kr">is</span> transparent
-Expands to: Constant Cava.Core.CavaClass.inv</span></blockquote></div></div></small></span></pre><p>You can see in the type signature <tt class="docutils literal">signal Bit <span class="pre">-&gt;</span> cava (signal Bit)</tt> that
+<pre class="alectryon-io"><!-- Generator: Alectryon --><span class="alectryon-wsp"><span class="highlight">  </span></span><span class="alectryon-sentence"><input class="alectryon-toggle" id="tutorial-v-chk1" style="display: none" type="checkbox"><label class="alectryon-input" for="tutorial-v-chk1"><span class="highlight"><span class="kn">Check</span> inv.</span></label><small class="alectryon-output"><div class="alectryon-output-sticky-wrapper"><div class="alectryon-messages"><blockquote class="alectryon-message"><span class="highlight">inv
+     : signal Bit -&gt; cava (signal Bit)</span></blockquote></div></div></small></span></pre><p>You can see in the type signature <tt class="docutils literal">signal Bit <span class="pre">-&gt;</span> cava (signal Bit)</tt> that
 <tt class="docutils literal">inv</tt> is defined as a pure Coq function in terms of a monad called
 <tt class="docutils literal">cava</tt>. The <tt class="docutils literal">cava</tt> monad, like <tt class="docutils literal">inv</tt>, is provided by <tt class="docutils literal">semantics</tt>. The
 monad is used to capture sharing; it's semantically different in Cava to write:</p>


### PR DESCRIPTION
Tutorial is updated to:
- advise mobile users that they can tap on a line to see the Coq output
- link to Alectryon in the text (got a few people asking me how "I" did the Coq output feature, so I think it makes sense to add a link more prominent than the one in the banner at the top)
- change `About inv` to `Check inv` to reduce the amount of unnecessary information printed

Also updates the HTML to include changes from #714