### PR TITLE
Add files for OpenTitan {gold,silveroak} comparison

### DIFF
--- a/silveroak-opentitan/aes/.gitignore
+++ b/silveroak-opentitan/aes/.gitignore
@@ -1,0 +1,3 @@
+opentitan_gold/
+opentitan_silveroak/
+Impl/AESSV

--- a/silveroak-opentitan/aes/Makefile
+++ b/silveroak-opentitan/aes/Makefile
@@ -16,7 +16,7 @@
 
 SUBDIRS = Spec Impl
 
-.PHONY: all coq minimize-requires clean subdirs $(SUBDIRS)
+.PHONY: all coq minimize-requires clean subdirs $(SUBDIRS) diff_opentitan
 
 all: subdirs
 
@@ -51,3 +51,9 @@ clean: SUBDIRTARGET=clean
 
 # Impl depends on Spec
 Impl: Spec
+
+diff_opentitan: all
+	./configure_opentitan_verilator.sh # Not strictly necessary
+	./prepare_silveroak_items.sh
+	./diff_opentitan_silveroak.sh
+

--- a/silveroak-opentitan/aes/RunningInOpenTitan.md
+++ b/silveroak-opentitan/aes/RunningInOpenTitan.md
@@ -49,7 +49,11 @@ Add '-D_FTDI_DISABLE_DEPRECATED' to the c_args list:
 
 1. Make sure the SilverOak AES components were built by the first step.
 1. Then whilst in the `silveroak-opentitan/aes` directory run
-   `./copy_silveroak_files.sh`
+   ```
+   ./configure_opentitan_verilator.sh # Not strictly necessary
+   ./prepare_silveroak_items.sh
+   ./copy_silveroak_files.sh
+   ```
 1. The SilverOak components should now be in `third_party/opentitan/hw/ip/aes/rtl/`
 
 ## Build the OpenTitan Verilator model

--- a/silveroak-opentitan/aes/RunningInOpenTitan.md
+++ b/silveroak-opentitan/aes/RunningInOpenTitan.md
@@ -48,7 +48,8 @@ Add '-D_FTDI_DISABLE_DEPRECATED' to the c_args list:
 ## Replace the combinational components
 
 1. Make sure the SilverOak AES components were built by the first step.
-1. Then whilst in the `silveroak-opentitan/aes` directory run `./copy_to_opentitan.sh`
+1. Then whilst in the `silveroak-opentitan/aes` directory run
+   `./copy_silveroak_files.sh`
 1. The SilverOak components should now be in `third_party/opentitan/hw/ip/aes/rtl/`
 
 ## Build the OpenTitan Verilator model

--- a/silveroak-opentitan/aes/RunningInOpenTitan.md
+++ b/silveroak-opentitan/aes/RunningInOpenTitan.md
@@ -50,7 +50,7 @@ Add '-D_FTDI_DISABLE_DEPRECATED' to the c_args list:
 1. Make sure the SilverOak AES components were built by the first step.
 1. Then whilst in the `silveroak-opentitan/aes` directory run
    ```
-   ./configure_opentitan_verilator.sh # Not strictly necessary
+   ./configure_opentitan_verilator.sh
    ./prepare_silveroak_items.sh
    ./copy_silveroak_files.sh
    ```

--- a/silveroak-opentitan/aes/configure_opentitan_verilator.sh
+++ b/silveroak-opentitan/aes/configure_opentitan_verilator.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Copyright 2021 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+VERILATOR_CONFIG=../../third_party/opentitan/hw/lint/tools/verilator/common.vlt
+
+# OpenTitan Verilator config is empty, we need to turn off "DETECTARRAYS" as we
+# generate large arrays that choke Verilator. Alternatively we could
+# rebuild Verilator with larger inbuilt DETECTARRAYS constant
+cat <<EOS > $VERILATOR_CONFIG
+\`verilator_config
+lint_off -rule DETECTARRAY
+EOS
+

--- a/silveroak-opentitan/aes/copy_silveroak_files.sh
+++ b/silveroak-opentitan/aes/copy_silveroak_files.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# Copyright 2021 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eu
+
+BASE_DIR=${1:-../../third_party/opentitan}
+BASE_DIR+=/hw/ip/aes/rtl
+
+cp aes_mix_columns.sv aes_sbox_lut.sv aes_sub_bytes.sv aes_shift_rows.sv aes_cipher_core.sv $BASE_DIR

--- a/silveroak-opentitan/aes/diff_opentitan_silveroak.sh
+++ b/silveroak-opentitan/aes/diff_opentitan_silveroak.sh
@@ -23,8 +23,8 @@ echo "** Please make sure third_party/opentitan does not contain modified RTL fi
 rm -rf opentitan_gold
 rm -rf opentitan_silveroak
 
-cp -r ../../third_party/opentitan opentitan_gold
-cp -r ../../third_party/opentitan opentitan_silveroak
+rsync -r --exclude=.git --copy-links ../../third_party/opentitan/ opentitan_gold
+rsync -r --exclude=.git --copy-links ../../third_party/opentitan/ opentitan_silveroak
 ./copy_silveroak_files.sh ./opentitan_silveroak
 
 echo "** Sanity check: diff should report changes to files replaced by silveroak below:"

--- a/silveroak-opentitan/aes/diff_opentitan_silveroak.sh
+++ b/silveroak-opentitan/aes/diff_opentitan_silveroak.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# Copyright 2021 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eu
+
+echo "** Please make sure third_party/opentitan does not contain modified RTL files"
+
+rm -rf opentitan_gold
+rm -rf opentitan_silveroak
+
+cp -r ../../third_party/opentitan opentitan_gold
+cp -r ../../third_party/opentitan opentitan_silveroak
+./copy_silveroak_files.sh ./opentitan_silveroak
+
+echo "** Sanity check: diff should report changes to files replaced by silveroak below:"
+diff -qr opentitan_gold/ opentitan_silveroak/ || true

--- a/silveroak-opentitan/aes/prepare_silveroak_items.sh
+++ b/silveroak-opentitan/aes/prepare_silveroak_items.sh
@@ -16,10 +16,9 @@
 # limitations under the License.
 #
 
-set -eu
+# Prepare generated files for OpenTitan compatiblity
 
-OPENTITAN_AES_DIR=../../third_party/opentitan/hw/ip/aes/rtl
-VERILATOR_CONFIG=../../third_party/opentitan/hw/lint/tools/verilator/common.vlt
+set -eu
 
 # Remove timing as OpenTitan modules do not have them and Verilator raises
 # errors with mixed usage
@@ -41,14 +40,4 @@ awk '
     case /timeprecision/: break
     default: print; break
   } } ' Impl/aes_cipher_core.sv > aes_cipher_core.sv
-
-cp aes_mix_columns.sv aes_sbox_lut.sv aes_sub_bytes.sv aes_shift_rows.sv aes_cipher_core.sv $OPENTITAN_AES_DIR
-
-# OpenTitan Verilator config is empty, we need to turn off "DETECTARRAYS" as we
-# generate large arrays that choke Verilator. Alternatively we could
-# rebuild Verilator with larger inbuilt DETECTARRAYS constant
-cat <<EOS > $VERILATOR_CONFIG
-\`verilator_config
-lint_off -rule DETECTARRAY
-EOS
 

--- a/silveroak-opentitan/aes/run_in_opentitan.sh
+++ b/silveroak-opentitan/aes/run_in_opentitan.sh
@@ -35,7 +35,7 @@ case $rebuild in
   * ) ;;
 esac
 
-./copy_to_opentitan.sh
+# ./copy_to_opentitan.sh TODO:
 cd ../../third_party/opentitan
 fusesoc --cores-root . run --flag=fileset_top --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
 

--- a/silveroak-opentitan/aes/run_in_opentitan.sh
+++ b/silveroak-opentitan/aes/run_in_opentitan.sh
@@ -35,7 +35,10 @@ case $rebuild in
   * ) ;;
 esac
 
-# ./copy_to_opentitan.sh TODO:
+./configure_opentitan_verilator.sh
+./prepare_silveroak_items.sh
+./copy_to_opentitan.sh
+
 cd ../../third_party/opentitan
 fusesoc --cores-root . run --flag=fileset_top --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
 


### PR DESCRIPTION
- Update `silveroak-opentitan/aes` bash files
- Add `make diff_opentitan` to `silveroak-opentitan/aes/Makefile`
   This will create copies of `third_party/opentitan` as subdirectories `opentitan_gold` and `opentitan_silveroak` in `silveroak-opentitan/aes` with `opentitan_silveroak` containing silveroak replacements. Both directories should be buildable.
- Update doc

#722