### PR TITLE
Option 1 of 2: Interpret bedrock2 constants as literals for proofs, vars for printing

### DIFF
--- a/investigations/bedrock2/Constants.v
+++ b/investigations/bedrock2/Constants.v
@@ -1,0 +1,23 @@
+Require Import Coq.Strings.String.
+Require Import Coq.ZArith.ZArith.
+Require Import bedrock2.Syntax.
+Require Import coqutil.Word.Interface.
+
+Module constant.
+  (* Typeclass for constant values *)
+  Definition constant (name : string) : Type := Z.
+  Existing Class constant.
+
+  (* Typeclass for functions that convert a constant to a bedrock2 expression *)
+  Definition interp : Type := forall name, constant name -> expr.expr.
+  Existing Class interp.
+
+  (* Use `Existing Instance constants.var_interp` to interpret constants as
+     named variables -- useful for printing C that will use those constants *)
+  Definition var_interp : interp := fun name _ => expr.var name.
+
+  (* Use `Existing Instance constants.literal_interp` to interpret constants as
+     literals -- useful for proofs *)
+  Definition literal_interp : interp := fun _ => expr.literal.
+End constant.
+Notation constant := constant.constant.

--- a/investigations/bedrock2/IncrementWait/IncrementWait.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWait.v
@@ -6,6 +6,7 @@ Require Import bedrock2.Syntax.
 Require Import bedrock2.NotationsCustomEntry.
 Require Import bedrock2.ToCString.
 Require Import coqutil.Word.Interface.
+Require Import Bedrock2Experiments.Constants.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWaitSemantics.
 Import Syntax.Coercions List.ListNotations.
 Local Open Scope string_scope.
@@ -13,8 +14,13 @@ Local Open Scope Z_scope.
 Local Open Scope list_scope.
 
 Section Impl.
-  Context {consts : constants}.
-  Import constants.
+  Context {env : global_env} {interp : constant.interp}.
+  Import global_env.
+
+  (* To get around the Uniform Inheritance Condition, we need to redefine interp
+     for the coercion *)
+  Local Definition to_expr {name} (c : constant name) : expr := interp _ c.
+  Local Coercion to_expr : constant >-> expr.expr.
 
   (* Notations for small constants *)
   Local Notation "0" := (expr.literal 0) (in custom bedrock_expr).

--- a/investigations/bedrock2/IncrementWait/IncrementWaitProperties.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWaitProperties.v
@@ -13,6 +13,7 @@ Require Import coqutil.Word.Properties.
 Require Import coqutil.Map.Interface.
 Require Import coqutil.Tactics.Tactics.
 Require Import coqutil.Tactics.letexists.
+Require Import Bedrock2Experiments.Constants.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWaitSemantics.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWait.
 Import Syntax.Coercions List.ListNotations.
@@ -20,9 +21,13 @@ Local Open Scope Z_scope.
 
 Section Proofs.
   Context {p : parameters} {p_ok : parameters.ok p}
-          {consts : constants} {consts_ok : constants.ok consts}
+          {env : global_env} {env_ok : global_env.ok env}
           {timing : timing}.
-  Import constants parameters.
+  Import global_env parameters.
+
+  (* bedrock2 does not support proof logic for global constants, so for proofs
+     interpret constants as literals *)
+  Local Existing Instance constant.literal_interp.
 
   (* plug in implicits *)
   Definition put_wait_get := put_wait_get.
@@ -122,8 +127,8 @@ Section Proofs.
     execution t s2 ->
     s1 = s2.
   Proof.
-    pose proof addrs_unique (ok:=consts_ok).
-    pose proof flags_unique_and_nonzero (ok:=consts_ok) as Hflags.
+    pose proof addrs_unique (ok:=env_ok).
+    pose proof flags_unique_and_nonzero (ok:=env_ok) as Hflags.
     cbv [map] in Hflags.
     simplify_unique_words_in Hflags.
     revert s1 s2.

--- a/investigations/bedrock2/IncrementWait/IncrementWaitToC.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWaitToC.v
@@ -2,20 +2,28 @@ Require Import Coq.Lists.List.
 Require Import Coq.ZArith.ZArith.
 Require Import bedrock2.ToCString.
 Require Import coqutil.Z.HexNotation.
+Require Import Bedrock2Experiments.Constants.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWaitSemantics.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWait.
 Import ListNotations.
+Local Open Scope Z_scope.
 
 Definition BASE_ADDR : Z := Ox"1000".
 
-Instance consts : constants :=
-  {| constants.STATUS_IDLE := 0;
-     constants.STATUS_BUSY := 1;
-     constants.STATUS_DONE := 2;
-     constants.STATUS_ADDR := BASE_ADDR + Ox"0";
-     constants.VALUE_ADDR := BASE_ADDR + Ox"4";
+Instance env : global_env :=
+  {| global_env.STATUS_IDLE := 0;
+     global_env.STATUS_BUSY := 1;
+     global_env.STATUS_DONE := 2;
+     global_env.STATUS_ADDR := BASE_ADDR + Ox"0";
+     global_env.VALUE_ADDR := BASE_ADDR + Ox"4";
   |}.
 
-Definition funcs := [put_wait_get].
+Definition funcs {interp : constant.interp} := [put_wait_get].
+
+(* Print with constants as variables *)
+Existing Instance constant.var_interp.
+
+(* Uncomment to print with constants as literals *)
+(* Existing Instance constant.literal_interp. *)
 
 Redirect "incrementwait.c" Compute c_module funcs.

--- a/investigations/bedrock2/incrementwait.c.out
+++ b/investigations/bedrock2/incrementwait.c.out
@@ -15,13 +15,13 @@ static inline void _br2_store(uintptr_t a, uintptr_t v, size_t sz) {
 
 
 uintptr_t put_wait_get(uintptr_t input) {
-  uintptr_t status, out;
-  REG32_SET((uintptr_t)4100ULL, input);
+  uintptr_t STATUS_DONE, status, STATUS_ADDR, out, VALUE_ADDR;
+  REG32_SET(VALUE_ADDR, input);
   status = (uintptr_t)0ULL;
-  while (((status)&(((uintptr_t)1ULL)<<((uintptr_t)2ULL)))==((uintptr_t)0ULL)) {
-    status = REG32_GET((uintptr_t)4096ULL);
+  while (((status)&(((uintptr_t)1ULL)<<(STATUS_DONE)))==((uintptr_t)0ULL)) {
+    status = REG32_GET(STATUS_ADDR);
   }
-  out = REG32_GET((uintptr_t)4100ULL);
+  out = REG32_GET(VALUE_ADDR);
   return out;
 }
 


### PR DESCRIPTION
In #729 I mentioned as part of "next steps" that the constant values were printed as literals, and therefore couldn't be copy-pasted into an environment using global constants. The crux of the problem here is that bedrock2 doesn't support global constants at all (the proof logic starts functions bodies with an empty context).

This is 1 out of 2 possible solutions to the problem. Here, I've defined a `constant` typeclass, and a typeclass for interpretation functions that change a `constant` into a bedrock2 `expr`. There are two instances of the interpretation typeclass: one interprets the constants using `expr.var` (that is, by referencing the string part of the constant as a variable) and the other interprets the constants using `expr.literal` (referencing the Z part of the constant as a literal value).

The end result is that in proofs, we reason about constants as if they were literals (although the proof is still parameterized over their exact values), but the C printout shows them as local variables:
```
uintptr_t put_wait_get(uintptr_t input) {
  uintptr_t STATUS_DONE, status, STATUS_ADDR, out, VALUE_ADDR;
  REG32_SET(VALUE_ADDR, input);
  status = (uintptr_t)0ULL;
  while (((status)&(((uintptr_t)1ULL)<<(STATUS_DONE)))==((uintptr_t)0ULL)) {
    status = REG32_GET(STATUS_ADDR);
  }
  out = REG32_GET(VALUE_ADDR);
  return out;
}
```

One major disadvantage of this approach is that it does not protect against global constants being overwritten. For instance, if I had written a new value to a local variable called `STATUS_ADDR`, the proof logic could still use the literal value from the global constant. This is a bit of a weird edge case, but still is a concern.

Another minor disadvantage is that the global variables declarations at the top of the function will need to be removed before copy-pasting this into a C file.

CC @atondwal 