### PR TITLE
Option 2 of 2: Interpret bedrock2 constants as arguments

### DIFF
--- a/investigations/bedrock2/IncrementWait/IncrementWait.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWait.v
@@ -13,8 +13,9 @@ Local Open Scope Z_scope.
 Local Open Scope list_scope.
 
 Section Impl.
-  Context {consts : constants}.
   Import constants.
+  Local Existing Instance constant_names.
+  Local Existing Instance constant_vars.
 
   (* Notations for small constants *)
   Local Notation "0" := (expr.literal 0) (in custom bedrock_expr).
@@ -30,7 +31,7 @@ Section Impl.
     (* temporary variables *)
     let status := "status" in
     ("put_wait_get",
-     ([input], [out], bedrock_func_body:(
+     (globals ++ [input], [out], bedrock_func_body:(
         (* write input value *)
         output! WRITE (VALUE_ADDR, input) ;
         (* initialize status to 0 *)

--- a/investigations/bedrock2/IncrementWait/IncrementWaitToC.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWaitToC.v
@@ -5,17 +5,10 @@ Require Import coqutil.Z.HexNotation.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWaitSemantics.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWait.
 Import ListNotations.
+Local Open Scope string_scope.
+Local Open Scope Z_scope.
 
-Definition BASE_ADDR : Z := Ox"1000".
-
-Instance consts : constants :=
-  {| constants.STATUS_IDLE := 0;
-     constants.STATUS_BUSY := 1;
-     constants.STATUS_DONE := 2;
-     constants.STATUS_ADDR := BASE_ADDR + Ox"0";
-     constants.VALUE_ADDR := BASE_ADDR + Ox"4";
-  |}.
+Existing Instance constants.constant_names.
 
 Definition funcs := [put_wait_get].
-
 Redirect "incrementwait.c" Compute c_module funcs.

--- a/investigations/bedrock2/incrementwait.c.out
+++ b/investigations/bedrock2/incrementwait.c.out
@@ -14,16 +14,16 @@ static inline void _br2_store(uintptr_t a, uintptr_t v, size_t sz) {
 }
 
 
-uintptr_t put_wait_get(uintptr_t input) {
+uintptr_t put_wait_get(uintptr_t VALUE_ADDR, uintptr_t STATUS_ADDR, uintptr_t STATUS_IDLE, uintptr_t STATUS_BUSY, uintptr_t STATUS_DONE, uintptr_t input) {
   uintptr_t status, out;
-  REG32_SET((uintptr_t)4100ULL, input);
+  REG32_SET(VALUE_ADDR, input);
   status = (uintptr_t)0ULL;
-  while (((status)&(((uintptr_t)1ULL)<<((uintptr_t)2ULL)))==((uintptr_t)0ULL)) {
-    status = REG32_GET((uintptr_t)4096ULL);
+  while (((status)&(((uintptr_t)1ULL)<<(STATUS_DONE)))==((uintptr_t)0ULL)) {
+    status = REG32_GET(STATUS_ADDR);
   }
-  out = REG32_GET((uintptr_t)4100ULL);
+  out = REG32_GET(VALUE_ADDR);
   return out;
 }
 
-"%string
+"
      : string


### PR DESCRIPTION
Alternative to #737; only one of the two should be merged.

This solves the same problem as #737 but with a different method. Here, the constants are interpreted as _arguments_ to the function, both in the C printout and in the proofs. The C printout looks like:
```
uintptr_t put_wait_get(uintptr_t VALUE_ADDR, uintptr_t STATUS_ADDR, uintptr_t STATUS_IDLE, uintptr_t STATUS_BUSY, uintptr_t STATUS_DONE, uintptr_t input) {
  uintptr_t status, out;
  REG32_SET(VALUE_ADDR, input);
  status = (uintptr_t)0ULL;
  while (((status)&(((uintptr_t)1ULL)<<(STATUS_DONE)))==((uintptr_t)0ULL)) {
    status = REG32_GET(STATUS_ADDR);
  }
  out = REG32_GET(VALUE_ADDR);
  return out;
}
```

Compared to #737, this solution:
- (+) avoids the issue in #737 where overwriting global constants can lead to discrepancies between C and proofs
- (+) is likely easier to copy-paste; the functions have extra arguments, but these will all be in the exact same order and can be removed with a quick `sed`
- (-) has more boilerplate; constants have to be listed multiple times and loop invariants need to prove that global constants were not overwritten

Curious for thoughts on which of these solutions is better!

CC @atondwal 