### PR TITLE
Upgrade to Coq 8.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ requests.
 
 Please install the following components:
 
-* The [Coq proof assistant](https://coq.inria.fr/) version 8.12.0.
+* The [Coq proof assistant](https://coq.inria.fr/) version 8.13.0.
 * The [GHC Haskell compiler](https://www.haskell.org/ghc/) version 8.6.5 or later
 * [Verilator](https://www.veripool.org/wiki/verilator) version 4.028 (as specified by the
   [OpenTitan](https://docs.opentitan.org/doc/ug/install_instructions/#verilator) documentation).

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -87,7 +87,7 @@ library
                      Byte
                      Decimal
                      Hexadecimal
-                     Numeral
+                     Number
                      Specif
                      MonadExc
                      MonadFix

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 let
   tools = with pkgs; [
     # Building
-    coq_8_12
+    coq_8_13
     (haskell.packages.ghc8104.ghcWithPackages (pkgs: with pkgs; [Cabal]))
     gcc
     verilator

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ requests.
 
 Please install the following components:
 
-* The [Coq proof assistant](https://coq.inria.fr/) version 8.12.0.
+* The [Coq proof assistant](https://coq.inria.fr/) version 8.13.0.
 * The [GHC Haskell compiler](https://www.haskell.org/ghc/) version 8.6.5 or later
 * [Verilator](https://www.veripool.org/wiki/verilator) version 4.028 (as specified by the
   [OpenTitan](https://docs.opentitan.org/doc/ug/install_instructions/#verilator) documentation).

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -63,3 +63,4 @@ coq: all
 clean:
 	-cd bedrock2 && $(MAKE) clean_all
 	-cd coq-ext-lib && $(MAKE) clean
+	-cd coq-record-update && $(MAKE) clean


### PR DESCRIPTION
~Testing CI, please ignore for now.~ CI passed!

Resolves #730 

This PR upgrades us to use Coq 8.13 in the CI. It is most likely not a backwards-compatible change due to a change to module names in the Haskell extraction, and possibly also due to the coq-record-update upgrade that was needed for 8.13 to build. Before this PR is merged, everyone should update their local development environment to 8.13 or higher. I've upgraded mine to 8.13.2 and everything builds, so any 8.13.x version is likely fine.