### PR TITLE
Add cabal support to Haskell modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,7 @@
 **/obj_dir
 **/*.vcd
 **/*/_CoqProject
+**/dist/
+**/dist-newstyle/
+_build/
 cava.code-workspace

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  cava/Cava2HDL.cabal
+  examples/cava-examples.cabal
+  tests/cava-tests.cabal
+  silveroak-opentitan/pinmux/silveroak-pinmux.cabal
+  silveroak-opentitan/aes/silveroak-aes.cabal
+

--- a/cava/Makefile
+++ b/cava/Makefile
@@ -35,9 +35,7 @@ haskell:	coq FixupHaskell
 		./FixupHaskell
 		mv Ascii2.hs Ascii.hs
 		mv ByteVector2.hs ByteVector.hs
-		runhaskell Setup.hs configure --user
-		runhaskell Setup.hs build
-		runhaskell Setup.hs install
+		cabal build
 
 Makefile.coq:	_CoqProject
 		coq_makefile -f _CoqProject -o Makefile.coq

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ let
   tools = with pkgs; [
     # Building
     coq_8_12
-    (haskell.packages.ghc8104.ghcWithPackages (pkgs: with pkgs; [Cabal]))
+    (haskell.packages.ghc8104.ghcWithPackages (pkgs: with pkgs; [cabal-install]))
     gcc
     verilator
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -57,8 +57,8 @@ minimize-requires: coq
 		$(MAKE) -f Makefile.coq $@
 
 ExamplesSV:	coq ExamplesSV.hs
-		ghc --make ExamplesSV.hs
-		./ExamplesSV
+		cabal build examples
+		cabal run examples
 
 $(SV) $(BENCHES) $(CPPS):	ExamplesSV
 

--- a/examples/cava-examples.cabal
+++ b/examples/cava-examples.cabal
@@ -1,0 +1,28 @@
+cabal-version:       >=1.10
+
+name:                cava-examples
+version:             0.1.0.0
+-- synopsis:
+-- description:
+-- bug-reports:
+-- license:
+license-file:        ../LICENSE
+author:              The SilverOak Team
+maintainer:          benblaxill@google.com
+-- copyright:
+-- category:
+build-type:          Simple
+
+executable examples
+  main-is:             ExamplesSV.hs
+  other-modules:
+        AdderTree
+        BitonicSorter
+        FullAdderExample
+        NandGate
+        TwoSorter
+        UnsignedAdderExamples
+  -- other-extensions:
+  build-depends:       base >=4.14 && <4.15, Cava2HDL
+  -- hs-source-dirs:
+  default-language:    Haskell2010

--- a/silveroak-opentitan/aes/Impl/Makefile
+++ b/silveroak-opentitan/aes/Impl/Makefile
@@ -30,7 +30,7 @@
 
 .PHONY: all coq minimize-requires clean _CoqProject
 
-SV = aes_mix_columns.sv aes_shift_rows.sv aes_sub_bytes.sv
+SV = aes_mix_columns.sv aes_shift_rows.sv aes_sub_bytes.sv aes_add_round_key.sv
 
 BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)
@@ -62,8 +62,7 @@ coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
 AESSV:		coq AESSV.hs
-		ghc --make -j AESSV.hs
-		./AESSV
+		cabal build aes
 
 minimize-requires: coq
 	../../../tools/minimize-requires.sh
@@ -73,6 +72,7 @@ minimize-requires: coq
 		$(MAKE) -f Makefile.coq $@
 
 $(SV) $(BENCHES) $(CPPS):	coq AESSV
+		cabal run aes
 
 obj_dir/V%_tb:	%.sv %_tb.sv %_tb.cpp
 		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp

--- a/silveroak-opentitan/aes/silveroak-aes.cabal
+++ b/silveroak-opentitan/aes/silveroak-aes.cabal
@@ -1,0 +1,38 @@
+cabal-version:       >=1.10
+
+name:                silveroak-aes
+version:             0.1.0.0
+-- synopsis:
+-- description:
+-- bug-reports:
+-- license:
+license-file:        ../LICENSE
+author:              The SilverOak Team
+maintainer:          benblaxill@google.com
+-- copyright:
+-- category:
+build-type:          Simple
+
+executable aes
+  main-is:             AESSV.hs
+  hs-source-dirs: Impl
+  other-modules:
+        AddRoundKeyCircuit
+        AddRoundKeyNetlist
+        CipherCircuit
+        CipherControlCircuit
+        CipherControlNetlist
+        FFunctor
+        MixColumnsCircuit
+        MixColumnsNetlist
+        Pkg
+        RecordSet
+        ShiftRowsCircuit
+        ShiftRowsNetlist
+        SubBytesCircuit
+        SubBytesNetlist
+  -- other-extensions:
+  build-depends:       base >=4.14 && <4.15, Cava2HDL
+
+  -- hs-source-dirs:
+  default-language:    Haskell2010

--- a/silveroak-opentitan/pinmux/Makefile
+++ b/silveroak-opentitan/pinmux/Makefile
@@ -43,15 +43,15 @@ minimize-requires: coq
 		$(MAKE) -f Makefile.coq $@
 
 PinmuxSV:	coq PinmuxSV.hs
-		ghc --make PinmuxSV.hs
+		cabal build pinmux
 
 pinmux.sv:	coq PinmuxSV
-		./PinmuxSV
+		cabal run pinmux
 
 compile_pinmux:	pinmux.sv
 		cd snapshot && $(MAKE)
 
-clean:		
+clean:
 		-@$(MAKE) -f Makefile.coq clean
 		rm -rf PinmuxSV.hi PinmuxSV.o PinmuxSV \
 		       Pinmux.vo Pinmux.o Pinmux.hs Pinmux.hi pinmux.sv

--- a/silveroak-opentitan/pinmux/silveroak-pinmux.cabal
+++ b/silveroak-opentitan/pinmux/silveroak-pinmux.cabal
@@ -1,0 +1,23 @@
+cabal-version:       >=1.10
+
+name:                silveroak-pinxmux
+version:             0.1.0.0
+-- synopsis:
+-- description:
+-- bug-reports:
+-- license:
+license-file:        ../LICENSE
+author:              The SilverOak Team
+maintainer:          benblaxill@google.com
+-- copyright:
+-- category:
+build-type:          Simple
+
+executable pinmux
+  main-is:             PinmuxSV.hs
+  other-modules: Pinmux
+  -- other-extensions:
+  build-depends:       base >=4.14 && <4.15, Cava2HDL
+
+  -- hs-source-dirs:
+  default-language:    Haskell2010

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,8 +57,8 @@ minimize-requires: coq
 		$(MAKE) -f Makefile.coq $@
 
 TestsSV:	coq TestsSV.hs
-		ghc --make TestsSV
-		./TestsSV
+		cabal build cava-tests
+		cabal run tests
 
 $(SV) $(BENCHES) $(CPPS):	coq TestsSV
 

--- a/tests/cava-tests.cabal
+++ b/tests/cava-tests.cabal
@@ -1,0 +1,33 @@
+cabal-version:       >=1.10
+
+name:                cava-tests
+version:             0.1.0.0
+-- synopsis:
+-- description:
+-- bug-reports:
+-- license:
+license-file:        ../LICENSE
+author:              The SilverOak Team
+maintainer:          benblaxill@google.com
+-- copyright:
+-- category:
+build-type:          Simple
+
+executable tests
+  main-is:             TestsSV.hs
+  other-modules:
+        AccumulatingAdderEnable
+        AdderSubtractorTests
+        Array
+        CountBy
+        Delay
+        DoubleCountBy
+        Instantiate
+        MuxTests
+        TestDecoder
+        TestMultiply
+  -- other-extensions:
+  build-depends:       base >=4.14 && <4.15, Cava2HDL
+
+  -- hs-source-dirs:
+  default-language:    Haskell2010


### PR DESCRIPTION
- Removes the requirement to install Cava2HDL globally

#742 