### PR TITLE
Consistent name for make target `clean_all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 	done
 
 # clean everything *including* third_party
-cleanall:
+clean_all:
 	for dir in $(SUBDIRS); do \
 		$(MAKE) -C $$dir clean; \
 	done


### PR DESCRIPTION
This was called `clean_all` elsewhere