### PR TITLE
Instantiate compiler correctness proof for increment-wait

### DIFF
--- a/investigations/bedrock2/IncrementWait/Constants.v
+++ b/investigations/bedrock2/IncrementWait/Constants.v
@@ -35,6 +35,18 @@ Definition constant_vars
      STATUS_DONE := expr.var STATUS_DONE;
   |}.
 
+(* Given the Z values of all the constants, convert them to exprs with
+   expr.literal *)
+Definition constant_literals
+           {vals : constants Z}
+  : constants expr :=
+  {| VALUE_ADDR := expr.literal VALUE_ADDR;
+     STATUS_ADDR := expr.literal STATUS_ADDR;
+     STATUS_IDLE := expr.literal STATUS_IDLE;
+     STATUS_BUSY := expr.literal STATUS_BUSY;
+     STATUS_DONE := expr.literal STATUS_DONE;
+  |}.
+
 (* Given the Z values of all the constants, convert them to words with
    word.of_Z *)
 Definition constant_words

--- a/investigations/bedrock2/IncrementWait/IncrementWaitMMIO.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWaitMMIO.v
@@ -54,19 +54,6 @@ Definition compile_ext_call(results: list Z) a (args: list Z):
     | _, _ => [[]] (* invalid, excluded by ext_spec *)
     end.
 
-Lemma compile_ext_call_length: forall binds f args,
-    Z.of_nat (List.length (compile_ext_call binds f args)) <= 1.
-Proof.
-  intros. unfold compile_ext_call.
-  destruct (String.eqb _ _); destruct binds; try destruct binds;
-  try destruct args; try destruct args; try destruct args;
-  cbv; intros; discriminate.
-Qed.
-
-Lemma compile_ext_call_length': forall binds f args,
-    Z.of_nat (List.length (compile_ext_call binds f args)) <= 7.
-Proof. intros. rewrite compile_ext_call_length. blia. Qed.
-
 Lemma compile_ext_call_emits_valid: forall iset binds a args,
     Forall valid_FlatImp_var binds ->
     Forall valid_FlatImp_var args ->

--- a/investigations/bedrock2/IncrementWait/IncrementWaitToRiscV.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWaitToRiscV.v
@@ -119,8 +119,7 @@ Definition put_wait_get_asm := Eval compute in fst (fst put_wait_get_compile_res
 
 Module PrintAssembly.
   Import riscv.Utility.InstructionNotations.
-  (* Uncomment to see assembly code *)
-  (* Print put_wait_get_asm. *)
+  Redirect "put_wait_get.s" Print put_wait_get_asm.
   (*
     put_wait_get:
      addi    x2, x2, -84   // decrease stack pointer

--- a/investigations/bedrock2/IncrementWait/IncrementWaitToRiscVProperties.v
+++ b/investigations/bedrock2/IncrementWait/IncrementWaitToRiscVProperties.v
@@ -1,0 +1,181 @@
+Require Import Coq.derive.Derive.
+Require Import Coq.Strings.String.
+Require Import Coq.ZArith.ZArith.
+Require Import bedrock2.Map.Separation.
+Require Import bedrock2.Map.SeparationLogic.
+Require Import bedrock2.MetricLogging.
+Require Import bedrock2.ProgramLogic.
+Require Import bedrock2.Semantics.
+Require Import bedrock2.Scalars.
+Require Import bedrock2.Syntax.
+Require Import bedrock2.WeakestPreconditionProperties.
+Require Import compiler.FlatToRiscvCommon.
+Require Import compiler.Pipeline.
+Require Import Bedrock2Experiments.List.
+Require Import Bedrock2Experiments.Tactics.
+Require Import Bedrock2Experiments.IncrementWait.Constants.
+Require Import Bedrock2Experiments.IncrementWait.IncrementWait.
+Require Import Bedrock2Experiments.IncrementWait.IncrementWaitMMIO.
+Require Import Bedrock2Experiments.IncrementWait.IncrementWaitProperties.
+Require Import Bedrock2Experiments.IncrementWait.IncrementWaitSemantics.
+Require Import Bedrock2Experiments.IncrementWait.IncrementWaitToRiscV.
+Import Syntax.Coercions.
+Local Open Scope string_scope.
+
+Local Hint Resolve FlattenExpr.mk_Semantics_params_ok FlattenExpr_hyps : typeclass_instances.
+Existing Instances constant_words spec_of_put_wait_get.
+
+Instance consts_ok : constants_ok (constant_words (word_ok:=parameters.word_ok)).
+Proof.
+  constructor.
+  { reflexivity. }
+  { repeat constructor. }
+  { repeat constructor. }
+  { reflexivity. }
+  { repeat constructor. }
+Qed.
+
+Instance Pipeline_assumptions : Pipeline.assumptions.
+Proof.
+  constructor.
+  { apply MMIO.word_riscv_ok. }
+  { exact MMIO.funname_env_ok. }
+  { exact MMIO.locals_ok. }
+  { exact PR. }
+  { exact FlatToRiscv_hyps. }
+  { exact ext_spec_ok. }
+  { exact compile_ext_call_correct. }
+  { reflexivity. }
+Qed.
+
+Definition post_main
+           (input output_placeholder : parameters.word) R
+           (t' : trace) (m' : Semantics.mem) : Prop :=
+  (* trace is valid and leads to IDLE state *)
+  execution t' IDLE
+  /\ (scalar (word.of_Z input_ptr) input
+     * scalar (word.of_Z output_ptr) (proc input)
+     * R)%sep m'.
+
+Local Ltac simplify_implicits :=
+  change semantics_parameters
+  with (FlattenExpr.mk_Semantics_params
+          Pipeline.FlattenExpr_parameters) in *.
+
+Lemma main_correct
+      fs input output_placeholder
+      R (t : @trace semantics_parameters) m l :
+  (scalar (word.of_Z input_ptr) input
+   * scalar (word.of_Z output_ptr) output_placeholder
+   * R)%sep m ->
+  execution t IDLE ->
+  WeakestPrecondition.cmd
+    (WeakestPrecondition.call (put_wait_get :: fs))
+    main_body t m l
+    (fun t' m' _ => post_main input output_placeholder R t' m').
+Proof.
+  intros. simplify_implicits.
+  repeat straightline.
+  pose proof (put_wait_get_correct
+                (consts:=constant_words (word_ok:=parameters.word_ok)) fs).
+  straightline_call; [ eassumption .. | ].
+  repeat straightline_with_map_lookup.
+  eexists; split; repeat straightline_with_map_lookup; [ ].
+  split; [ assumption | ].
+
+  (* change the implicit arguments of scalar to match hypothesis *)
+  lazymatch goal with
+  | H : sep _ _ ?m |- sep _ _ ?m =>
+    lazymatch type of H with
+    | context [(@scalar ?a1 ?b1 ?c1)] =>
+      lazymatch goal with
+      | |- context [(@scalar ?a2 ?b2 ?c2)] =>
+        change a2 with a1; change b2 with b1; change c2 with c1
+      end
+    end
+  end.
+  ecancel_assumption.
+Qed.
+
+Lemma exec_put_wait_get fs input output_placeholder R
+      (t : trace) (m : Semantics.mem) (l : Semantics.locals) mc :
+  (scalar (word.of_Z input_ptr) input
+   * scalar (word.of_Z output_ptr) output_placeholder
+   * R)%sep m ->
+  execution t IDLE ->
+  NoDup (map fst (main :: put_wait_get :: fs)) ->
+  exec (map.of_list (main :: put_wait_get :: fs))
+       main_body t m l mc
+       (fun t' m' _ _ => post_main input output_placeholder R t' m').
+Proof.
+  intros. apply sound_cmd; [ assumption | ].
+  apply main_correct; eauto.
+Qed.
+
+(* Location in the instructions that marks the start of the [main] routine *)
+Definition main_relative_pos : Z.
+  let x := constr:(map.get
+                     (snd (fst put_wait_get_compile_result))
+                     main) in
+  let x := eval vm_compute in x in
+      lazymatch x with
+      | Some ?y => exact y
+      end.
+Defined.
+
+Lemma put_wait_get_asm_correct
+      input output_placeholder R Rdata Rexec
+      (p_functions p_call : Utility.word)
+      (mem : Pipeline.mem)
+      (initial : MetricRiscvMachine) :
+  (* given that the input and output pointers are valid and the input pointer
+     points to input... *)
+  (scalar (word.of_Z input_ptr) input
+   * scalar (word.of_Z output_ptr) output_placeholder
+   * R)%sep mem ->
+  (* ...and the trace so far leads to an IDLE state... *)
+  execution (getLog initial) IDLE ->
+  (* ...and the current machine state is OK... *)
+  let instrs := fst (fst (put_wait_get_compile_result)) in
+  LowerPipeline.machine_ok
+    p_functions main_relative_pos
+    (stack_start ml) (stack_pastend ml)
+    instrs p_call p_call mem Rdata Rexec initial ->
+  (* ...then, after the [main] routine is executed... *)
+  runsTo initial
+         (fun final : MetricRiscvMachine =>
+            exists mem',
+              (* ...the postcondition of [main] holds on the new trace and
+                 memory... *)
+              post_main input output_placeholder R (getLog final) mem'
+              (* ...and the new machine state is OK *)
+              /\ LowerPipeline.machine_ok
+                  p_functions main_relative_pos
+                  (stack_start ml) (stack_pastend ml)
+                  instrs p_call (word.add p_call (word.of_Z 4)) mem' Rdata Rexec final).
+Proof.
+  intros.
+  let fs := constr:(map.of_list funcs) in
+  let fs := eval cbv [map.of_list put_wait_get main funcs] in fs in
+  eapply compiler_correct
+    with (functions:=fs)
+         (mc:=bedrock2.MetricLogging.EmptyMetricLog)
+         (f_entry_name := main)
+         (postH:=post_main input output_placeholder R).
+  { constructor; vm_compute; congruence. }
+  { cbv [ExprImp.valid_funs]. intros *.
+    rewrite !map.get_put_dec, map.get_empty.
+    repeat destruct_one_match; inversion 1; cbv [ExprImp.valid_fun].
+    all:ssplit.
+    all:apply dedup_NoDup_iff with (aeqb_spec:=String.eqb_spec).
+    all:reflexivity. }
+  { apply put_wait_get_compile_result_eq. }
+  { rewrite !map.get_put_dec, map.get_empty.
+    rewrite String.eqb_refl. reflexivity. }
+  { reflexivity. }
+  { vm_compute. congruence. }
+  { apply exec_put_wait_get with (fs:=[]); eauto.
+    apply dedup_NoDup_iff with (aeqb_spec:=String.eqb_spec).
+    reflexivity. }
+  { eauto. }
+Qed.

--- a/investigations/bedrock2/List.v
+++ b/investigations/bedrock2/List.v
@@ -1,0 +1,42 @@
+Require Import Coq.Lists.List.
+Require Import coqutil.Datatypes.List.
+Require Import coqutil.Decidable.
+Require Import coqutil.Tactics.Tactics.
+
+(* TODO: these lemmas should be merged upstream to coqutil *)
+
+Lemma dedup_length {A} (aeqb : A -> A -> bool) (aeqb_spec : EqDecider aeqb) l :
+  length (dedup aeqb l) <= length l.
+Proof.
+  induction l; [ reflexivity | ].
+  cbn [dedup]. destruct_one_match; cbn [length]; Lia.lia.
+Qed.
+
+Lemma dedup_NoDup_iff {A} (aeqb : A -> A -> bool) (aeqb_spec : EqDecider aeqb) l :
+  dedup aeqb l = l <-> NoDup l.
+Proof.
+  split.
+  { induction l; [ solve [constructor] | ].
+    cbn [dedup]. destruct_one_match.
+    { intro Heq. pose proof dedup_length aeqb _ l as Hlen.
+      rewrite Heq in Hlen. cbn [length] in *; Lia.lia. }
+    { inversion 1 as [Heq].
+      constructor; [ | rewrite Heq; solve [eauto] ].
+      intro Hin. rewrite Heq in Hin.
+      lazymatch goal with
+      | H : find (aeqb ?x) _ = None |- _ =>
+        eapply find_none in H; [ | eapply Hin ];
+          destr (aeqb x x)
+      end; congruence. } }
+  { induction l; [ reflexivity | ].
+    inversion 1; subst. cbn [dedup].
+    destruct_one_match; [ | rewrite IHl; solve [auto] ].
+    lazymatch goal with
+    | H : find (aeqb ?x) _ = Some _ |- _ =>
+      eapply find_some in H; destruct H
+    end.
+    lazymatch goal with
+      | H : context [aeqb ?x ?y] |- _ =>
+        destr (aeqb x y)
+    end; congruence. }
+Qed.


### PR DESCRIPTION
This PR builds on #792 to write a fully-instantiated correctness proof for the assembly code in the increment-wait minimal example, in order to make sure that everything ties together and all of the compiler proofs' preconditions are satisfied.
- Creates a `main` function that simply reads an input value from a constant location in memory, calls `put_wait_get`, and stores the output to another constant location in memory (the `main` function is not allowed to have arguments)
- Compiles the `main` function and the `put_wait_get` function together
- Proves that, if the input/output pointers are valid, a RISC-V machine executing the resulting assembly will remain in a valid state and satisfy the postcondition of `main` (which says that the circuit has returned to the IDLE state, the value at the input location has stayed the same, and the value at the output location in memory is now the result of incrementing the input value).