### PR TITLE
Update AES semantics to be compatible with compiler proofs

### DIFF
--- a/investigations/bedrock2/Aes/Aes.v
+++ b/investigations/bedrock2/Aes/Aes.v
@@ -6,6 +6,7 @@ Require Import bedrock2.Syntax.
 Require Import bedrock2.NotationsCustomEntry.
 Require Import bedrock2.ToCString.
 Require Import coqutil.Word.Interface.
+Require Import Bedrock2Experiments.StateMachineSemantics.
 Require Import Bedrock2Experiments.Aes.Constants.
 Require Import Bedrock2Experiments.Aes.AesSemantics.
 Import Syntax.Coercions List.ListNotations.

--- a/investigations/bedrock2/Aes/AesProperties.v
+++ b/investigations/bedrock2/Aes/AesProperties.v
@@ -67,128 +67,21 @@ Section Proofs.
     change Semantics.word_ok with parameters.word_ok in *;
     change Semantics.mem_ok with parameters.mem_ok in *.
 
-  (* alternate form of reg_addr_unique *)
-  Lemma reg_addr_neq r1 r2 : r1 <> r2 -> reg_addr r1 <> reg_addr r2.
-  Proof.
-    intros. intro Heq. apply reg_addr_unique in Heq. congruence.
-  Qed.
-
-  (* TODO: move to Util/List *)
-  Lemma existsb_nexists {A} (f : A -> bool) l : existsb f l = false <-> (forall x, In x l -> f x = false).
-  Proof.
-    split.
-    { induction l; intros; cbn [In existsb] in *; [ tauto | ].
-      repeat lazymatch goal with
-             | H : (_ || _)%bool = false |- _ => apply Bool.orb_false_iff in H; destruct H
-             | H : _ \/ _ |- _ => destruct H
-             | _ => subst; eauto; congruence
-             end. }
-    { induction l; intros; cbn [In existsb] in *; [ tauto | ].
-      rewrite IHl by auto. rewrite Bool.orb_false_r. eauto. }
-  Qed.
-
-  (*
-  Lemma addr_in_category_reg_addr r c :
-    addr_in_category (reg_addr r) c = reg_category_eqb c (reg_category r).
-  Proof.
-    cbv [addr_in_category].
-    case_eq (reg_category_eqb c (reg_category r)); intros.
-    { apply existsb_exists; exists r.
-      split; [ apply all_regs_complete | ].
-      apply Bool.andb_true_iff; split; [ apply word.eqb_eq; reflexivity | ].
-      congruence. }
-    { apply existsb_nexists; intro r2. intros.
-      apply Bool.andb_false_iff.
-      destr (word.eqb (reg_addr r) (reg_addr r2)).
-      { lazymatch goal with
-          H : reg_addr _ = reg_addr _ |- _ => apply reg_addr_unique in H end.
-        subst. tauto. }
-      { left. apply word.eqb_ne; auto. } }
-  Qed.
-
-  Lemma nregs_populated_put rs r v cat :
-    reg_lookup rs r = None ->
-    nregs_populated (map.put rs (reg_addr r) v) cat =
-    if reg_category_eqb cat (reg_category r)
-    then S (nregs_populated rs cat)
-    else nregs_populated rs cat.
-  Proof.
-    cbv [nregs_populated reg_lookup]. intros.
-    rewrite map.fold_put; auto.
-    { rewrite addr_in_category_reg_addr. reflexivity. }
-    { intros. repeat destruct_one_match; reflexivity. }
-  Qed.
-
-  Lemma nregs_populated_remove rs r cat v :
-    reg_lookup rs r = Some v ->
-    nregs_populated (map.remove rs (reg_addr r)) cat =
-    if reg_category_eqb cat (reg_category r)
-    then (nregs_populated rs cat - 1)%nat
-    else nregs_populated rs cat.
-  Proof.
-    cbv [nregs_populated reg_lookup]. intros.
-    erewrite map.fold_remove with (m:=rs); eauto; [ | ].
-    { rewrite addr_in_category_reg_addr.
-      destruct_one_match; try reflexivity. lia. }
-    { intros. repeat destruct_one_match; reflexivity. }
-  Qed.
-
-  Lemma regs_empty_impl rs c r :
-    nregs_populated rs c = 0%nat ->
-    reg_category_eqb c (reg_category r) = true ->
-    reg_lookup rs r = None.
-  Proof.
-    intros. revert dependent rs.
-    cbv [nregs_populated].
-    apply (map.fold_spec (fun rs count => count = 0%nat -> reg_lookup rs r = None));
-      intros; [ apply map.get_empty | ].
-    cbv [reg_lookup] in *.
-    destruct_one_match_hyp; try congruence; [ ].
-    rewrite map.get_put_dec.
-    destruct_one_match; subst; [ | tauto ].
-    rewrite addr_in_category_reg_addr in *.
-    congruence.
-  Qed.
-
-  Lemma regs_lookup_put rs r1 r2 v :
-    r1 <> r2 -> reg_lookup rs r1 = None ->
-    reg_lookup (map.put rs (reg_addr r2) v) r1 = None.
-  Proof.
-    cbv [reg_lookup]. intros.
-    rewrite map.get_put_diff by (apply reg_addr_neq; congruence).
-    assumption.
-  Qed.
-
-  Lemma unset_inp_regs_put rs r v :
-    unset_inp_regs (map.put rs (reg_addr r) v) =
-    if (reg_category_eqb DataInReg (reg_category r)
-        || reg_category_eqb IVReg (reg_category r)
-        || reg_category_eqb KeyReg (reg_category r))%bool
-    then unset_inp_regs rs
-    else map.put (unset_inp_regs rs) (reg_addr r) v.
-  Proof.
-    cbv [unset_inp_regs]. apply map.map_ext; intros.
-    destruct_one_match.
-    { rewrite !map.get_remove_dec.
-      repeat (destruct_one_match; try reflexivity); [ ].
-      apply map.get_put_diff.
-      destruct r; cbn [reg_category reg_category_eqb orb] in *; congruence. }
-    { repeat lazymatch goal with H : (_ || _)%bool = false |- _ =>
-                                 apply Bool.orb_false_iff in H; destruct H end.
-      repeat lazymatch goal with
-               | |- context [map.get (map.put _ _ _) _] => rewrite map.get_put_dec
-               | |- context [map.get (map.remove _ _) _] => rewrite map.get_remove_dec
-               | H : reg_addr _ = reg_addr _ |- _ =>
-                 apply reg_addr_unique in H; subst;
-                   cbn [reg_category reg_category_eqb] in *; try congruence
-               | _ => destruct_one_match; subst; try reflexivity
-               end. }
-  Qed.
-   *)
   (* tactic to solve the side conditions of interact_read and interact_write *)
   Local Ltac solve_dexprs ::=
     repeat straightline_with_map_lookup;
     simplify_implicits; repeat straightline_with_map_lookup.
+
+  (* tactic to simplify side conditions in terms of [dexpr] *)
+  Local Ltac dexpr_hammer :=
+    subst_lets; simplify_implicits;
+    repeat first [ progress push_unsigned
+                 | rewrite word.unsigned_of_Z in *
+                 | rewrite word.wrap_small in * by lia
+                 | destruct_one_match
+                 | lia
+                 | progress ring_simplify
+                 | reflexivity ].
 
   Lemma execution_unique (t : trace) s1 s2 :
     execution t s1 ->
@@ -220,8 +113,11 @@ Section Proofs.
     all:logical_simplify; subst.
     all:lazymatch goal with
         | H : False |- _ => contradiction H
-        | _ => reflexivity
+        | H1 : ?x = Some ?a, H2 : ?x = Some ?b |- _ =>
+          rewrite H1 in H2; inversion H2; clear H2; subst
+        | _ => idtac
         end.
+    all:reflexivity.
   Qed.
 
   Local Ltac infer_states_equal :=
@@ -242,12 +138,80 @@ Section Proofs.
     repeat first [ progress infer_states_equal
                  | progress infer_state_data_equal ].
 
+  (* TODO: lots of annoying bit arithmetic here, maybe try to clean it up *)
   Lemma status_read_always_ok s :
     exists val s', read_step s STATUS val s'.
   Proof.
-    destruct s; cbn [read_step reg_category].
-    all:do 2 eexists.
-  Admitted. (* TODO *)
+    assert (forall x y : parameters.word,
+               word.slu (word.of_Z 1) x <> word.slu (word.of_Z 1) y -> x <> y)
+           as Hshift_neq by (intros; subst; congruence).
+    pose proof status_flags_unique_and_nonzero as Hflags.
+    simplify_unique_words_in Hflags.
+    repeat match goal with
+           | H : _ |- _ => apply Hshift_neq in H
+           end.
+    pose proof status_flags_inbounds as Hbounds.
+    repeat lazymatch goal with
+           | H : Forall _ (_ :: _) |- _ =>
+             pose proof (Forall_inv H);
+               apply Forall_inv_tail in H
+           | H : Forall _ [] |- _ => clear H
+           end.
+    cbv beta in *.
+    destruct s; cbn [read_step reg_category status_matches_state].
+    { exists (word.of_Z 0). eexists; ssplit; [ | reflexivity ].
+      cbv [is_flag_set]. boolsimpl.
+      rewrite !word.eqb_eq; [ reflexivity | apply word.unsigned_inj .. ].
+      all:push_unsigned; rewrite Z.land_0_l; reflexivity. }
+    { exists (word.or (word.slu (word.of_Z 1) AES_STATUS_IDLE)
+                 (word.slu (word.of_Z 1) AES_STATUS_INPUT_READY)).
+      eexists; ssplit; [ | reflexivity ].
+      cbv [is_flag_set]. boolsimpl.
+      repeat lazymatch goal with
+             | |- (_ && _)%bool = true => apply Bool.andb_true_iff; split
+             | |- negb _ = true => apply Bool.negb_true_iff
+             end.
+      all:rewrite word.unsigned_eqb.
+      all:first [ apply Z.eqb_eq | apply Z.eqb_neq ].
+      all:try lazymatch goal with
+              | |- word.unsigned (word.and ?x ?y) <> _ =>
+                let H := fresh in
+                assert (word.unsigned (word.and x y) = word.unsigned y)
+                  as H;
+                  [ | rewrite H; intro Heq; apply word.unsigned_inj in Heq;
+                      simplify_implicits; cbn in *; congruence ]
+              end.
+      all:push_unsigned; cbv [word.wrap]; rewrite <-!Z.land_ones by lia;
+        bitblast.Z.bitblast.
+      all:rewrite !Z_testbit_1_l;
+        repeat lazymatch goal with
+               | |- context [?x =? ?y] =>
+                 destr (x =? y)
+               end.
+      all:boolsimpl; try reflexivity.
+      all:subst.
+      all:lazymatch goal with
+          | H1 : ?i - word.unsigned ?x = 0,
+                 H2 : ?i - word.unsigned ?y = 0 |- _ =>
+            assert (x = y) by (apply word.unsigned_inj; lia)
+          end.
+      all:simplify_implicits; cbn in *; congruence. }
+    { exists (word.slu (word.of_Z 1) AES_STATUS_OUTPUT_VALID).
+      destruct data. rewrite is_flag_set_shift by (cbv [boolean]; tauto || lia).
+      rewrite word.eqb_ne by
+          (intro Heq; apply word.of_Z_inj_small in Heq; lia).
+      cbn [negb]. eauto. }
+    { exists (word.slu (word.of_Z 1) AES_STATUS_OUTPUT_VALID).
+      eexists; split; [ | reflexivity ].
+      rewrite is_flag_set_shift by (cbv [boolean]; tauto || lia).
+      rewrite word.eqb_ne by
+          (intro Heq; apply word.of_Z_inj_small in Heq; lia).
+      rewrite !is_flag_set_shift_neq by
+          (cbv [boolean];
+           first [ tauto | lia
+                   | intro; cbn in *; simplify_implicits; congruence ]).
+      reflexivity. }
+  Qed.
 
   (* solve common side conditions from interactions *)
   Local Ltac post_interaction :=
@@ -301,6 +265,7 @@ Section Proofs.
       eauto.
     cbv [write_step]. cbn [reg_category].
     exists s; destruct s; try contradiction;
+      repeat destruct_one_match;
       eexists; ssplit; (assumption || reflexivity).
   Qed.
 
@@ -370,10 +335,108 @@ Section Proofs.
       exists (IDLE rs). eexists; ssplit; eauto. }
   Qed.
 
+  Definition data_in_from_index (i : nat) : Register :=
+    nth i [DATA_IN0;DATA_IN1;DATA_IN2;DATA_IN3] CTRL.
+
+  Lemma data_in_from_index_category i :
+    (i < 4)%nat -> reg_category (data_in_from_index i) = DataInReg.
+  Proof.
+    intros. cbv [data_in_from_index].
+    apply Forall_nth; [ | length_hammer ].
+    repeat constructor.
+  Qed.
+
+  Lemma interact_write_data_in i call addre vale t m l
+        (post : trace -> mem -> locals -> Prop) rs addr val :
+    dexprs m l [addre; vale] [addr; val] ->
+    addr = word.add AES_DATA_IN0 (word.mul (word.of_Z (Z.of_nat i)) (word.of_Z 4)) ->
+    (i < 4)%nat ->
+    execution t (IDLE rs) ->
+    (forall s',
+        write_step (IDLE rs) (data_in_from_index i) val s' ->
+        (* implied by other preconditions but convenient to have separately *)
+        execution ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t) s' ->
+        post ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t)
+             m l) ->
+    cmd call (cmd.interact [] WRITE [addre;vale]) t m l post.
+  Proof.
+    intros; eapply interact_write; intros; infer;
+      cbv [parameters.write_step state_machine_parameters] in *;
+      eauto.
+    { repeat (destruct i; try lia); subst; cbn; ring. }
+    { cbv [write_step]. rewrite data_in_from_index_category by lia.
+      exists (IDLE rs). destruct_one_match; eexists; ssplit; eauto. }
+  Qed.
+
+
+  Definition data_out_from_index (i : nat) : Register :=
+    nth i [DATA_OUT0;DATA_OUT1;DATA_OUT2;DATA_OUT3] CTRL.
+
+  Lemma data_out_from_index_category i :
+    (i < 4)%nat -> reg_category (data_out_from_index i) = DataOutReg.
+  Proof.
+    intros. cbv [data_out_from_index].
+    apply Forall_nth; [ | length_hammer ].
+    repeat constructor.
+  Qed.
+
+  Lemma interact_read_data_out i call addre bind t m l
+        (post : trace -> mem -> locals -> Prop) data addr val :
+    dexprs m l [addre] [addr] ->
+    addr = word.add AES_DATA_OUT0 (word.mul (word.of_Z (Z.of_nat i)) (word.of_Z 4)) ->
+    (i < 4)%nat ->
+    match data_out_from_index i with
+    | DATA_OUT0 => done_data_out0 data
+    | DATA_OUT1 => done_data_out1 data
+    | DATA_OUT2 => done_data_out2 data
+    | DATA_OUT3 => done_data_out3 data
+    | _ => None
+    end = Some val ->
+    execution t (DONE data) ->
+    (forall s' val,
+        read_step (DONE data) (data_out_from_index i) val s' ->
+        (* implied by other preconditions but convenient to have separately *)
+        execution ((map.empty, READ, [addr], (map.empty, [val])) :: t) s' ->
+        post ((map.empty, READ, [addr], (map.empty, [val])) :: t)
+             m (map.put l bind val)) ->
+    cmd call (cmd.interact [bind] READ [addre]) t m l post.
+  Proof.
+    intros; eapply interact_read with (r:=data_out_from_index i);
+      intros; infer;
+        cbv [parameters.read_step state_machine_parameters] in *;
+        eauto.
+    { repeat (destruct i; try lia); subst; cbn; ring. }
+    { cbv [read_step]. rewrite data_out_from_index_category by lia.
+      exists (DONE data). repeat (destruct i; try lia); subst.
+      all:cbn [data_out_from_index nth read_output_reg] in *.
+      all:match goal with H : _ = Some _ |- _ => rewrite H end.
+      all:do 2 eexists; ssplit; eauto. }
+  Qed.
+
+  Lemma get_aes_input_none data :
+    (idle_data_in0 data = None
+     \/ idle_data_in1 data = None
+     \/ idle_data_in2 data = None
+     \/ idle_data_in3 data = None) ->
+    get_aes_input data = None.
+  Proof.
+    cbv [get_aes_input]. destruct data; cbn; intros.
+    repeat lazymatch goal with
+           | H : _ \/ _ |- _ => destruct H
+           | H : ?x = None |- _ => rewrite H
+           end.
+    all:repeat destruct_one_match; reflexivity.
+  Qed.
+
+  (* apply interact_read_status and do some post-processing *)
   Local Ltac read_status :=
     eapply interact_read_status; [ try post_interaction .. | ].
+
+  (* apply interact_write_status and do some post-processing *)
   Local Ltac write_control :=
     eapply interact_write_control; [ try post_interaction .. | ].
+
+  (* apply interact_write_key and do some post-processing *)
   Local Ltac write_key :=
     eapply interact_write_key;
     [ try post_interaction ..
@@ -383,6 +446,9 @@ Section Proofs.
             cbv [write_step] in H;
             rewrite key_from_index_category in H by lia; subst
           end ].
+
+  (* apply interact_write_iv for the nth IV register, and do some
+     post-processing *)
   Local Ltac write_iv_n n :=
     eapply interact_write_iv with (i:=n);
     [ try post_interaction ..
@@ -392,44 +458,70 @@ Section Proofs.
             cbv [write_step] in H;
             rewrite iv_from_index_category in H by lia; subst
           end ].
-  (*
-  Local Ltac invert_read_step :=
-    lazymatch goal with
-    | H : read_step _ _ _ _ |- _ =>
-      cbv [read_step] in H; cbn [reg_category] in H
-    end;
-    logical_simplify; simplify_implicits;
-    repeat lazymatch goal with
-           | H : False |- _ => contradiction H
-           | Heq : nregs_populated _ ?c = _,
-                   H : context [nregs_populated (map.remove ?m _) ?c] |- _ =>
-             erewrite !nregs_populated_remove in H by eauto;
-               simplify_implicits; rewrite Heq in H;
-                 cbn [reg_category reg_category_eqb Nat.sub] in H
-           | H : S _ = O |- _ => lia
-           | H : O <> O |- _ => lia
-           | _ => first [ destruct_one_match_hyp
-                       | progress logical_simplify ]
-           end.
 
-  Local Ltac invert_write_step :=
-    lazymatch goal with
-    | H : write_step _ _ _ _ |- _ =>
-      cbv [write_step] in H; cbn [reg_category] in H
-    end;
-    repeat lazymatch goal with
-           | Hemp : nregs_populated _ ?c = 0%nat,
-                    H : context [nregs_populated (map.put _ _ _) ?c] |- _ =>
-             rewrite !nregs_populated_put in H
-               by (repeat (apply regs_lookup_put; [ congruence | ]);
-                   eauto using regs_empty_impl);
-             rewrite Hemp in H;
-             cbn [reg_category reg_category_eqb Nat.eqb] in H; subst
-           | H : False |- _ => contradiction H
-           | _ => first [ destruct_one_match_hyp
-                       | progress logical_simplify ]
-           end.
-   *)
+  (* apply interact_write_data_in for the nth DATA_IN register, and do some
+     post-processing *)
+  Local Ltac write_data_in_n n :=
+    eapply interact_write_data_in with (i:=n);
+    [ lazymatch goal with
+      | |- _ = word.add _ _ =>
+        subst_lets; simplify_implicits;
+        cbn [Z.of_nat Pos.of_succ_nat Pos.succ]; ring
+      | _ => idtac
+      end;
+      try post_interaction ..
+    | intros;
+      try lazymatch goal with
+          | H : write_step _ _ _ _ |- _ =>
+            cbv [write_step] in H;
+            rewrite data_in_from_index_category in H by lia; subst
+          end
+    ].
+
+  (* same as write_data_in_n but with extra processing to prove we didn't
+     transition to the BUSY state after the write because there are still
+     unwritten input registers *)
+  Local Ltac write_data_in_nonlast_n n :=
+    write_data_in_n n;
+    [ ..
+    | lazymatch goal with
+      | H : context [match get_aes_input ?d with _ => _ end] |- _ =>
+        cbn [data_in_from_index nth] in H;
+        rewrite get_aes_input_none in H
+          by (cbv [write_input_reg];
+              repeat match goal with H : ?x = None |- _ => rewrite H end;
+              tauto)
+      end
+    ].
+
+  (* apply interact_read_data_out for the nth DATA_OUT register, and do some
+     post-processing *)
+  Local Ltac read_data_out_n n :=
+    eapply interact_read_data_out with (i:=n);
+    [lazymatch goal with
+      | |- _ = word.add _ _ =>
+        subst_lets; simplify_implicits;
+        cbn [Z.of_nat Pos.of_succ_nat Pos.succ]; ring
+      | _ => idtac
+      end;
+      try post_interaction ..
+    | intros;
+      try lazymatch goal with
+          | H : read_step _ _ _ _ |- _ =>
+            cbv [read_step] in H;
+            rewrite data_out_from_index_category in H by lia;
+            cbn [read_step read_output_reg data_out_from_index nth] in H;
+            cbn [done_data_out0 done_data_out1 done_data_out2 done_data_out3] in H;
+            destruct H as [? [H ?]];
+            inversion H; clear H; subst
+          end
+    ];
+    (* try eauto on leftover side condtions now that evars have been filled
+       in *)
+    [
+      cbn [data_out_from_index nth done_data_out0 done_data_out1
+                               done_data_out2 done_data_out3];
+      eauto .. | ].
 
   Local Notation aes_op_t := (enum_member aes_op) (only parsing).
   Local Notation aes_mode_t := (enum_member aes_mode) (only parsing).
@@ -443,14 +535,6 @@ Section Proofs.
     select_bits ctrl AES_CTRL_KEY_LEN_OFFSET AES_CTRL_KEY_LEN_MASK.
   Definition ctrl_manual_operation (ctrl : parameters.word) : bool :=
     is_flag_set ctrl AES_CTRL_MANUAL_OPERATION.
-
-  Definition get_known_regs (s : state) : known_register_state :=
-    match s with
-    | UNINITIALIZED => map.empty
-    | IDLE rs => rs
-    | BUSY rs _ _ => rs
-    | DONE rs => rs
-    end.
 
   (* prevent [inversion] from exposing word.of_Z in constants *)
   Local Opaque constant_words.
@@ -468,10 +552,11 @@ Section Proofs.
         call function_env aes_data_ready tr m (aes_globals ++ args)
              (fun tr' m' rets =>
                 exists (status out : Semantics.word) (s' : state),
-                  (* trace has exactly one new read value *)
-                  tr' = (map.empty, READ, [AES_STATUS],(map.empty,[status])) :: tr
-                  (* ...and there is a new state matching the new trace *)
-                  /\ execution tr' s'
+                  (* the new state matches the new trace *)
+                  execution tr' s'
+                  (* ...and there exists a single valid status-read step between
+                     the old and new state, and the read result was [status] *)
+                  /\ read_step s STATUS status s'
                   (* ...and all the same properties as before hold on the memory *)
                   /\ R m'
                   (* ...and there is one output value *)
@@ -507,10 +592,11 @@ Section Proofs.
         call function_env aes_data_valid tr m (aes_globals ++ args)
              (fun tr' m' rets =>
                 exists (status out : Semantics.word) (s' : state),
-                  (* trace has exactly one new read value *)
-                  tr' = (map.empty, READ, [AES_STATUS],(map.empty,[status])) :: tr
-                  (* ...and there is a new state matching the new trace *)
-                  /\ execution tr' s'
+                  (* the new state matches the new trace *)
+                  execution tr' s'
+                  (* ...and there exists a single valid status-read step between
+                     the old and new state, and the read result was [status] *)
+                  /\ read_step s STATUS status s'
                   (* ...and all the same properties as before hold on the memory *)
                   /\ R m'
                   (* ...and there is one output value *)
@@ -547,10 +633,11 @@ Section Proofs.
         call function_env aes_idle tr m (aes_globals ++ args)
              (fun tr' m' rets =>
                 exists (status out : Semantics.word) (s' : state),
-                  (* trace has exactly one new read value *)
-                  tr' = (map.empty, READ, [AES_STATUS],(map.empty,[status])) :: tr
-                  (* ...and there is a new state matching the new trace *)
-                  /\ execution tr' s'
+                  (* the new state matches the new trace *)
+                  execution tr' s'
+                  (* ...and there exists a single valid status-read step between
+                     the old and new state, and the read result was [status] *)
+                  /\ read_step s STATUS status s'
                   (* ...and all the same properties as before hold on the memory *)
                   /\ R m'
                   (* ...and there is one output value *)
@@ -578,18 +665,13 @@ Section Proofs.
 
   Global Instance spec_of_aes_init : spec_of aes_init :=
     fun function_env =>
-      forall s (tr : trace) (m : mem) (R : _ -> Prop)
+      forall (tr : trace) (m : mem) (R : _ -> Prop)
         aes_cfg_operation aes_cfg_mode aes_cfg_key_len
         aes_cfg_manual_operation,
         (* no special requirements of the memory *)
         R m ->
-        (* circuit must start in UNINITIALIZED or IDLE state *)
-        execution tr s ->
-        match s with
-        | UNINITIALIZED => True
-        | IDLE _ => True
-        | _ => False
-        end ->
+        (* circuit must start in UNINITIALIZED state *)
+        execution tr UNINITIALIZED ->
         (* operation must be in the aes_op enum *)
         aes_op_t aes_cfg_operation ->
         (* mode must be in the aes_mode enum *)
@@ -605,7 +687,10 @@ Section Proofs.
                 (* the circuit is in IDLE state with the correct control
                    register value and no other known register values *)
                 (exists ctrl,
-                    execution tr' (IDLE (map.put (get_known_regs s) AES_CTRL ctrl))
+                    execution tr' (IDLE (Build_idle_data ctrl None None None None
+                                                           None None None None
+                                                           None None None None
+                                                           None None None None))
                     /\ ctrl_operation ctrl = negb (word.eqb aes_cfg_operation (word.of_Z 0))
                     /\ ctrl_mode ctrl = aes_cfg_mode
                     /\ ctrl_key_len ctrl = aes_cfg_key_len
@@ -623,7 +708,7 @@ Section Proofs.
     (* initial processing *)
     repeat straightline.
 
-    write_control.
+    write_control; [ cbn iota; trivial | ].
     repeat straightline.
 
     (* simplify post-write guarantees *)
@@ -651,8 +736,7 @@ Section Proofs.
     (* split cases *)
     eexists; ssplit.
     { (* prove that the execution trace is OK *)
-      destruct_one_match_hyp; try contradiction;
-        subst; eassumption. }
+      subst; eassumption. }
     { (* prove that the "operation" flag is correct *)
       cbv [ctrl_operation].
       rewrite !is_flag_set_or_shiftl_low by lia.
@@ -673,8 +757,7 @@ Section Proofs.
 
   Global Instance spec_of_aes_key_put : spec_of aes_key_put :=
     fun function_env =>
-      forall (tr : trace) (m : mem) R
-        (rs : known_register_state)
+      forall (tr : trace) (m : mem) R (data : idle_data)
         (key_len key_arr_ptr : Semantics.word) (key_arr : list Semantics.word),
         (* key_len is a member of the aes_key_len enum *)
         aes_key_len_t key_len ->
@@ -685,53 +768,20 @@ Section Proofs.
                            then 4%nat else if word.eqb key_len kAes192
                                        then 6%nat else 8%nat) ->
         (* circuit must be in IDLE state *)
-        execution tr (IDLE rs) ->
+        execution tr (IDLE data) ->
         let args := [key_arr_ptr; key_len] in
         call function_env aes_key_put tr m (aes_globals ++ args)
              (fun tr' m' rets =>
                 (* the circuit is in IDLE state with the key registers updated *)
-                (exists rs',
-                    map.putmany_of_list_zip
-                      [reg_addr KEY0; reg_addr KEY1; reg_addr KEY2; reg_addr KEY3;
-                      reg_addr KEY4; reg_addr KEY5; reg_addr KEY6; reg_addr KEY7]
-                      (key_arr ++ repeat (word.of_Z 0) (8 - length key_arr)) rs
-                    = Some rs'
-                    /\ execution tr' (IDLE rs'))
+                execution tr'
+                          (IDLE (fold_left
+                                   (fun data i =>
+                                      write_input_reg (key_from_index i) data (nth i key_arr (word.of_Z 0)))
+                                   (seq 0 8) data))
                 (* ...and the same properties as before hold on the memory *)
                 /\ (array scalar32 (word.of_Z 4) key_arr_ptr key_arr * R)%sep m'
                 (* ...and there is no output *)
                 /\ rets = []).
-
-  Local Ltac dexpr_hammer :=
-    subst_lets; simplify_implicits;
-    repeat first [ progress push_unsigned
-                 | rewrite word.unsigned_of_Z in *
-                 | rewrite word.wrap_small in * by lia
-                 | destruct_one_match
-                 | lia ].
-
-  (* TODO: move *)
-  Lemma map_putmany_of_list_zip_snoc {key value} {map : map.map key value}
-        ks vs k v m m' :
-    map.putmany_of_list_zip (map:=map) ks vs m = Some m' ->
-    map.putmany_of_list_zip (ks ++ [k]) (vs ++ [v]) m = Some (map.put m' k v).
-  Proof.
-    revert vs k v m m'; induction ks; destruct vs;
-      [ cbn; congruence | discriminate | discriminate | ].
-    intros. rewrite <-!app_comm_cons. cbn [map.putmany_of_list_zip].
-    auto.
-  Qed.
-
-  (* TODO: move *)
-  Lemma nth_firstn {A} (l : list A) i n d :
-    (i < n)%nat -> nth i (firstn n l) d = nth i l d.
-  Proof.
-    revert l i d. induction n; [ lia | ].
-    destruct l; [ reflexivity | ].
-    destruct i; [ reflexivity | ].
-    cbn [firstn nth]; intros.
-    apply IHn. lia.
-  Qed.
 
   Lemma aes_key_put_correct :
     program_logic_goal_for_function! aes_key_put.
@@ -800,12 +850,16 @@ Section Proofs.
            (invariant:=
               fun v tr' m' l' =>
                 (* the new state is the old one plus the first i keys *)
-                (exists rs',
-                    map.putmany_of_list_zip
-                      (map (fun i => reg_addr (key_from_index i))
-                           (seq 0 (length key_arr - v)))
-                      (firstn (length key_arr - v) key_arr) rs = Some rs'
-                    /\ execution (p:=state_machine_parameters) tr' (IDLE rs'))
+                execution
+                  (p:=state_machine_parameters) tr'
+                  (IDLE
+                     (fold_left
+                        (fun data i =>
+                           write_input_reg
+                             (key_from_index i) data
+                             (nth i key_arr (word.of_Z 0)))
+                        (seq 0 (length key_arr - v))
+                        data))
                 (* array accesses in bounds *)
                 /\ (0 < v <= length key_arr)%nat
                 (* locals are unaffected except for i *)
@@ -841,8 +895,7 @@ Section Proofs.
       | |- (_ <= _)%nat => lia
       | _ => idtac
       end.
-      cbn [firstn]. eexists; split; [ reflexivity | ].
-      eassumption. }
+      cbn [firstn fold_left]. eassumption. }
 
     { (* the body of the loop proves the invariant if it continues and the
          postcondition if it breaks *)
@@ -934,11 +987,9 @@ Section Proofs.
           replace (length key_arr - (v - 1))%nat
             with (S (length key_arr - v))%nat by lia
         end.
-        rewrite !firstn_succ_snoc with (d:=word.of_Z 0) by length_hammer.
-        eexists; ssplit; [ | eassumption ].
         autorewrite with pull_snoc natsimpl.
-        rewrite !hd_skipn.
-        auto using map_putmany_of_list_zip_snoc. }
+        rewrite <-!hd_skipn.
+        eassumption. }
 
       { (* "break" case; prove postcondition holds after the rest of the function *)
 
@@ -963,13 +1014,16 @@ Section Proofs.
         (* invariant *)
         exists (fun v tr' m' l' =>
              (* the new state is the old one plus the first i keys *)
-             (exists rs',
-                 map.putmany_of_list_zip
-                   (map (fun i => reg_addr (key_from_index i))
-                        (seq 0 (8 - v)))
-                   (key_arr ++ repeat (word.of_Z 0) (8 - v - length key_arr))
-                   rs = Some rs'
-                 /\ execution (p:=state_machine_parameters) tr' (IDLE rs'))
+             execution
+               (p:=state_machine_parameters) tr'
+               (IDLE
+                  (fold_left
+                     (fun data i =>
+                        write_input_reg
+                          (key_from_index i) data
+                          (nth i key_arr (word.of_Z 0)))
+                     (seq 0 (8 - v))
+                     data))
              (* bounds for # iterations *)
              /\ (v <= 8 - length key_arr)%nat
              (* locals are unaffected except for i *)
@@ -981,7 +1035,8 @@ Section Proofs.
         { (* invariant holds at loop start *)
           exists (8 - length key_arr)%nat. (* total # iterations *)
           replace (8 - (8 - length key_arr))%nat with (length key_arr) by lia.
-          rewrite Nat.sub_diag. cbn [repeat]. rewrite app_nil_r.
+          (*
+          rewrite Nat.sub_diag. cbn [repeat]. rewrite app_nil_r.*)
           ssplit;
           lazymatch goal with
             | |- ?m = map.put ?m _ _ =>
@@ -992,22 +1047,14 @@ Section Proofs.
             | _ => idtac
           end.
 
-          eexists; ssplit; [ | eassumption ].
-
-          assert (v = 1)%nat by lia.
           lazymatch goal with
-          | H : map.putmany_of_list_zip (map ?f (seq 0 ?n)) (firstn ?n ?vs) _ = Some _
-            |- context [map.putmany_of_list_zip ?ks ?vs ?m] =>
-            replace (map.putmany_of_list_zip ks vs m)
-              with (map.putmany_of_list_zip
-                      (map f (seq 0 (S n))) (firstn (S n) vs) m)
-                   by (autorewrite with push_firstn;
-                       repeat (f_equal; try lia))
+          | H : context [write_input_reg _ (fold_left _ (seq 0 ?n) _)]
+            |- context [fold_left _ (seq 0 ?m)] =>
+            replace (seq 0 m) with (seq 0 (S n)) by (f_equal; lia)
           end.
           autorewrite with pull_snoc natsimpl.
-          rewrite firstn_succ_snoc with (d:=word.of_Z 0) by length_hammer.
-          rewrite hd_skipn.
-          eauto using map_putmany_of_list_zip_snoc. }
+          rewrite <-!hd_skipn.
+          eassumption. }
 
         { (* the body of the loop proves the invariant if it continues and the
              postcondition if it breaks *)
@@ -1065,16 +1112,13 @@ Section Proofs.
             replace (8 - (v - 1))%nat
               with (S (8 - v))%nat by lia
           end.
-          rewrite (Nat.sub_succ_l (length key_arr) (8 - _)%nat) by lia.
 
           (* list simplifications *)
-          cbn [repeat]. rewrite repeat_cons, app_assoc.
-          autorewrite with pull_snoc.
+          autorewrite with pull_snoc natsimpl.
+          autorewrite with push_nth.
 
           (* solve *)
-          simplify_implicits.
-          eexists; ssplit; [ | eassumption ].
-          eauto using map_putmany_of_list_zip_snoc. }
+          eassumption. }
 
           { (* post-loop; given invariant and loop-break condition, prove
                postcondition holds after the rest of the function *)
@@ -1092,40 +1136,36 @@ Section Proofs.
             end.
 
             eexists; ssplit; eauto; [ ].
-            eexists; ssplit; eauto; [ ].
+
             lazymatch goal with
-            | H : map.putmany_of_list_zip ?ks1 ?vs1 ?m = Some ?m'
-              |- map.putmany_of_list_zip ?ks2 ?vs2 ?m = Some ?m' =>
-              replace ks2 with ks1;
-                [ replace vs2 with vs1; [ exact H | ] | ]
+            | H : context [fold_left _ (seq 0 (8 - ?v))] |- _ =>
+              replace (8 - v)%nat with 8%nat in H by lia
             end.
-            { repeat (f_equal; try lia). }
-            { lazymatch goal with |- context [(8-?v)%nat] =>
-                                  assert (v = 0)%nat by lia end.
-              subst. reflexivity. } } } } }
+            eassumption. } } } }
   Qed.
 
   Global Instance spec_of_aes_iv_put : spec_of aes_iv_put :=
     fun function_env =>
-      forall (tr : trace) (m : mem) R
-        (rs : known_register_state)
-        (iv_ptr iv0 iv1 iv2 iv3 : Semantics.word),
+      forall (tr : trace) (m : mem) R (data : idle_data)
+        (iv_ptr : Semantics.word) (iv_arr : list Semantics.word),
         (* iv array is in memory *)
-        (array scalar32 (word.of_Z 4) iv_ptr [iv0;iv1;iv2;iv3] * R)%sep m ->
+        (array scalar32 (word.of_Z 4) iv_ptr iv_arr * R)%sep m ->
+        (* iv array has 4 elements *)
+        length iv_arr = 4%nat ->
         (* circuit must be in IDLE state *)
-        execution tr (IDLE rs) ->
+        execution tr (IDLE data) ->
         let args := [iv_ptr] in
         call function_env aes_iv_put tr m (aes_globals ++ args)
              (fun tr' m' rets =>
                 (* the circuit is in IDLE state with the iv registers updated *)
                 execution tr'
-                          (IDLE (map.putmany_of_list
-                                   [(reg_addr IV0, iv0)
-                                    ; (reg_addr IV1, iv1)
-                                    ; (reg_addr IV2, iv2)
-                                    ; (reg_addr IV3, iv3)] rs))
+                          (IDLE (fold_left
+                                   (fun data i =>
+                                      write_input_reg (iv_from_index i) data
+                                                      (nth i iv_arr (word.of_Z 0)))
+                                   (seq 0 4) data))
                 (* ...and the same properties as before hold on the memory *)
-                /\ (array scalar32 (word.of_Z 4) iv_ptr [iv0;iv1;iv2;iv3] * R)%sep m'
+                /\ (array scalar32 (word.of_Z 4) iv_ptr iv_arr * R)%sep m'
                 (* ...and there is no output *)
                 /\ rets = []).
 
@@ -1137,6 +1177,7 @@ Section Proofs.
     simplify_implicits.
 
     (* simplify array predicate *)
+    destruct_lists_by_length.
     cbn [array] in *.
     repeat match goal with
            | H : context [scalar32 ?addr] |- _ =>
@@ -1186,244 +1227,39 @@ Section Proofs.
 
   Global Instance spec_of_aes_data_put : spec_of aes_data_put :=
     fun function_env =>
-      forall (tr : trace) (m : mem) R
-        (rs : known_register_state)
-        (data_ptr data0 data1 data2 data3 : Semantics.word),
-        (* data array is in memory *)
-        (array scalar32 (word.of_Z 4) data_ptr [data0;data1;data2;data3] * R)%sep m ->
+      forall (tr : trace) (m : mem) R (data : idle_data) all_aes_input
+        (input_ptr : Semantics.word) (input_arr : list Semantics.word),
+        (* input array is in memory *)
+        (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m ->
+        (* input array has 4 elements *)
+        length input_arr = 4%nat ->
         (* circuit must be in IDLE state *)
-        execution tr (IDLE rs) ->
-        (* the key and iv registers must be populated *)
-        nregs_populated rs KeyReg = 8%nat ->
-        nregs_populated rs IVReg = 4%nat ->
-        (* the data registers must *not* be populated *)
-        nregs_populated rs DataInReg = 0%nat ->
-        let args := [data_ptr] in
+        execution tr (IDLE data) ->
+        (* input-data registers must not be currently set *)
+        data.(idle_data_in0) = None ->
+        data.(idle_data_in1) = None ->
+        data.(idle_data_in2) = None ->
+        data.(idle_data_in3) = None ->
+        (* adding input-data registers must result in a full set of data
+           (i.e. key and iv registers are already set) *)
+        get_aes_input
+          (fold_left
+             (fun data i =>
+                write_input_reg (data_in_from_index i) data
+                                (nth i input_arr (word.of_Z 0)))
+             (seq 0 4) data) = Some all_aes_input ->
+        let args := [input_ptr] in
         call function_env aes_data_put tr m (aes_globals ++ args)
              (fun tr' m' rets =>
-                exists exp_out,
-                  (* the circuit is now in the BUSY state *)
-                  execution tr' (BUSY (unset_inp_regs rs) exp_out
-                                      timing.ndelays_core)
-                  (* ...and the expected output matches the AES spec for this data *)
-                  /\ aes_expected_output
-                      (map.putmany_of_list
-                         [(reg_addr DATA_IN0, data0)
-                          ; (reg_addr DATA_IN1, data1)
-                          ; (reg_addr DATA_IN2, data2)
-                          ; (reg_addr DATA_IN3, data3)] rs) = Some exp_out
-                  (* ...and the same properties as before hold on the memory *)
-                  /\ (array scalar32 (word.of_Z 4) data_ptr [data0;data1;data2;data3] * R)%sep m'
-                  (* ...and there is no output *)
-                  /\ rets = []).
-
-  Definition data_in_from_index (i : nat) : Register :=
-    nth i [DATA_IN0;DATA_IN1;DATA_IN2;DATA_IN3] CTRL.
-
-  Lemma data_in_from_index_category i :
-    (i < 4)%nat -> reg_category (data_in_from_index i) = DataInReg.
-  Proof.
-    intros. cbv [data_in_from_index].
-    apply Forall_nth; [ | length_hammer ].
-    repeat constructor.
-  Qed.
-
-  Lemma all_regs_in_category_complete c r :
-    reg_category r = c -> In r (all_regs_in_category c).
-  Proof.
-    destruct c, r; cbn [reg_category]; try discriminate; intros;
-      cbn; tauto.
-  Qed.
-
-  (* TODO: move *)
-  Lemma length_filter_le {A} (f : A -> bool) l :
-    (length (filter f l) <= length l)%nat.
-  Proof.
-    induction l; cbn [filter length]; [ lia | ].
-    destruct_one_match; length_hammer.
-  Qed.
-
-  (* TODO: move *)
-  Lemma filter_noop_forallb {A} (f : A -> bool) l :
-    length (filter f l) = length l <-> forallb f l = true.
-  Proof.
-    induction l; intros; [ cbn; tauto | ].
-    cbn [filter forallb].
-    destruct_one_match; cbn [andb length];
-      [ rewrite <-IHl; lia | ].
-    split; try discriminate; [ ].
-    pose proof (length_filter_le f l).
-    lia.
-  Qed.
-
-  Lemma nregs_populated_full rs c :
-    nregs_populated rs c = length (all_regs_in_category c) ->
-    forall r, reg_category r = c -> reg_lookup rs r <> None.
-  Proof.
-    cbv [nregs_populated]. rewrite filter_noop_forallb.
-    rewrite forallb_forall. intros Hlookup; intros.
-    specialize (Hlookup _ ltac:(eauto using all_regs_in_category_complete)).
-    destruct_one_match_hyp; congruence.
-  Qed.
-
-  Lemma aes_expected_output_exists rs :
-    nregs_populated rs ControlReg = 1%nat ->
-    nregs_populated rs KeyReg = 8%nat ->
-    nregs_populated rs IVReg = 4%nat ->
-    nregs_populated rs DataInReg = 4%nat ->
-    aes_expected_output rs <> None.
-  Proof.
-    intros.
-    cbv [aes_expected_output option_bind].
-    repeat
-      (destruct_one_match;
-       [ | repeat
-             lazymatch goal with
-             | H : reg_lookup _ _ = None |- None <> None =>
-               exfalso; eapply nregs_populated_full;
-               [ | solve [eauto] .. ]; cbn [reg_category]
-             | H : nregs_populated ?rs ?c = _
-               |- context [nregs_populated ?rs ?c] =>
-               rewrite H; reflexivity
-             end ]).
-    repeat destruct_pair_let. congruence.
-  Qed.
-
-  Lemma nregs_populated_put rs r v cat :
-    nregs_populated (map.put rs (reg_addr r) v) cat =
-    if reg_category_eqb cat (reg_category r)
-    then match reg_lookup rs r with
-         | None => S (nregs_populated rs cat)
-         | Some _ => nregs_populated rs cat
-         end
-    else nregs_populated rs cat.
-  Proof.
-    cbv [nregs_populated reg_lookup].
-    destruct cat.
-    all:cbn.
-    { destruct r; cbn [reg_category reg_addr].
-      { rewrite map.get_put_same.
-        destruct_one_match; reflexivity. }
-
-      destr (reg_category r);
-        lazymatch goal with
-          | H : reg_category _ = _ |- _ =>
-            apply all_regs_in_category_complete in H;
-              cbn in H
-        end.
-      2:{
-        rewrite map.get_put_diff.
-        Check all_regs_in_category_complete.
-        2:{
-      destruct r; cbn [reg_category reg_addr].
-      { rewrite map.get_put_dec.
-        rewrite word.eqb_refl.
-    cbv [nregs_populated reg_lookup]. intros.
-    rewrite map.fold_put; auto.
-    { rewrite addr_in_category_reg_addr. reflexivity. }
-    { intros. repeat destruct_one_match; reflexivity. }
-  Qed.
-
-  (* if the circuit is in any state except UNINITIALIZED, the control register
-     must exist *)
-  Lemma control_register_exists t s :
-    s <> UNINITIALIZED ->
-    execution t s ->
-    nregs_populated (get_known_regs s) ControlReg = 1%nat.
-  Proof.
-    revert s; induction t; [ cbn; congruence | ].
-    intros. cbn [execution] in *. destruct_products.
-    cbv [step] in *.
-    cbn [parameters.write_step
-           parameters.read_step state_machine_parameters] in *.
-    cbv [read_step write_step] in *.
-    repeat lazymatch goal with
-           | H : False |- _ => contradiction H
-           | _ => destruct_one_match_hyp;
-                   logical_simplify; subst
-           end.
-    all:cbn [get_known_regs].
-  Qed.
-
-  Lemma interact_write_data_in i call addre vale t m l
-        (post : trace -> mem -> locals -> Prop) rs addr val :
-    dexprs m l [addre; vale] [addr; val] ->
-    addr = word.add AES_DATA_IN0 (word.mul (word.of_Z (Z.of_nat i)) (word.of_Z 4)) ->
-    (i < 4)%nat ->
-    nregs_populated rs KeyReg = 8%nat ->
-    nregs_populated rs IVReg = 4%nat ->
-    (nregs_populated rs DataInReg < 4)%nat ->
-    execution t (IDLE rs) ->
-    (forall s',
-        write_step (IDLE rs) (data_in_from_index i) val s' ->
-        (* implied by other preconditions but convenient to have separately *)
-        execution ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t) s' ->
-        post ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t)
-             m l) ->
-    cmd call (cmd.interact [] WRITE [addre;vale]) t m l post.
-  Proof.
-    intros; eapply interact_write; intros; infer;
-      cbv [parameters.write_step state_machine_parameters] in *;
-      eauto.
-    { repeat (destruct i; try lia); subst; cbn; ring. }
-    { cbv [write_step]. rewrite data_in_from_index_category by lia.
-      exists (IDLE rs). destruct_one_match.
-      1:{ rewrite nregs_populated_put. lia.
-      destruct_one_match; [ | solve [eexists; eauto] ].
-      eexists.
-      Search nregs_populated.
-      2: eauto 10.
-      Search aes_expected_output.
-      exists (match s with
-      do 2 eexists; ssplit; eauto.
-      cbn beta iota. ssplit; try eauto.
-      destruct_one_match.
-      2:reflexivity.
-      exists (IDLE rs). eexists; ssplit; eauto. }
-  Qed.
-  Lemma interact_write_data_in i call addre vale t m l
-        (post : trace -> mem -> locals -> Prop) rs addr val :
-    dexprs m l [addre; vale] [addr; val] ->
-    addr = word.add AES_DATA_IN0 (word.mul (word.of_Z (Z.of_nat i)) (word.of_Z 4)) ->
-    (i < 4)%nat ->
-    nregs_populated rs KeyReg = 8%nat ->
-    nregs_populated rs IVReg = 4%nat ->
-    (nregs_populated rs DataInReg < 4)%nat ->
-    execution t (IDLE rs) ->
-    (forall s',
-        write_step (IDLE rs) (data_in_from_index i) val s' ->
-        (* implied by other preconditions but convenient to have separately *)
-        execution ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t) s' ->
-        post ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t)
-             m l) ->
-    cmd call (cmd.interact [] WRITE [addre;vale]) t m l post.
-  Proof.
-    intros; eapply interact_write; intros; infer;
-      cbv [parameters.write_step state_machine_parameters] in *;
-      eauto.
-    { repeat (destruct i; try lia); subst; cbn; ring. }
-    { cbv [write_step]. rewrite data_in_from_index_category by lia.
-      exists (IDLE rs). destruct_one_match; [ | solve [eexists; eauto] ].
-      eexists.
-      Search nregs_populated.
-      2: eauto 10.
-      Search aes_expected_output.
-      exists (match s with
-      do 2 eexists; ssplit; eauto.
-      cbn beta iota. ssplit; try eauto.
-      destruct_one_match.
-      2:reflexivity.
-      exists (IDLE rs). eexists; ssplit; eauto. }
-  Qed.
-  Local Ltac write_data_in_n n :=
-    eapply interact_write_data_in with (i:=n);
-    [ try post_interaction ..
-    | intros;
-      try lazymatch goal with
-          | H : write_step _ _ _ _ |- _ =>
-            cbv [write_step] in H;
-            rewrite data_in_from_index_category in H by lia; subst
-          end ].
+                (* the circuit is now in the BUSY state *)
+                execution tr' (BUSY (Build_busy_data
+                                       (idle_ctrl data)
+                                       (aes_expected_output all_aes_input)
+                                       timing.ndelays_core))
+                (* ...and the same properties as before hold on the memory *)
+                /\ (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m'
+                (* ...and there is no output *)
+                /\ rets = []).
 
   Lemma aes_data_put_correct :
     program_logic_goal_for_function! aes_data_put.
@@ -1433,6 +1269,7 @@ Section Proofs.
     simplify_implicits.
 
     (* simplify array predicate *)
+    destruct_lists_by_length.
     cbn [array] in *.
     repeat match goal with
            | H : context [scalar32 ?addr] |- _ =>
@@ -1451,28 +1288,25 @@ Section Proofs.
 
     (* i = 0 *)
     split; repeat straightline; [ dexpr_hammer | ].
-    interaction_with_reg DATA_IN0.
-    infer; subst; clear_old_executions.
-    repeat straightline.
-
+    write_data_in_nonlast_n 0%nat. repeat straightline.
 
     (* i = 1 *)
     split; repeat straightline; [ dexpr_hammer | ].
-    interaction_with_reg DATA_IN1.
-    infer; subst; clear_old_executions.
-    repeat straightline.
+    write_data_in_nonlast_n 1%nat. repeat straightline.
 
     (* i = 2 *)
     split; repeat straightline; [ dexpr_hammer | ].
-    interaction_with_reg DATA_IN2.
-    infer; subst; clear_old_executions.
-    repeat straightline.
+    write_data_in_nonlast_n 2%nat. repeat straightline.
 
     (* i = 3 *)
     split; repeat straightline; [ dexpr_hammer | ].
-    interaction_with_reg DATA_IN3.
-    infer; subst; clear_old_executions.
-    repeat straightline.
+    write_data_in_n 3%nat. repeat straightline.
+    lazymatch goal with
+    | H1 : get_aes_input (fold_left _ _ _) = Some _,
+      H2 : context [match get_aes_input _ with _ => _ end] |- _ =>
+      cbn [fold_left seq nth data_in_from_index] in H1, H2;
+        rewrite H1 in H2
+    end.
 
     (* i = 4; loop done *)
     ssplit; repeat straightline; [ dexpr_hammer | ].
@@ -1484,13 +1318,7 @@ Section Proofs.
              progress ring_simplify addr
            end.
 
-    eexists; ssplit; eauto; [ ].
-    (* find and apply execution hypothesis by asserting states are equal *)
-    lazymatch goal with H : execution ?t ?s1 |- execution ?t ?s2 =>
-                        let H' := fresh in
-                        assert (s2 = s1) as H'; [ | rewrite H'; apply H ]
-    end.
-    rewrite !unset_inp_regs_put. reflexivity.
+    ssplit; eauto.
   Qed.
 
   (* TODO: the real state machine is slightly more complex; AES block can get
@@ -1499,36 +1327,39 @@ Section Proofs.
      exactly the same as aes_data_put. *)
   Global Instance spec_of_aes_data_put_wait : spec_of aes_data_put_wait :=
     fun function_env =>
-      forall (tr : trace) (m : mem) R
-        (rs : known_register_state)
-        (data_ptr data0 data1 data2 data3 : Semantics.word),
-        (* data array is in memory *)
-        (array scalar32 (word.of_Z 4) data_ptr [data0;data1;data2;data3] * R)%sep m ->
+      forall (tr : trace) (m : mem) R (data : idle_data) all_aes_input
+        (input_ptr : Semantics.word) (input_arr : list Semantics.word),
+        (* input array is in memory *)
+        (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m ->
+        (* input array has 4 elements *)
+        length input_arr = 4%nat ->
         (* circuit must be in IDLE state *)
-        execution tr (IDLE rs) ->
-        (* the key and iv registers must be populated *)
-        nregs_populated rs KeyReg = 8%nat ->
-        nregs_populated rs IVReg = 4%nat ->
-        (* the data registers must *not* be populated *)
-        nregs_populated rs DataInReg = 0%nat ->
-        let args := [data_ptr] in
+        execution tr (IDLE data) ->
+        (* input-data registers must not be currently set *)
+        data.(idle_data_in0) = None ->
+        data.(idle_data_in1) = None ->
+        data.(idle_data_in2) = None ->
+        data.(idle_data_in3) = None ->
+        (* adding input-data registers must result in a full set of data
+           (i.e. key and iv registers are already set) *)
+        get_aes_input
+          (fold_left
+             (fun data i =>
+                write_input_reg (data_in_from_index i) data
+                                (nth i input_arr (word.of_Z 0)))
+             (seq 0 4) data) = Some all_aes_input ->
+        let args := [input_ptr] in
         call function_env aes_data_put_wait tr m (aes_globals ++ args)
              (fun tr' m' rets =>
-                exists exp_out,
-                  (* the circuit is now in the BUSY state *)
-                  execution tr' (BUSY (unset_inp_regs rs) exp_out
-                                      timing.ndelays_core)
-                  (* ...and the expected output matches the AES spec for this data *)
-                  /\ aes_expected_output
-                      (map.putmany_of_list
-                         [(reg_addr DATA_IN0, data0)
-                          ; (reg_addr DATA_IN1, data1)
-                          ; (reg_addr DATA_IN2, data2)
-                          ; (reg_addr DATA_IN3, data3)] rs) = Some exp_out
-                  (* ...and the same properties as before hold on the memory *)
-                  /\ (array scalar32 (word.of_Z 4) data_ptr [data0;data1;data2;data3] * R)%sep m'
-                  (* ...and there is no output *)
-                  /\ rets = []).
+                (* the circuit is now in the BUSY state *)
+                execution tr' (BUSY (Build_busy_data
+                                       (idle_ctrl data)
+                                       (aes_expected_output all_aes_input)
+                                       timing.ndelays_core))
+                (* ...and the same properties as before hold on the memory *)
+                /\ (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m'
+                (* ...and there is no output *)
+                /\ rets = []).
 
   Lemma aes_data_put_wait_correct :
     program_logic_goal_for_function! aes_data_put_wait.
@@ -1548,30 +1379,19 @@ Section Proofs.
 
     (* simplify guarantees *)
     logical_simplify; subst.
-    lazymatch goal with
-    | H : execution (_ :: _) _ |- _ =>
-      pose proof H; apply invert1_execution in H; logical_simplify
-    end.
-    invert_step; subst.
-    cbn [parameters.reg_addr parameters.write_step parameters.read_step
-                             state_machine_parameters] in *.
-    infer; subst.
-    (* assert that the register address we just read is STATUS *)
-    lazymatch goal with
-    | H : reg_addr ?r = AES_STATUS |- _ =>
-      apply (reg_addr_unique r STATUS) in H; subst
-    end.
-    cbv [status_matches_state] in *. simplify_implicits.
+    cbn [read_step reg_category] in *.
+    cbv [status_matches_state] in *.
+    logical_simplify; simplify_implicits.
     repeat match goal with
            | H : (_ && _)%bool = true |- _ => apply Bool.andb_true_iff in H; destruct H
            | H : word.eqb _ _ = _ |- _ => apply word.eqb_false in H
            | H : is_flag_set _ _  = _ |- _ => progress rewrite H in *
            end.
+    subst.
 
     (* loop done *)
     repeat straightline.
-    split; repeat straightline; [ dexpr_hammer; try congruence; reflexivity | ].
-    split; repeat straightline; [ dexpr_hammer | ].
+    split; repeat straightline; [ dexpr_hammer; congruence | ].
 
     (* call aes_data_put *)
     straightline_call; eauto; [ ].
@@ -1585,36 +1405,31 @@ Section Proofs.
 
   Global Instance spec_of_aes_data_get : spec_of aes_data_get :=
     fun function_env =>
-      forall (tr : trace) (m : mem) R
-        (rs : known_register_state)
-        (data_ptr data0 data1 data2 data3 : Semantics.word),
-        (* data array is in memory, with arbitrary values *)
-        (array scalar32 (word.of_Z 4) data_ptr [data0;data1;data2;data3] * R)%sep m ->
+      forall (tr : trace) (m : mem) R (data : done_data)
+        (data_ptr out0 out1 out2 out3 : Semantics.word)
+        (data_arr : list Semantics.word),
+        (* data array is in memory, with arbitrary initital values *)
+        (array scalar32 (word.of_Z 4) data_ptr data_arr * R)%sep m ->
+        length data_arr = 4%nat ->
         (* circuit must be in the DONE state *)
-        execution tr (DONE rs) ->
-        (* the output data registers must be populated *)
-        nregs_populated rs DataOutReg = 4%nat ->
+        execution tr (DONE data) ->
+        (* the output registers must all be populated *)
+        data.(done_data_out0) = Some out0 ->
+        data.(done_data_out1) = Some out1 ->
+        data.(done_data_out2) = Some out2 ->
+        data.(done_data_out3) = Some out3 ->
         let args := [data_ptr] in
         call function_env aes_data_get tr m (aes_globals ++ args)
              (fun tr' m' rets =>
-                exists out0 out1 out2 out3,
-                  (* the circuit is now in the IDLE state with output registers unset *)
-                  execution tr' (IDLE (map.remove
-                                         (map.remove
-                                            (map.remove
-                                               (map.remove rs
-                                                           (reg_addr DATA_OUT0))
-                                               (reg_addr DATA_OUT1))
-                                            (reg_addr DATA_OUT2))
-                                         (reg_addr DATA_OUT3)))
-                  (* ...and the array now holds the values from the output registers *)
-                  /\ (array scalar32 (word.of_Z 4) data_ptr [out0;out1;out2;out3] * R)%sep m'
-                  /\ reg_lookup rs DATA_OUT0 = Some out0
-                  /\ reg_lookup rs DATA_OUT1 = Some out1
-                  /\ reg_lookup rs DATA_OUT2 = Some out2
-                  /\ reg_lookup rs DATA_OUT3 = Some out3
-                  (* ...and there are no return values *)
-                  /\ rets = []).
+                (* the circuit is now in the IDLE state with output registers unset *)
+                execution tr' (IDLE (Build_idle_data
+                                       (done_ctrl data) None None None None None None None None
+                                       None None None None None None None None))
+                (* ...and the array now holds the values from the output registers *)
+                /\ (array scalar32 (word.of_Z 4) data_ptr [out0;out1;out2;out3] * R)%sep m'
+                (* ...and there are no return values *)
+                /\ rets = []).
+
 
   Lemma aes_data_get_correct :
     program_logic_goal_for_function! aes_data_get.
@@ -1624,6 +1439,7 @@ Section Proofs.
     simplify_implicits.
 
     (* simplify array predicate *)
+    destruct_lists_by_length.
     cbn [array] in *.
     repeat match goal with
            | H : context [scalar32 ?addr] |- _ =>
@@ -1640,13 +1456,18 @@ Section Proofs.
 
     (* process each iteration of the while loop *)
 
+    destruct data;
+      cbn [AesSemantics.done_ctrl
+             AesSemantics.done_data_out0
+             AesSemantics.done_data_out1
+             AesSemantics.done_data_out2
+             AesSemantics.done_data_out3] in *; subst.
+
     (* i = 0 *)
     split; repeat straightline; [ dexpr_hammer | ].
 
     (* read register *)
-    interaction_with_reg DATA_OUT0.
-    infer; subst; clear_old_executions.
-    repeat straightline.
+    read_data_out_n 0%nat. repeat straightline.
 
     (* store result in memory *)
     simplify_implicits.
@@ -1661,26 +1482,7 @@ Section Proofs.
     split; repeat straightline; [ dexpr_hammer | ].
 
     (* read register *)
-    interaction_with_reg DATA_OUT1.
-    infer; subst; clear_old_executions.
-    repeat straightline.
-
-    (* store result in memory *)
-    simplify_implicits.
-    ring_simplify_store_addr.
-    (* the following line is in [straightline] but needs simplify_implicits for
-       it to work *)
-    eapply store_four_of_sep_32bit;
-      [ reflexivity | simplify_implicits; solve [ ecancel_assumption ] |  ].
-    repeat straightline.
-
-    (* i = 2 *)
-    split; repeat straightline; [ dexpr_hammer | ].
-
-    (* read register *)
-    interaction_with_reg DATA_OUT2.
-    infer; subst; clear_old_executions.
-    repeat straightline.
+    read_data_out_n 1%nat. repeat straightline.
 
     (* store result in memory *)
     simplify_implicits.
@@ -1695,9 +1497,22 @@ Section Proofs.
     split; repeat straightline; [ dexpr_hammer | ].
 
     (* read register *)
-    interaction_with_reg DATA_OUT3.
-    infer; subst; clear_old_executions.
+    read_data_out_n 2%nat. repeat straightline.
+
+    (* store result in memory *)
+    simplify_implicits.
+    ring_simplify_store_addr.
+    (* the following line is in [straightline] but needs simplify_implicits for
+       it to work *)
+    eapply store_four_of_sep_32bit;
+      [ reflexivity | simplify_implicits; solve [ ecancel_assumption ] |  ].
     repeat straightline.
+
+    (* i = 3 *)
+    split; repeat straightline; [ dexpr_hammer | ].
+
+    (* read register *)
+    read_data_out_n 3%nat. repeat straightline.
 
     (* store result in memory *)
     simplify_implicits.
@@ -1718,45 +1533,34 @@ Section Proofs.
              progress ring_simplify addr
            end.
 
-    (* change register lookups to refer to original register state *)
-    repeat lazymatch goal with
-           | H : reg_lookup (map.remove _ _) _ = Some _ |- _ =>
-             cbv [reg_lookup] in H;
-               rewrite !map.get_remove_dec in H;
-               rewrite !word.eqb_ne in H by (apply reg_addr_neq; congruence)
-           end.
-
-    do 4 eexists; ssplit; eauto; [ ].
+    ssplit; eauto; [ ].
     simplify_implicits.
     ecancel_assumption.
   Qed.
 
-  Definition output_matches_state out s :=
+  Definition output_matches_state (out : aes_output) (s : state) : Prop :=
     match s with
-    | DONE rs =>
-      reg_lookup rs DATA_OUT0 = Some out.(data_out0)
-      /\ reg_lookup rs DATA_OUT1 = Some out.(data_out1)
-      /\ reg_lookup rs DATA_OUT2 = Some out.(data_out2)
-      /\ reg_lookup rs DATA_OUT3 = Some out.(data_out3)
-    | BUSY _ exp_output _ => exp_output = out
+    | BUSY data => busy_exp_output data = out
+    | DONE data =>
+      data = done_data_from_output (done_ctrl data) out
     | _ => False
     end.
 
-  Definition get_register_state s : known_register_state :=
+  Definition get_ctrl (s : state) : Semantics.word :=
     match s with
-    | DONE rs => rs
-    | BUSY rs _ _ => rs
-    | IDLE rs => rs
-    | UNINITIALIZED => map.empty
+    | UNINITIALIZED => word.of_Z 0 (* dummy value *)
+    | IDLE data => idle_ctrl data
+    | BUSY data => busy_ctrl data
+    | DONE data => done_ctrl data
     end.
 
   Global Instance spec_of_aes_data_get_wait : spec_of aes_data_get_wait :=
     fun function_env =>
-      forall (tr : trace) (m : mem) R
-        (out : aes_output)
-        (data_ptr data0 data1 data2 data3 : Semantics.word) (s : state),
-        (* data array is in memory, with arbitrary values *)
-        (array scalar32 (word.of_Z 4) data_ptr [data0;data1;data2;data3] * R)%sep m ->
+      forall (tr : trace) (m : mem) R (out : aes_output)
+        (data_ptr : Semantics.word) (data_arr : list Semantics.word) (s : state),
+        (* data array is in memory, with arbitrary initital values *)
+        (array scalar32 (word.of_Z 4) data_ptr data_arr * R)%sep m ->
+        length data_arr = 4%nat ->
         (* circuit must be in the DONE or BUSY state (otherwise we can't prove
            termination) and expected or already-written output matches out *)
         execution tr s ->
@@ -1765,14 +1569,9 @@ Section Proofs.
         call function_env aes_data_get_wait tr m (aes_globals ++ args)
              (fun tr' m' rets =>
                 (* the circuit is now in the IDLE state with output registers unset *)
-                execution tr' (IDLE (map.remove
-                                       (map.remove
-                                          (map.remove
-                                             (map.remove (get_register_state s)
-                                                         (reg_addr DATA_OUT0))
-                                             (reg_addr DATA_OUT1))
-                                          (reg_addr DATA_OUT2))
-                                       (reg_addr DATA_OUT3)))
+                execution tr' (IDLE (Build_idle_data (get_ctrl s) None None None None
+                                                     None None None None None None None None
+                                                     None None None None))
                 (* ...and the array now holds the values from the expected output *)
                 /\ (array scalar32 (word.of_Z 4) data_ptr
                          [out.(data_out0)
@@ -1782,110 +1581,6 @@ Section Proofs.
                 (* ...and there are no return values *)
                 /\ rets = []).
 
-  Lemma unset_inp_regs_ignores_outregs rs out :
-    aes_expected_output rs = Some out ->
-    nregs_populated (unset_inp_regs rs) DataOutReg = nregs_populated rs DataOutReg.
-  Proof.
-    cbv [unset_inp_regs]. cbv [aes_expected_output option_bind].
-    repeat (destruct_one_match; try congruence); [ ]. intros.
-    repeat (erewrite nregs_populated_remove
-             by (cbv [reg_lookup];
-                 rewrite ?map.get_remove_diff by (apply reg_addr_neq; congruence);
-                 eassumption);
-            cbn [reg_category reg_category_eqb]).
-    reflexivity.
-  Qed.
-
-  Lemma map_remove_put_same m k v :
-    map.remove (map:=parameters.regs) (map.put m k v) k = map.remove m k.
-  Proof.
-    apply map.map_ext; intros.
-    rewrite ?map.get_remove_dec, ?map.get_put_dec;
-      destruct_one_match; subst; reflexivity.
-  Qed.
-
-  Lemma map_remove_put_diff m k1 k2 v :
-    k1 <> k2 ->
-    map.remove (map:=parameters.regs) (map.put m k1 v) k2 = map.put (map.remove m k2) k1 v.
-  Proof.
-    intros. apply map.map_ext; intros.
-    rewrite ?map.get_remove_dec, ?map.get_put_dec, ?map.get_remove_dec;
-      repeat destruct_one_match; subst; congruence.
-  Qed.
-
-  (* if a put causes more registers to be populated, then the put must set a
-     register that was not previously set *)
-  Lemma nregs_populated_increase rs r v c :
-    (nregs_populated rs c
-     < nregs_populated (map.put rs (reg_addr r) v) c)%nat ->
-    reg_lookup rs r = None.
-  Proof.
-    cbv [nregs_populated reg_lookup]. intros.
-    destr (map.get rs (reg_addr r)); [ exfalso | reflexivity ].
-    erewrite map.fold_remove with (m:=rs) (k:=reg_addr r) in H;
-      [ | intros; repeat destruct_one_match; reflexivity | eassumption ].
-    erewrite map.fold_remove
-      with (m:=map.put rs _ _) (k:=reg_addr r) in H;
-      [ | intros; repeat destruct_one_match; reflexivity
-        | apply map.get_put_same ].
-    rewrite map_remove_put_same in *.
-    destruct_one_match_hyp; lia.
-  Qed.
-
-  Lemma nregs_populated_set_out_regs rs out :
-    nregs_populated (set_out_regs rs out) DataOutReg = 4%nat.
-  Proof.
-    cbv [set_out_regs nregs_populated].
-    repeat match goal with
-           | |- context [map.put _ ?key] =>
-             erewrite map.fold_remove with (k:=key);
-               [ | intros; repeat destruct_one_match; reflexivity
-                 | rewrite ?map.get_remove_diff, ?map.get_put_diff
-                   by (apply reg_addr_neq; congruence);
-                   apply map.get_put_same ];
-               rewrite addr_in_category_reg_addr; cbn [reg_category reg_category_eqb];
-                 rewrite ?map_remove_put_diff by (apply reg_addr_neq; congruence);
-                 rewrite map_remove_put_same
-           end.
-    repeat apply (f_equal S).
-    lazymatch goal with
-    | |- map.fold ?f ?r0 ?m = _ =>
-      let H' := fresh in
-      pose proof map.fold_to_list f r0 m as H';
-        destruct H' as [l [Heq Hin] ]; rewrite Heq;
-          rewrite <-(rev_involutive l)
-    end.
-    rewrite fold_left_rev_right.
-    eapply fold_left_invariant with (I:= eq 0%nat); auto; [ ].
-    intros. destruct_products; subst.
-    repeat lazymatch goal with
-           | H : In _ (rev _) |- _ => rewrite <-in_rev in H
-           | H : In (?k,?v) ?l |- _ => apply Hin in H
-           | H : context [map.get (map.remove _ _)] |- _ =>
-             rewrite map.get_remove_dec in H
-           end.
-    repeat (destruct_one_match_hyp; try congruence).
-    cbv [addr_in_category].
-    cbn [all_regs existsb reg_category reg_category_eqb].
-    boolsimpl. destruct_one_match; try reflexivity; [ ].
-    repeat lazymatch goal with
-           | H : (_ || _)%bool = true |- _ => apply Bool.orb_true_iff in H; destruct H
-           | H : word.eqb _ _ = true |- _ => apply word.eqb_true in H
-           | _ => congruence
-           end.
-  Qed.
-
-  Lemma output_matches_state_set_out_regs rs out :
-    output_matches_state out (DONE rs) ->
-    set_out_regs rs out = rs.
-  Proof.
-    cbv [output_matches_state reg_lookup].
-    intros; logical_simplify.
-    cbv [set_out_regs]. apply map.map_ext; intros.
-    rewrite !map.get_put_dec.
-    repeat destruct_one_match; congruence.
-  Qed.
-
   Lemma aes_data_get_wait_correct :
     program_logic_goal_for_function! aes_data_get_wait.
   Proof.
@@ -1893,68 +1588,179 @@ Section Proofs.
     repeat straightline.
     simplify_implicits.
 
-    set (max_iterations:=fun s : parameters.state =>
-                           match s with
-                           | BUSY _ _ n => n
-                           | DONE _ => 1%nat
-                           | _ => 0%nat
-                           end).
+    (* separate out cases where s is initially BUSY or DONE *)
+    cbv [output_matches_state] in *.
+    destruct s; try contradiction; [ | ].
 
-    (* begin while loop *)
-    let l := lazymatch goal with |- cmd _ _ _ _ ?l _ => l end in
-    apply atleastonce_localsmap
-      with (v0:=max_iterations s)
-           (lt:=lt)
-           (invariant:=
-              fun i tr' m' l' =>
-                exists (s' : parameters.state) is_valid,
-                  (* s' is the state for the new trace *)
-                  execution tr' s'
-                  (* the remaining maximum iterations match the "measure" i *)
-                  /\ max_iterations s' = i
-                  (* as long as the loop continues, we keep setting is_valid to
-                     0, so locals are unchanged until the loop breaks *)
-                  /\ l' = map.put l "is_valid" is_valid
-                  (* expected output still matches *)
-                  /\ output_matches_state out s'
-                  (* s' is related to s either by decrementing counter or being equal *)
-                  /\ match s with
-                    | BUSY rs out n => exists n', s' = BUSY rs out n'
-                    | DONE rs => s' = s
-                    | _ => False
-                    end
-                  (* memory is unaffected *)
-                  /\ (array scalar32 (word.of_Z 4) data_ptr [data0; data1; data2; data3] ⋆ R)%sep m').
-    { apply lt_wf. }
-
-    { (* case in which the loop breaks immediately (cannot happen) *)
-      repeat straightline.
-      exfalso. (* proof by contradiction *)
-
-      repeat lazymatch goal with
-             | v := word.of_Z 0 |- _ => subst v
-             | br := if word.eqb _ (word.of_Z 0) then _ else _ |- _ => subst br
-             end.
-      rewrite @word.unsigned_eqb in * by typeclasses eauto.
-      autorewrite with push_unsigned in *.
-      destruct_one_match_hyp_of_type bool; congruence. }
-
-    { (* proof that invariant holds at loop start *)
-      do 2 eexists; ssplit;
+    { (* case in which the initial state is BUSY *)
       lazymatch goal with
-      | |- execution _ _ => eassumption
-      | |- (?x <= ?x)%nat => reflexivity
-      | |- ?x = ?x => reflexivity
-      | |- sep _ _ _ => eassumption
-      | |- _ = map.put _ _ _ => symmetry; solve [apply map.put_put_same]
-      | |- output_matches_state _ _ =>
-        cbv [output_matches_state] in *;
-        destruct_one_match; solve [eauto]
-      | _ => idtac
-      end; [ ].
-      destruct_one_match; eauto. }
+        H : execution tr (BUSY data) |- _ =>
+        destruct data as [ctrl exp_output max_cycles];
+          cbn [get_ctrl] in *;
+          cbn [busy_ctrl busy_exp_output busy_max_cycles_until_done] in *
+      end.
+      subst.
 
-    { (* invariant holds through loop (or postcondition holds, if loop breaks) *)
+      (* begin while loop *)
+      let l := lazymatch goal with |- cmd _ _ _ _ ?l _ => l end in
+      apply atleastonce_localsmap
+        with (v0:=max_cycles)
+             (lt:=lt)
+             (invariant:=
+                fun i tr' m' l' =>
+                  exists (s' : state) is_valid,
+                    (* s' is the state for the new trace *)
+                    execution (p:=state_machine_parameters) tr' s'
+                    (* as long as the loop continues, we keep setting is_valid to
+                       0, so locals are unchanged until the loop breaks *)
+                    /\ l' = map.put l "is_valid" is_valid
+                    /\ (exists n',
+                          (* current state has the same control and expected
+                             output as the initial state, but a possibly different
+                             counter *)
+                          s' = BUSY (Build_busy_data ctrl out n')
+                          (* the counter matches the "measure" i *)
+                          /\ n' = i)
+                    (* memory is unaffected *)
+                    /\ (array scalar32 (word.of_Z 4) data_ptr data_arr ⋆ R)%sep m').
+      { apply lt_wf. }
+
+      { (* case in which the loop breaks immediately (cannot happen) *)
+        repeat straightline.
+        exfalso. (* proof by contradiction *)
+
+        repeat lazymatch goal with
+               | v := word.of_Z 0 |- _ => subst v
+                    | br := if word.eqb _ (word.of_Z 0) then _ else _ |- _ => subst br
+               end.
+        rewrite @word.unsigned_eqb in * by typeclasses eauto.
+        autorewrite with push_unsigned in *.
+        destruct_one_match_hyp_of_type bool; congruence. }
+
+      { (* proof that invariant holds at loop start *)
+        do 2 eexists; ssplit;
+        lazymatch goal with
+        | |- execution _ _ => eassumption
+        | |- (?x <= ?x)%nat => reflexivity
+        | |- ?x = ?x => reflexivity
+        | |- sep _ _ _ => eassumption
+        | |- _ = map.put _ _ _ => symmetry; solve [apply map.put_put_same]
+        | |- output_matches_state _ _ =>
+          cbv [output_matches_state] in *;
+          destruct_one_match; solve [eauto]
+        | _ => idtac
+        end; [ ].
+        eauto. }
+
+      { (* invariant holds through loop (or postcondition holds, if loop breaks) *)
+        intros; logical_simplify; subst.
+        repeat straightline.
+
+        (* Call aes_data_valid *)
+        straightline_call; eauto; [ ].
+
+        (* simplify guarantees *)
+        logical_simplify; subst.
+        cbn [read_step reg_category] in *.
+        destruct_one_match_hyp.
+
+        { (* case in which the status is now DONE; break *)
+          repeat straightline.
+          { (* continuation case -- contradiction *)
+            exfalso.
+            cbv [status_matches_state] in *.
+            repeat invert_bool.
+            simplify_implicits.
+            lazymatch goal with
+            | br := if word.eqb _ (word.of_Z 0) then _ else _,
+                    H : word.unsigned br <> 0 |- _ =>
+                    subst br; apply H
+            end.
+            push_unsigned.
+            destruct_one_match; subst; try reflexivity; [ ].
+            (* TODO: add to invert_bool *)
+            lazymatch goal with
+            | H:true = negb _ |- _ => symmetry in H; apply Bool.negb_true_iff in H
+            end.
+            congruence. }
+          { (* break case *)
+
+            (* Call aes_data_get *)
+            straightline_call; eauto; try reflexivity; [ ].
+
+            (* simplify guarantees *)
+            logical_simplify; subst.
+
+            (* postcondition *)
+            repeat straightline.
+            ssplit; eauto. } }
+
+        { (* case in which the state is still BUSY *)
+          intros; logical_simplify.
+          destruct_one_match_hyp; [ contradiction | subst ].
+          repeat straightline.
+
+          { (* continuation case *)
+            cbv [Markers.split].
+            match goal with |- exists v, _ /\ (v < S ?n)%nat => exists n end.
+            split; [ | lia ].
+
+            (* invariant still holds *)
+            do 2 eexists; ssplit;
+              lazymatch goal with
+              | |- execution _ _ => eassumption
+              | |- sep _ _ _ => eassumption
+              | |- @eq map.rep ?l1 ?l2 =>
+                subst1_map l1;
+                  lazymatch goal with
+                  | |- @eq map.rep ?l1 ?l2 =>
+                    subst1_map l1
+                  end;
+                  apply map.put_put_same
+              | _ => eauto
+              end. }
+          { (* break case -- contradiction *)
+            exfalso.
+            cbv [status_matches_state] in *.
+            repeat invert_bool; try congruence; [ ].
+            simplify_implicits.
+            lazymatch goal with
+            | H : word.eqb _ _ = negb (is_flag_set ?x ?flag),
+                  H' : is_flag_set ?x ?flag = _ |- _ =>
+              rewrite H' in H; cbn [negb] in H
+            end.
+            lazymatch goal with
+            | br := if word.eqb ?x (word.of_Z 0) then _ else _,
+                    Heq : word.eqb ?x (word.of_Z 0) = _,
+                          Hz : word.unsigned br = 0 |- _ =>
+                    subst br; rewrite Heq in Hz;
+                      autorewrite with push_unsigned in Hz
+            end.
+            discriminate. } } } }
+
+    { (* case in which the initial state is DONE *)
+
+      (* use output_matches_state precondition *)
+      lazymatch goal with
+      | H : ?data = done_data_from_output (done_ctrl ?data) out |- _ =>
+        cbv [done_data_from_output] in H; destruct data;
+        cbn [AesSemantics.done_ctrl
+               AesSemantics.done_data_out0
+               AesSemantics.done_data_out1
+               AesSemantics.done_data_out2
+               AesSemantics.done_data_out3] in *;
+        inversion H; clear H; subst
+      end.
+
+      (* while loop will run exactly once *)
+      eapply unroll_while with (iterations:=1%nat). cbn [repeat_logic_step].
+      repeat straightline.
+
+      (* prove that we do enter the while loop *)
+      ssplit;
+        [ subst_lets; rewrite word.eqb_eq by reflexivity;
+          push_unsigned; congruence | ].
+
       repeat straightline.
 
       (* Call aes_data_valid *)
@@ -1962,201 +1768,35 @@ Section Proofs.
 
       (* simplify guarantees *)
       logical_simplify; subst.
+      cbn [read_step reg_category] in *.
+      cbv [status_matches_state] in *.
+      logical_simplify; subst.
+      repeat invert_bool; try congruence; [ ].
+      simplify_implicits.
       lazymatch goal with
-      | H : execution (_ :: _) _ |- _ =>
-        pose proof H;
-        apply invert1_execution in H; logical_simplify
+      | H : word.eqb _ _ = negb (is_flag_set ?x ?flag),
+            H' : is_flag_set ?x ?flag = _ |- _ =>
+        rewrite H' in H; cbn [negb] in H;
+          apply word.eqb_false in H
       end.
-      invert_step; subst.
-      cbn [parameters.reg_addr parameters.write_step parameters.read_step
-                               state_machine_parameters] in *.
-      infer; subst.
-      (* assert that the register address we just read is STATUS *)
-      lazymatch goal with
-      | H : reg_addr ?r = AES_STATUS |- _ =>
-        apply (reg_addr_unique r STATUS) in H; subst
-      end.
-      invert_read_step; infer; subst; try discriminate;
-        (* get rid of cases that are not BUSY or DONE *)
-        try lazymatch goal with
-            | H : output_matches_state _ _ |- _ =>
-              cbv [output_matches_state] in H; contradiction H
-            end;
-        (* three cases left : BUSY -> DONE, BUSY -> BUSY, DONE -> DONE *)
-        [ | | ].
 
-      { (* case in which the state was BUSY, but is now DONE *)
-        repeat straightline.
-        { (* continuation case -- contradiction *)
-          exfalso.
-          cbv [status_matches_state] in *.
-          repeat invert_bool.
-          simplify_implicits.
-          lazymatch goal with
-          | br := if word.eqb _ (word.of_Z 0) then _ else _,
-                  H : word.unsigned br <> 0 |- _ =>
-                  subst br; apply H
-          end.
-          push_unsigned.
-          destruct_one_match; subst; try reflexivity; [ ].
-          (* TODO: add to invert_bool *)
-          lazymatch goal with
-          | H:true = negb _ |- _ => symmetry in H; apply Bool.negb_true_iff in H
-          end.
-          congruence. }
-        { (* break case *)
+      repeat straightline.
 
-          (* Call aes_data_get *)
-          straightline_call; eauto using nregs_populated_set_out_regs; [ ].
-          repeat straightline.
-          logical_simplify; subst.
-          lazymatch goal with
-          | H : execution (_ :: _) _ |- _ =>
-            apply invert1_execution in H; logical_simplify
-          end.
-          infer; subst.
-          (* assert that the register address we just read is STATUS *)
-          lazymatch goal with
-          | H : parameters.reg_addr ?r = AES_STATUS |- _ =>
-            replace AES_STATUS with (reg_addr STATUS) in H
-              by (cbn [reg_addr]; subst_lets; ring);
-              apply reg_addr_unique in H; try subst r
-          end.
-          cbn [parameters.reg_addr parameters.write_step parameters.read_step
-                                   state_machine_parameters] in *.
-          invert_read_step; subst; try discriminate; [ ].
-          infer.
+      (* prove the loop breaks *)
+      ssplit;
+        [ subst_lets; simplify_implicits;
+          destruct_one_match; push_unsigned; congruence | ].
 
-          (* postcondition *)
-          lazymatch goal with
-          | H : output_matches_state ?out _ |- context [?out] =>
-            cbv [output_matches_state] in H; subst
-          end.
-          cbv [reg_lookup set_out_regs] in *.
-          repeat lazymatch goal with
-                 | H : map.get (map.put _ ?k _) ?k = _ |- _ => rewrite map.get_put_same in H
-                 | H : map.get (map.put _ _ _) _ = _ |- _ =>
-                   rewrite map.get_put_diff in H by (apply reg_addr_neq; congruence)
-                 | H : context [map.remove (map.put _ ?k _) ?k] |- _ =>
-                   rewrite map_remove_put_same in H
-                 | H : context [map.remove (map.put _ _ _) _] |- _ =>
-                   rewrite map_remove_put_diff in H by (apply reg_addr_neq; congruence)
-                 | H : Some _ = Some _ |- _ => inversion H; clear H; subst
-                 end.
-          cbn [get_register_state].
-          ssplit; eauto. } }
+      repeat straightline.
 
-      { (* case in which the state was BUSY and is still BUSY *)
-        repeat straightline.
-        { (* continuation case *)
-          cbn [max_iterations]. cbv [Markers.split].
-          match goal with |- exists v, _ /\ (v < S ?n)%nat => exists n end.
-          split; [ | lia ].
+      (* Call aes_data_get *)
+      straightline_call; eauto; try reflexivity; [ ].
 
-          (* invariant still holds *)
-          do 2 eexists; ssplit;
-            lazymatch goal with
-            | |- execution _ _ => eassumption
-            | |- max_iterations _ = _ => reflexivity
-            | |- sep _ _ _ => eassumption
-            | |- @eq map.rep ?l1 ?l2 =>
-              subst1_map l1;
-                lazymatch goal with
-                | |- @eq map.rep ?l1 ?l2 =>
-                  subst1_map l1
-                end;
-                apply map.put_put_same
-            | |- exists n, ?f ?x = ?f n => exists x; reflexivity
-            | |- output_matches_state _ _ =>
-              cbv [output_matches_state] in *; solve [eauto]
-            | _ => idtac
-            end. }
-        { (* break case -- contradiction *)
-          exfalso.
-          cbv [status_matches_state] in *.
-          repeat invert_bool; try congruence; [ ].
-          lazymatch goal with
-          | H : word.eqb _ _ = negb (is_flag_set ?x ?flag),
-                H' : is_flag_set ?x ?flag = _ |- _ =>
-            rewrite H' in H; cbn [negb] in H
-          end.
-          simplify_implicits.
-          lazymatch goal with
-          | br := if word.eqb ?x (word.of_Z 0) then _ else _,
-                  Heq : word.eqb ?x (word.of_Z 0) = _,
-                  Hz : word.unsigned br = 0 |- _ =>
-                  subst br; rewrite Heq in Hz;
-                    autorewrite with push_unsigned in Hz
-          end.
-          discriminate. } }
+      (* simplify guarantees *)
+      logical_simplify; subst.
 
-      { (* case in which the state was DONE to begin with *)
-        repeat straightline.
-        { (* continuation case -- contradiction *)
-          exfalso.
-          cbv [status_matches_state] in *.
-          repeat invert_bool.
-          simplify_implicits.
-          lazymatch goal with
-          | br := if word.eqb _ (word.of_Z 0) then _ else _,
-                  H : word.unsigned br <> 0 |- _ =>
-                  subst br; apply H
-          end.
-          push_unsigned.
-          destruct_one_match; subst; try reflexivity; [ ].
-          (* TODO: add to invert_bool *)
-          lazymatch goal with
-          | H:true = negb _ |- _ => symmetry in H; apply Bool.negb_true_iff in H
-          end.
-          congruence. }
-        { (* break case *)
-
-          (* Call aes_data_get *)
-          straightline_call; eauto;
-          lazymatch goal with
-          | |- nregs_populated ?rs DataOutReg = _ =>
-            erewrite <-(output_matches_state_set_out_regs rs) by eassumption;
-            solve [eapply nregs_populated_set_out_regs]
-          | _ => idtac
-          end; [ ].
-          repeat straightline.
-          logical_simplify; subst.
-          lazymatch goal with
-          | H : execution (_ :: _) _ |- _ =>
-            apply invert1_execution in H; logical_simplify
-          end.
-          infer; subst.
-          (* assert that the register address we just read is STATUS *)
-          lazymatch goal with
-          | H : parameters.reg_addr ?r = AES_STATUS |- _ =>
-            replace AES_STATUS with (reg_addr STATUS) in H
-              by (cbn [reg_addr]; subst_lets; ring);
-              apply reg_addr_unique in H; try subst r
-          end.
-          cbn [parameters.reg_addr parameters.write_step parameters.read_step
-                                   state_machine_parameters] in *.
-          invert_read_step; subst; try discriminate; [ ].
-          infer.
-
-          (* postcondition *)
-          lazymatch goal with
-          | H : output_matches_state ?out _ |- context [?out] =>
-            cbv [output_matches_state] in H; subst
-          end.
-          cbv [reg_lookup set_out_regs] in *. logical_simplify.
-          repeat lazymatch goal with
-                 | H : map.get (map.put _ ?k _) ?k = _ |- _ => rewrite map.get_put_same in H
-                 | H : map.get (map.put _ _ _) _ = _ |- _ =>
-                   rewrite map.get_put_diff in H by (apply reg_addr_neq; congruence)
-                 | H : context [map.remove (map.put _ ?k _) ?k] |- _ =>
-                   rewrite map_remove_put_same in H
-                 | H : context [map.remove (map.put _ _ _) _] |- _ =>
-                   rewrite map_remove_put_diff in H by (apply reg_addr_neq; congruence)
-                 | H1 : map.get ?m ?k = Some _, H2 : map.get ?m ?k = Some _ |- _ =>
-                   rewrite H1 in H2
-                 | H : Some _ = Some _ |- _ => inversion H; clear H; subst
-                 end.
-          cbn [get_register_state].
-          ssplit; eauto. } } }
+      (* postcondition *)
+      repeat straightline.
+      ssplit; eauto. }
   Qed.
 End Proofs.

--- a/investigations/bedrock2/Aes/AesSemantics.v
+++ b/investigations/bedrock2/Aes/AesSemantics.v
@@ -211,9 +211,9 @@ Section WithParameters.
       idle_data_in3 : option word;
     }.
   Record busy_data :=
-    { ctrl : word;
-      exp_output : aes_output;
-      max_cycles_until_done : nat;
+    { busy_ctrl : word;
+      busy_exp_output : aes_output;
+      busy_max_cycles_until_done : nat;
     }.
   Record done_data :=
     { done_ctrl : word;
@@ -236,7 +236,7 @@ Section WithParameters.
   Definition status_matches_state (s : state) (status : word) : bool :=
     match s with
     | UNINITIALIZED =>
-      (is_flag_set status AES_STATUS_IDLE
+      (negb (is_flag_set status AES_STATUS_IDLE)
        && negb (is_flag_set status AES_STATUS_STALL)
        && negb (is_flag_set status AES_STATUS_OUTPUT_VALID)
        && negb (is_flag_set status AES_STATUS_INPUT_READY))
@@ -341,7 +341,11 @@ Section WithParameters.
 
   Definition read_output_reg (r : Register) (data : done_data)
     : option (word * done_data) :=
-    let (ctrl, o0, o1, o2, o3) := data in
+    let ctrl := done_ctrl data in
+    let o0 := done_data_out0 data in
+    let o1 := done_data_out1 data in
+    let o2 := done_data_out2 data in
+    let o3 := done_data_out3 data in
     match r with
     | DATA_OUT0 =>
       match o0 with
@@ -411,9 +415,23 @@ Section WithParameters.
 
   Definition write_input_reg (r : Register) (data : idle_data) (val : word)
     : idle_data :=
-    let (ctrl, iv0, iv1, iv2, iv3,
-         key0, key1, key2, key3, key4, key5, key6, key7,
-         data_in0, data_in1, data_in2, data_in3) := data in
+    let ctrl := idle_ctrl data in
+    let iv0 := idle_iv0 data in
+    let iv1 := idle_iv1 data in
+    let iv2 := idle_iv2 data in
+    let iv3 := idle_iv3 data in
+    let key0 := idle_key0 data in
+    let key1 := idle_key1 data in
+    let key2 := idle_key2 data in
+    let key3 := idle_key3 data in
+    let key4 := idle_key4 data in
+    let key5 := idle_key5 data in
+    let key6 := idle_key6 data in
+    let key7 := idle_key7 data in
+    let data_in0 := idle_data_in0 data in
+    let data_in1 := idle_data_in1 data in
+    let data_in2 := idle_data_in2 data in
+    let data_in3 := idle_data_in3 data in
     match r with
     | IV0 => Build_idle_data
               ctrl (Some val) iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7

--- a/investigations/bedrock2/Aes/AesSemantics.v
+++ b/investigations/bedrock2/Aes/AesSemantics.v
@@ -35,7 +35,6 @@ Module parameters.
   Class parameters :=
     { word :> Interface.word.word 32;
       mem :> Interface.map.map word Byte.byte;
-      regs :> Interface.map.map word word; (* register values *)
       (* TODO: mode is currently ignored *)
       aes_spec :
         forall (is_decrypt : bool)
@@ -47,7 +46,6 @@ Module parameters.
   Class ok (p : parameters) :=
     { word_ok :> word.ok word; (* for impl of mem below *)
       mem_ok :> Interface.map.ok mem; (* for impl of mem below *)
-      regs_ok :> Interface.map.ok regs;
     }.
 End parameters.
 Notation parameters := parameters.parameters.
@@ -168,25 +166,69 @@ Section WithParameters.
     all:destruct r2; try first [ exact eq_refl | congruence ].
   Qed.
 
-  Definition known_register_state : Type := map.rep (map:=regs).
-
-  Definition reg_lookup (rs : known_register_state) (r : Register) : option word :=
-    map.get rs (reg_addr r).
-
+  Record aes_input :=
+    { is_decrypt : bool;
+      iv0 : word;
+      iv1 : word;
+      iv2 : word;
+      iv3 : word;
+      key0 : word;
+      key1 : word;
+      key2 : word;
+      key3 : word;
+      key4 : word;
+      key5 : word;
+      key6 : word;
+      key7 : word;
+      data_in0 : word;
+      data_in1 : word;
+      data_in2 : word;
+      data_in3 : word;
+    }.
   Record aes_output :=
     { data_out0 : word;
       data_out1 : word;
       data_out2 : word;
       data_out3 : word; }.
 
+  Record idle_data :=
+    { idle_ctrl : word;
+      idle_iv0 : option word;
+      idle_iv1 : option word;
+      idle_iv2 : option word;
+      idle_iv3 : option word;
+      idle_key0 : option word;
+      idle_key1 : option word;
+      idle_key2 : option word;
+      idle_key3 : option word;
+      idle_key4 : option word;
+      idle_key5 : option word;
+      idle_key6 : option word;
+      idle_key7 : option word;
+      idle_data_in0 : option word;
+      idle_data_in1 : option word;
+      idle_data_in2 : option word;
+      idle_data_in3 : option word;
+    }.
+  Record busy_data :=
+    { ctrl : word;
+      exp_output : aes_output;
+      max_cycles_until_done : nat;
+    }.
+  Record done_data :=
+    { done_ctrl : word;
+      done_data_out0 : option word;
+      done_data_out1 : option word;
+      done_data_out2 : option word;
+      done_data_out3 : option word;
+    }.
+
   (* state *from the perspective of the software* *)
   Inductive state : Type :=
-  | UNINITIALIZED (* CTRL register not yet written *)
-  | IDLE (rs : known_register_state)
-  | BUSY (rs : known_register_state)
-         (exp_output : aes_output)
-         (max_cycles_until_done : nat)
-  | DONE (rs : known_register_state)
+  | UNINITIALIZED
+  | IDLE (data : idle_data)
+  | BUSY (data : busy_data)
+  | DONE (data : done_data)
   (* TODO: add CLEAR state for aes_clear *)
   .
 
@@ -203,7 +245,7 @@ Section WithParameters.
        && negb (is_flag_set status AES_STATUS_STALL)
        && negb (is_flag_set status AES_STATUS_OUTPUT_VALID)
        && is_flag_set status AES_STATUS_INPUT_READY)
-    | BUSY _ _ _ =>
+    | BUSY _ =>
       (negb (is_flag_set status AES_STATUS_IDLE)
        && negb (is_flag_set status AES_STATUS_STALL)
        && negb (is_flag_set status AES_STATUS_OUTPUT_VALID)
@@ -215,39 +257,33 @@ Section WithParameters.
        && negb (is_flag_set status AES_STATUS_INPUT_READY))
     end.
 
-  Definition aes_expected_output (rs : known_register_state) : option aes_output :=
-    ctrl <- reg_lookup rs CTRL ;;
-    key0 <- reg_lookup rs KEY0 ;;
-    key1 <- reg_lookup rs KEY1 ;;
-    key2 <- reg_lookup rs KEY2 ;;
-    key3 <- reg_lookup rs KEY3 ;;
-    key4 <- reg_lookup rs KEY4 ;;
-    key5 <- reg_lookup rs KEY5 ;;
-    key6 <- reg_lookup rs KEY6 ;;
-    key7 <- reg_lookup rs KEY7 ;;
-    iv0 <- reg_lookup rs IV0 ;;
-    iv1 <- reg_lookup rs IV1 ;;
-    iv2 <- reg_lookup rs IV2 ;;
-    iv3 <- reg_lookup rs IV3 ;;
-    data_in0 <- reg_lookup rs DATA_IN0 ;;
-    data_in1 <- reg_lookup rs DATA_IN1 ;;
-    data_in2 <- reg_lookup rs DATA_IN2 ;;
-    data_in3 <- reg_lookup rs DATA_IN3 ;;
-    let is_decrypt := is_flag_set ctrl AES_CTRL_OPERATION in
+  Definition aes_expected_output (input : aes_input) : aes_output :=
+    let (is_decrypt, iv0, iv1, iv2, iv3,
+         key0, key1, key2, key3, key4, key5, key6, key7,
+         data_in0, data_in1, data_in2, data_in3) := input in
     let '(out0, out1, out2, out3) :=
         aes_spec is_decrypt
                  (key0, key1, key2, key3, key4, key5, key6, key7)
                  (iv0, iv1, iv2, iv3)
                  (data_in0, data_in1, data_in2, data_in3) in
-    Some {| data_out0 := out0 ;
-            data_out1 := out1 ;
-            data_out2 := out2 ;
-            data_out3 := out3 ; |}.
+    {| data_out0 := out0 ;
+       data_out1 := out1 ;
+       data_out2 := out2 ;
+       data_out3 := out3 ; |}.
 
-  Definition is_busy (s : state) : bool :=
-    match s with
-    | BUSY _ _ _ => true
-    | _ => false
+  Definition get_aes_input (data : idle_data) : option aes_input :=
+    match data with
+    | Build_idle_data
+        ctrl (Some iv0) (Some iv1) (Some iv2) (Some iv3)
+        (Some key0) (Some key1) (Some key2) (Some key3)
+        (Some key4) (Some key5) (Some key6) (Some key7)
+        (Some data_in0) (Some data_in1) (Some data_in2) (Some data_in3) =>
+      Some (Build_aes_input
+              (is_flag_set ctrl AES_CTRL_OPERATION)
+              iv0 iv1 iv2 iv3
+              key0 key1 key2 key3 key4 key5 key6 key7
+              data_in0 data_in1 data_in2 data_in3)
+    | _ => None
     end.
 
   Inductive RegisterCategory : Set :=
@@ -299,48 +335,36 @@ Section WithParameters.
   Global Instance reg_category_eqb_spec : EqDecider reg_category_eqb.
   Proof. intros x y. destruct x,y; constructor; congruence. Qed.
 
-  Definition all_regs_in_category (c : RegisterCategory) : list Register :=
-    filter (fun r => reg_category_eqb c (reg_category r)) all_regs.
+  Definition done_data_from_output (ctrl : word) (out : aes_output) : done_data :=
+    Build_done_data ctrl (Some (data_out0 out)) (Some (data_out1 out))
+                    (Some (data_out2 out)) (Some (data_out3 out)).
 
-  (* gives the number of populated registers in the given category *)
-  Definition nregs_populated
-             (rs : known_register_state)
-             (cat : RegisterCategory) : nat :=
-    List.length
-      (filter
-         (fun r =>
-            match reg_lookup rs r with
-            | None => false
-            | Some _ => true
-            end)
-         (all_regs_in_category cat)).
-
-  Definition set_out_regs
-             (rs : known_register_state) (out : aes_output) : known_register_state :=
-    let rs := map.put rs (reg_addr DATA_OUT0) out.(data_out0) in
-    let rs := map.put rs (reg_addr DATA_OUT1) out.(data_out1) in
-    let rs := map.put rs (reg_addr DATA_OUT2) out.(data_out2) in
-    map.put rs (reg_addr DATA_OUT3) out.(data_out3).
-
-  Definition unset_inp_regs
-             (rs : known_register_state) : known_register_state :=
-    let rs := map.remove rs (reg_addr KEY0) in
-    let rs := map.remove rs (reg_addr KEY1) in
-    let rs := map.remove rs (reg_addr KEY2) in
-    let rs := map.remove rs (reg_addr KEY3) in
-    let rs := map.remove rs (reg_addr KEY4) in
-    let rs := map.remove rs (reg_addr KEY5) in
-    let rs := map.remove rs (reg_addr KEY6) in
-    let rs := map.remove rs (reg_addr KEY7) in
-    let rs := map.remove rs (reg_addr IV0) in
-    let rs := map.remove rs (reg_addr IV1) in
-    let rs := map.remove rs (reg_addr IV2) in
-    let rs := map.remove rs (reg_addr IV3) in
-    let rs := map.remove rs (reg_addr DATA_IN0) in
-    let rs := map.remove rs (reg_addr DATA_IN1) in
-    let rs := map.remove rs (reg_addr DATA_IN2) in
-    let rs := map.remove rs (reg_addr DATA_IN3) in
-    rs.
+  Definition read_output_reg (r : Register) (data : done_data)
+    : option (word * done_data) :=
+    let (ctrl, o0, o1, o2, o3) := data in
+    match r with
+    | DATA_OUT0 =>
+      match o0 with
+      | Some o0 => Some (o0, Build_done_data ctrl None o1 o2 o3)
+      | None => None
+      end
+    | DATA_OUT1 =>
+      match o1 with
+      | Some o1 => Some (o1, Build_done_data ctrl o0 None o2 o3)
+      | None => None
+      end
+    | DATA_OUT2 =>
+      match o2 with
+      | Some o2 => Some (o2, Build_done_data ctrl o0 o1 None o3)
+      | None => None
+      end
+    | DATA_OUT3 =>
+      match o3 with
+      | Some o3 => Some (o3, Build_done_data ctrl o0 o1 o2 None)
+      | None => None
+      end
+    | _ => None
+    end.
 
   Definition read_step
              (s : state) (r : Register) (val : word) (s' : state) : Prop :=
@@ -348,17 +372,17 @@ Section WithParameters.
     | StatusReg =>
       (* status register read *)
       match s with
-      | BUSY rs out n =>
-        if status_matches_state (DONE rs) val
+      | BUSY (Build_busy_data ctrl out n) =>
+        if is_flag_set val AES_STATUS_OUTPUT_VALID
         then
           (* transition to DONE state *)
-          s' = DONE (set_out_regs rs out)
+          s' = DONE (done_data_from_output ctrl out)
         else
           (* decrement max #cycles until done *)
           status_matches_state s val = true (* we must have read BUSY status *)
           /\ match n with
             | O => False (* exceeded max #cycles *)
-            | S n' => s' = BUSY rs out n'
+            | S n' => s' = BUSY (Build_busy_data ctrl out n')
             end
       | _ =>
         (* if the status is not busy, reading the status causes no change *)
@@ -367,19 +391,81 @@ Section WithParameters.
     | DataOutReg =>
       (* output data register read *)
       match s with
-      | DONE rs =>
-        reg_lookup rs r = Some val
-        /\ let rs' := map.remove rs (reg_addr r) in
-          if (nregs_populated rs' DataOutReg =? 0)%nat
-          then
-            (* all output registers have been read; transition to IDLE state *)
-            s' = IDLE rs'
-          else
-            (* stay in DONE state *)
-            s' = DONE rs'
-      | _ => False (* cannot read from output registers unless DONE *)
+      | DONE data =>
+        exists data',
+        read_output_reg r data = Some (val, data')
+        /\ s' = match data' with
+               | Build_done_data ctrl None None None None =>
+                 (* all output registers read; transition to IDLE state *)
+                 IDLE (Build_idle_data
+                         ctrl None None None None None None None None
+                         None None None None None None None None)
+               | _ =>
+                 (* some registers have not been read; stay in DONE state *)
+                 DONE data'
+               end
+      | _ => False (* read is not permitted from other states *)
       end
-    | _ => False (* no guarantees about the values of other registers *)
+    | ControlReg | DataInReg | KeyReg | IVReg => False (* not readable *)
+    end.
+
+  Definition write_input_reg (r : Register) (data : idle_data) (val : word)
+    : idle_data :=
+    let (ctrl, iv0, iv1, iv2, iv3,
+         key0, key1, key2, key3, key4, key5, key6, key7,
+         data_in0, data_in1, data_in2, data_in3) := data in
+    match r with
+    | IV0 => Build_idle_data
+              ctrl (Some val) iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+              data_in0 data_in1 data_in2 data_in3
+    | IV1 => Build_idle_data
+              ctrl iv0 (Some val) iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+              data_in0 data_in1 data_in2 data_in3
+    | IV2 => Build_idle_data
+              ctrl iv0 iv1 (Some val) iv3 key0 key1 key2 key3 key4 key5 key6 key7
+              data_in0 data_in1 data_in2 data_in3
+    | IV3 => Build_idle_data
+              ctrl iv0 iv1 iv2 (Some val) key0 key1 key2 key3 key4 key5 key6 key7
+              data_in0 data_in1 data_in2 data_in3
+    | KEY0 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 (Some val) key1 key2 key3 key4 key5 key6 key7
+               data_in0 data_in1 data_in2 data_in3
+    | KEY1 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 key0 (Some val) key2 key3 key4 key5 key6 key7
+               data_in0 data_in1 data_in2 data_in3
+    | KEY2 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 key0 key1 (Some val) key3 key4 key5 key6 key7
+               data_in0 data_in1 data_in2 data_in3
+    | KEY3 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 key0 key1 key2 (Some val) key4 key5 key6 key7
+               data_in0 data_in1 data_in2 data_in3
+    | KEY4 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 (Some val) key5 key6 key7
+               data_in0 data_in1 data_in2 data_in3
+    | KEY5 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 (Some val) key6 key7
+               data_in0 data_in1 data_in2 data_in3
+    | KEY6 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 (Some val) key7
+               data_in0 data_in1 data_in2 data_in3
+    | KEY7 => Build_idle_data
+               ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 (Some val)
+               data_in0 data_in1 data_in2 data_in3
+    | DATA_IN0 => Build_idle_data
+                   ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+                   (Some val) data_in1 data_in2 data_in3
+    | DATA_IN1 => Build_idle_data
+                   ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+                   data_in0 (Some val) data_in2 data_in3
+    | DATA_IN2 => Build_idle_data
+                   ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+                   data_in0 data_in1 (Some val) data_in3
+    | DATA_IN3 => Build_idle_data
+                   ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+                   data_in0 data_in1 data_in2 (Some val)
+    | _ => Build_idle_data
+            ctrl iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+            data_in0 data_in1 data_in2 data_in3
     end.
 
   Definition write_step
@@ -389,39 +475,40 @@ Section WithParameters.
       match s with
       | UNINITIALIZED =>
         (* transition to IDLE state *)
-        s' = IDLE (map.put map.empty AES_CTRL val)
-      | IDLE rs =>
+        s' = IDLE (Build_idle_data
+                     val None None None None None None None None
+                     None None None None None None None None)
+      | IDLE (Build_idle_data
+                _ iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+                data_in0 data_in1 data_in2 data_in3) =>
         (* stay IDLE, update ctrl value *)
-        s' = IDLE (map.put rs AES_CTRL val)
+        s' = IDLE (Build_idle_data
+                     val iv0 iv1 iv2 iv3 key0 key1 key2 key3 key4 key5 key6 key7
+                     data_in0 data_in1 data_in2 data_in3)
       | _ => False (* ctrl register is not writeable in other states *)
       end
     | KeyReg | IVReg =>
       match s with
-      | IDLE rs =>
-        s' = IDLE (map.put rs (reg_addr r) val)
+      | IDLE data => s' = IDLE (write_input_reg r data val)
       | _ => False (* key/iv registers are not writeable in other states *)
       end
     | DataInReg =>
       match s with
-      | IDLE rs =>
-        (* can only provide input once key/iv regs have been written *)
-        nregs_populated rs KeyReg = 8%nat
-        /\ nregs_populated rs IVReg = 4%nat
-        /\ (nregs_populated rs DataInReg < 4)%nat
-        /\ let rs' := map.put rs (reg_addr r) val in
-          if (nregs_populated rs' DataInReg =? 4)%nat
-          then
-            (* wrote to last input register; transition to BUSY state *)
-            match aes_expected_output (map.put rs (reg_addr r) val) with
-            | Some out => s' = BUSY (unset_inp_regs rs') out timing.ndelays_core
-            | None => False (* should not be possible *)
-            end
-          else
-            (* more input registers needed; stay in IDLE state *)
-            s' = IDLE rs'
-      | _ => False (* input data registers are not writeable in other states *)
+      | IDLE data =>
+        let data' := write_input_reg r data val in
+        s' = match get_aes_input data' with
+             | Some input =>
+               (* input registers are fully populated; encryption begins *)
+               BUSY (Build_busy_data
+                       (idle_ctrl data')
+                       (aes_expected_output input) timing.ndelays_core)
+             | None =>
+               (* more input registers needed; stay in IDLE state *)
+               IDLE data'
+             end
+      | _ => False (* input data registers not writeable in other states *)
       end
-    | StatusReg | DataOutReg => False (* not writeable *)
+    | DataOutReg | StatusReg => False (* not writeable *)
     end.
 
   Global Instance state_machine_parameters

--- a/investigations/bedrock2/Aes/Constants.v
+++ b/investigations/bedrock2/Aes/Constants.v
@@ -205,6 +205,12 @@ Class aes_constants_ok
                    ; AES_STATUS_STALL
                    ; AES_STATUS_OUTPUT_VALID
                    ; AES_STATUS_INPUT_READY]));
+    status_flags_inbounds :
+      Forall (fun flag => word.unsigned flag < 32)
+             [AES_STATUS_IDLE
+              ; AES_STATUS_STALL
+              ; AES_STATUS_OUTPUT_VALID
+              ; AES_STATUS_INPUT_READY];
 
     (* control register needs to be properly formatted *)
     op_size := 1;

--- a/investigations/bedrock2/StateMachineProperties.v
+++ b/investigations/bedrock2/StateMachineProperties.v
@@ -1,4 +1,6 @@
 Require Import Coq.Lists.List.
+Require Import Coq.Strings.String.
+Require Import bedrock2.ProgramLogic.
 Require Import bedrock2.Semantics.
 Require Import bedrock2.Syntax.
 Require Import bedrock2.WeakestPrecondition.
@@ -18,95 +20,97 @@ Local Open Scope Z_scope.
 Section Proofs.
   Context {width word} {p : StateMachineSemantics.parameters width word}
           {p_ok : parameters.ok p}.
+  Import parameters.
 
   Lemma execution_step action args rets t s s':
     execution t s -> step action s args rets s' ->
     execution ((map.empty, action, args, (map.empty, rets)) :: t) s'.
   Proof. intros; cbn [execution]; eauto. Qed.
 
-  Lemma invert1_execution action args rets t s':
-    execution ((map.empty, action, args, (map.empty, rets)) :: t) s' ->
-    exists s, execution t s /\ step action s args rets s'.
-  Proof. intros; cbn [execution]; eauto. Qed.
-
-  Lemma invert1_step action args rets s s':
-    step action s args rets s' ->
-    (exists r addr val,
-        args = [addr]
-        /\ rets = [val]
-        /\ parameters.reg_addr r = addr
-        /\ parameters.read_step s r val s')
-    \/ (exists r addr val,
-        args = [addr; val]
-        /\ rets = []
-        /\ parameters.reg_addr r = addr
-        /\ parameters.write_step s r val s').
+  Lemma execution_step_read r addr val t s s':
+    execution t s -> reg_addr r = addr -> read_step s r val s' ->
+    execution ((map.empty, READ, [addr], (map.empty, [val])) :: t) s'.
   Proof.
-    inversion 1; subst; [ left | right ];
-      do 3 eexists; ssplit; try reflexivity;
-        assumption.
+    intros. eapply execution_step; [ eassumption | ].
+    cbv [step]. change (READ =? WRITE)%string with false.
+    rewrite String.eqb_refl. eauto.
   Qed.
 
+  Lemma execution_step_write r addr val t s s':
+    execution t s -> reg_addr r = addr -> write_step s r val s' ->
+    execution ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t) s'.
+  Proof.
+    intros. eapply execution_step; [ eassumption | ].
+    cbv [step]. rewrite String.eqb_refl. eauto.
+  Qed.
 
-  Lemma invert1_step_read addr rets s s':
-    step parameters.READ s [addr] rets s' ->
-    (exists r val,
-        parameters.reg_addr r = addr
-        /\ rets = [val]
-        /\ parameters.read_step s r val s').
-  Proof. inversion 1; subst. eexists; eauto. Qed.
-
-  Lemma invert1_step_write addr val rets s s':
-    step parameters.WRITE s [addr; val] rets s' ->
-    (exists r,
-        parameters.reg_addr r = addr
-        /\ rets = []
-        /\ parameters.write_step s r val s').
-  Proof. inversion 1; subst. eexists; eauto. Qed.
-
-  Lemma interact_mmio call action binds arges t m l
-        (post : trace -> mem -> locals -> Prop) (args : list Semantics.word) :
-    dexprs m l arges args ->
-    (forall s' (rets : list Semantics.word),
-        execution ((map.empty, action, args, (map.empty, rets)) :: t) s' ->
-        (exists l0 : locals,
-            map.putmany_of_list_zip binds rets l = Some l0 /\
-            post ((map.empty, action, args, (map.empty, rets)) :: t) m l0)) ->
-    cmd call (cmd.interact binds action arges) t m l post.
+  Lemma interact_read r call bind addre t m l (post : trace -> mem -> locals -> Prop) addr :
+    dexprs m l [addre] [addr] ->
+    reg_addr r = addr ->
+    (exists s s' val, execution t s /\ read_step s r val s') ->
+    (forall s s' val,
+        execution t s ->
+        read_step s r val s' ->
+        (* implied by other preconditions but convenient to have separately *)
+        execution ((map.empty, READ, [addr], (map.empty, [val])) :: t) s' ->
+        post ((map.empty, READ, [addr], (map.empty, [val])) :: t)
+             m (map.put l bind val)) ->
+    cmd call (cmd.interact [bind] READ [addre]) t m l post.
   Proof.
     intros. eapply interact_nomem; [ eassumption | ].
     cbn [Semantics.ext_spec semantics_parameters].
-    cbv [ext_spec]. split; [reflexivity | ].
-    intros. split; [ reflexivity | ].
-    cbn [execution] in *; destruct_products.
-    eauto.
+    cbv [ext_spec]. change (READ =? WRITE)%string with false.
+    rewrite String.eqb_refl.
+    do 2 eexists; ssplit; [ reflexivity || eassumption .. | ].
+    intros; ssplit; [ reflexivity | ].
+    repeat straightline. eauto using execution_step_read.
+  Qed.
+
+  Lemma interact_write r call addre vale t m l
+        (post : trace -> mem -> locals -> Prop)  addr val :
+    dexprs m l [addre;vale] [addr;val] ->
+    reg_addr r = addr ->
+    (exists s s', execution t s /\ write_step s r val s') ->
+    (forall s s',
+        execution t s ->
+        write_step s r val s' ->
+        (* implied by other preconditions but convenient to have separately *)
+        execution ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t) s' ->
+        post ((map.empty, WRITE, [addr;val], (map.empty, [])) :: t) m l) ->
+    cmd call (cmd.interact [] WRITE [addre; vale]) t m l post.
+  Proof.
+    intros. eapply interact_nomem; [ eassumption | ].
+    cbn [Semantics.ext_spec semantics_parameters].
+    cbv [ext_spec]. rewrite String.eqb_refl.
+    do 3 eexists; ssplit; [ reflexivity || eassumption .. | ].
+    intros; ssplit; [ reflexivity | ].
+    repeat straightline. eauto using execution_step_write.
   Qed.
 End Proofs.
 
 (**** Tactics for state machine proofs ****)
 
-Ltac invert_step :=
-  lazymatch goal with
-  | H : step _ _ _ _ _ |- _ =>
-    first [ apply @invert1_step_read in H; destruct H as [? [? [? [? ?]]]]
-          | apply @invert1_step_write in H; destruct H as [? [? [? ?]]]
-          | inversion H; clear H ]; subst;
-    repeat lazymatch goal with
-           | H : _ :: _ = _ :: _ |- _ => inversion H; clear H; subst end
-  end.
+Ltac solve_dexprs :=
+  fail "Redefine the solve_dexprs tactic, and the new definition will be applied
+  to the dexprs side condition of interact_read and interact_write!".
 
-(* shorthand for applying [interact_mmio] and then doing some simplification
-   afterwards; takes a tactic argument which is run on the [dexprs] side
-   condition generated by interact_mmio *)
-Ltac interaction tac :=
-  (* get trace *)
-  let t := lazymatch goal with
-           | |- cmd _ (cmd.interact _ _ _) ?t _ _ _ => t end in
-  eapply interact_mmio; [ tac | ]; intros;
-  lazymatch goal with
-  | H : execution (_ :: t) _ |- _ =>
-    pose proof H; apply invert1_execution in H; destruct H as [? [? ?]]
-  end; invert_step.
+Ltac interact_read_reg reg :=
+  eapply (interact_read reg);
+  [ solve_dexprs
+  | reflexivity
+  | do 3 eexists; split; [ eassumption | ];
+    cbv [parameters.read_step]; eauto
+  | ];
+  repeat straightline.
+
+Ltac interact_write_reg reg :=
+  eapply (interact_write reg);
+  [ solve_dexprs
+  | reflexivity
+  | do 2 eexists; ssplit; [ eassumption | ];
+    cbv [parameters.write_step]; eauto
+  | ];
+  repeat straightline.
 
 (* Remove [execution] hypotheses that are superceded by later ones; improves
    proof performance *)

--- a/investigations/bedrock2/WhileProperties.v
+++ b/investigations/bedrock2/WhileProperties.v
@@ -29,7 +29,7 @@ Section Proofs.
 
   Lemma unroll_while functions conde body t m l
         (iterations : nat)
-        (post : trace -> mem -> locals -> Prop) (cond : Semantics.word) :
+        (post : trace -> mem -> locals -> Prop) :
     repeat_logic_step
       (fun t m l post =>
          exists cond,
@@ -37,9 +37,10 @@ Section Proofs.
            /\ word.unsigned cond <> 0
            /\ cmd (call functions) body t m l post)
       iterations (fun t m l =>
-                    dexpr m l conde cond
-                    /\ word.unsigned cond = 0
-                    /\ post t m l) t m l ->
+                    exists cond,
+                      dexpr m l conde cond
+                      /\ word.unsigned cond = 0
+                      /\ post t m l) t m l ->
     cmd (call functions) (cmd.while conde body) t m l post.
   Proof.
     lazymatch goal with


### PR DESCRIPTION
This PR contains some changes to the AES semantics and proofs that match the changes I made earlier to the increment-wait example circuit (see e.g. #792) so that it would be compatible with the bedrock2 compiler proofs. (The `ext_spec` definition forms part of the interface between program and compiler proofs; the previous version worked for proofs of programs but wouldn't have been strong enough to work with the compiler proofs.) This paves the way for actually compiling our AES code and getting proofs about the assembly.

Some of the code churn here is a change to how the state data (e.g. register values) is represented; since I was changing all these proofs anyway, it seemed worth a refactor because this representation was a major pain point before. Still not necessarily totally happy with the new solution, but it's at least much less painful than the old one (a lot of code got deleted from `AesProperties`).