### PR TITLE
Compile AES code

### DIFF
--- a/investigations/bedrock2/Aes/AesExample.v
+++ b/investigations/bedrock2/Aes/AesExample.v
@@ -19,26 +19,42 @@ Section Impl.
   Local Existing Instance constant_names.
   Local Existing Instance constant_vars.
 
+  (* Notations for small constants *)
+  Local Notation "0" := (expr.literal 0) (in custom bedrock_expr).
+
   Definition aes_encrypt : func :=
     let plaintext := "plaintext" in
     let key := "key" in
     let iv := "iv" in
     let ciphertext := "ciphertext" in
     ("b2_aes_encrypt",
-     (aes_globals ++ [plaintext; key; iv; ciphertext], [], bedrock_func_body:(
+     ([AES_CTRL; AES_CTRL_OPERATION;
+      AES_CTRL_MODE_MASK; AES_CTRL_MODE_OFFSET; AES_CTRL_KEY_LEN_MASK;
+      AES_CTRL_KEY_LEN_OFFSET; AES_CTRL_MANUAL_OPERATION; kAesEnc; kAesEcb;
+      AES_KEY0; AES_NUM_REGS_KEY; kAes256; kAes192;
+      AES_IV0; AES_NUM_REGS_IV;
+      AES_DATA_IN0; AES_NUM_REGS_DATA;
+      AES_STATUS; AES_STATUS_INPUT_READY;
+      AES_DATA_OUT0; AES_STATUS_OUTPUT_VALID;
+      plaintext; key; iv; ciphertext], [], bedrock_func_body:(
        (* initialize the AES block :
           operation = kAesEnc, mode = kAesEcb, key_len = kAes256,
           manual_operation = 0 *)
-       aes_init coq:(aes_globals ++ [kAesEnc; kAesEcb; kAes256; expr.literal 0]) ;
+       aes_init (AES_CTRL, AES_CTRL_OPERATION, AES_CTRL_MODE_MASK,
+                 AES_CTRL_MODE_OFFSET, AES_CTRL_KEY_LEN_MASK,
+                 AES_CTRL_KEY_LEN_OFFSET, AES_CTRL_MANUAL_OPERATION,
+                 kAesEnc, kAesEcb, kAes256, 0) ;
 
        (* write key and initialization vector *)
-       aes_key_put coq:(aes_globals ++ [expr.var key; expr.var kAes256]) ;
-       aes_iv_put coq:(aes_globals ++ [expr.var iv]) ;
+       aes_key_put (AES_KEY0, AES_NUM_REGS_KEY, kAes256, kAes192, key, kAes256) ;
+       aes_iv_put (AES_IV0, AES_NUM_REGS_IV, iv) ;
 
        (* write input data *)
-       aes_data_put_wait coq:(aes_globals ++ [expr.var plaintext]) ;
+       aes_data_put_wait (AES_DATA_IN0, AES_NUM_REGS_DATA, AES_STATUS,
+                          AES_STATUS_INPUT_READY, plaintext) ;
 
        (* wait for output, write it to ciphertext *)
-       aes_data_get_wait coq:(aes_globals ++ [expr.var ciphertext])
+       aes_data_get_wait (AES_DATA_OUT0, AES_NUM_REGS_DATA, AES_STATUS,
+                          AES_STATUS_OUTPUT_VALID, ciphertext)
     ))).
 End Impl.

--- a/investigations/bedrock2/Aes/AesExampleProperties.v
+++ b/investigations/bedrock2/Aes/AesExampleProperties.v
@@ -70,8 +70,17 @@ Section Proofs.
               (key0, key1, key2, key3, key4, key5, key6, key7)
               (iv0, iv1, iv2, iv3)
               (plaintext0, plaintext1, plaintext2, plaintext3) in
-        let args := [plaintext_ptr; key_ptr; iv_ptr; ciphertext_ptr] in
-        call function_env aes_encrypt tr m (aes_globals ++ args)
+        let args :=
+            [AES_CTRL; AES_CTRL_OPERATION;
+            AES_CTRL_MODE_MASK; AES_CTRL_MODE_OFFSET; AES_CTRL_KEY_LEN_MASK;
+            AES_CTRL_KEY_LEN_OFFSET; AES_CTRL_MANUAL_OPERATION; kAesEnc; kAesEcb;
+            AES_KEY0; AES_NUM_REGS_KEY; kAes256; kAes192;
+            AES_IV0; AES_NUM_REGS_IV;
+            AES_DATA_IN0; AES_NUM_REGS_DATA;
+            AES_STATUS; AES_STATUS_INPUT_READY;
+            AES_DATA_OUT0; AES_STATUS_OUTPUT_VALID;
+            plaintext_ptr; key_ptr; iv_ptr; ciphertext_ptr] in
+        call function_env aes_encrypt tr m args
              (fun tr' m' rets =>
                 let '(out0, out1, out2, out3) := expected_output in
                 (* the circuit is back in the IDLE state *)

--- a/investigations/bedrock2/Aes/AesProperties.v
+++ b/investigations/bedrock2/Aes/AesProperties.v
@@ -551,8 +551,8 @@ Section Proofs.
         R m ->
         (* no constraints on current state *)
         execution tr s ->
-        let args := [] in
-        call function_env aes_data_ready tr m (aes_globals ++ args)
+        let args := [AES_STATUS; AES_STATUS_INPUT_READY] in
+        call function_env aes_data_ready tr m args
              (fun tr' m' rets =>
                 exists (status out : Semantics.word) (s' : state),
                   (* the new state matches the new trace *)
@@ -591,8 +591,8 @@ Section Proofs.
         R m ->
         (* no constraints on current state *)
         execution tr s ->
-        let args := [] in
-        call function_env aes_data_valid tr m (aes_globals ++ args)
+        let args := [AES_STATUS; AES_STATUS_OUTPUT_VALID] in
+        call function_env aes_data_valid tr m args
              (fun tr' m' rets =>
                 exists (status out : Semantics.word) (s' : state),
                   (* the new state matches the new trace *)
@@ -632,8 +632,8 @@ Section Proofs.
         R m ->
         (* no constraints on current state *)
         execution tr s ->
-        let args := [] in
-        call function_env aes_idle tr m (aes_globals ++ args)
+        let args := [AES_STATUS; AES_STATUS_IDLE] in
+        call function_env aes_idle tr m args
              (fun tr' m' rets =>
                 exists (status out : Semantics.word) (s' : state),
                   (* the new state matches the new trace *)
@@ -683,9 +683,13 @@ Section Proofs.
         aes_key_len_t aes_cfg_key_len ->
         (* manual_operation is a boolean *)
         boolean aes_cfg_manual_operation ->
-        let args := [aes_cfg_operation; aes_cfg_mode; aes_cfg_key_len;
+        let args := [AES_CTRL; AES_CTRL_OPERATION;
+                    AES_CTRL_MODE_MASK; AES_CTRL_MODE_OFFSET;
+                    AES_CTRL_KEY_LEN_MASK; AES_CTRL_KEY_LEN_OFFSET;
+                    AES_CTRL_MANUAL_OPERATION;
+                    aes_cfg_operation; aes_cfg_mode; aes_cfg_key_len;
                     aes_cfg_manual_operation] in
-        call function_env aes_init tr m (aes_globals ++ args)
+        call function_env aes_init tr m args
              (fun tr' m' rets =>
                 (* the circuit is in IDLE state with the correct control
                    register value and no other known register values *)
@@ -772,8 +776,8 @@ Section Proofs.
                                        then 6%nat else 8%nat) ->
         (* circuit must be in IDLE state *)
         execution tr (IDLE data) ->
-        let args := [key_arr_ptr; key_len] in
-        call function_env aes_key_put tr m (aes_globals ++ args)
+        let args := [AES_KEY0; AES_NUM_REGS_KEY; kAes256; kAes192; key_arr_ptr; key_len] in
+        call function_env aes_key_put tr m args
              (fun tr' m' rets =>
                 (* the circuit is in IDLE state with the key registers updated *)
                 execution tr'
@@ -1157,8 +1161,8 @@ Section Proofs.
         length iv_arr = 4%nat ->
         (* circuit must be in IDLE state *)
         execution tr (IDLE data) ->
-        let args := [iv_ptr] in
-        call function_env aes_iv_put tr m (aes_globals ++ args)
+        let args := [AES_IV0; AES_NUM_REGS_IV; iv_ptr] in
+        call function_env aes_iv_put tr m args
              (fun tr' m' rets =>
                 (* the circuit is in IDLE state with the iv registers updated *)
                 execution tr'
@@ -1251,8 +1255,8 @@ Section Proofs.
                 write_input_reg (data_in_from_index i) data
                                 (nth i input_arr (word.of_Z 0)))
              (seq 0 4) data) = Some all_aes_input ->
-        let args := [input_ptr] in
-        call function_env aes_data_put tr m (aes_globals ++ args)
+        let args := [AES_DATA_IN0; AES_NUM_REGS_DATA; input_ptr] in
+        call function_env aes_data_put tr m args
              (fun tr' m' rets =>
                 (* the circuit is now in the BUSY state *)
                 execution tr' (BUSY (Build_busy_data
@@ -1351,8 +1355,9 @@ Section Proofs.
                 write_input_reg (data_in_from_index i) data
                                 (nth i input_arr (word.of_Z 0)))
              (seq 0 4) data) = Some all_aes_input ->
-        let args := [input_ptr] in
-        call function_env aes_data_put_wait tr m (aes_globals ++ args)
+        let args := [AES_DATA_IN0; AES_NUM_REGS_DATA;
+                    AES_STATUS; AES_STATUS_INPUT_READY; input_ptr] in
+        call function_env aes_data_put_wait tr m args
              (fun tr' m' rets =>
                 (* the circuit is now in the BUSY state *)
                 execution tr' (BUSY (Build_busy_data
@@ -1421,8 +1426,8 @@ Section Proofs.
         data.(done_data_out1) = Some out1 ->
         data.(done_data_out2) = Some out2 ->
         data.(done_data_out3) = Some out3 ->
-        let args := [data_ptr] in
-        call function_env aes_data_get tr m (aes_globals ++ args)
+        let args := [AES_DATA_OUT0; AES_NUM_REGS_DATA; data_ptr] in
+        call function_env aes_data_get tr m args
              (fun tr' m' rets =>
                 (* the circuit is now in the IDLE state with output registers unset *)
                 execution tr' (IDLE (Build_idle_data
@@ -1568,8 +1573,9 @@ Section Proofs.
            termination) and expected or already-written output matches out *)
         execution tr s ->
         output_matches_state out s ->
-        let args := [data_ptr] in
-        call function_env aes_data_get_wait tr m (aes_globals ++ args)
+        let args := [AES_DATA_OUT0; AES_NUM_REGS_DATA; AES_STATUS;
+                    AES_STATUS_OUTPUT_VALID; data_ptr] in
+        call function_env aes_data_get_wait tr m args
              (fun tr' m' rets =>
                 (* the circuit is now in the IDLE state with output registers unset *)
                 execution tr' (IDLE (Build_idle_data (get_ctrl s) None None None None

--- a/investigations/bedrock2/Aes/AesToRiscV.v
+++ b/investigations/bedrock2/Aes/AesToRiscV.v
@@ -1,0 +1,202 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Strings.String.
+Require Import Coq.micromega.Lia.
+Require Import Coq.derive.Derive.
+Require Import bedrock2.Syntax.
+Require Import compiler.FlatToRiscvDef.
+Require Import compiler.MemoryLayout.
+Require Import compiler.Pipeline.
+Require Import compiler.RiscvWordProperties.
+Require Import coqutil.Word.Interface.
+Require Import coqutil.Map.Z_keyed_SortedListMap.
+Require Import coqutil.Z.HexNotation.
+Require Import Bedrock2Experiments.WordProperties.
+Require Import Bedrock2Experiments.StateMachineMMIO.
+Require Import Bedrock2Experiments.StateMachineSemantics.
+Require Import Bedrock2Experiments.Aes.Constants.
+Require Import Bedrock2Experiments.Aes.Aes.
+Require Import Bedrock2Experiments.Aes.AesSemantics.
+Require coqutil.Word.Naive.
+Require coqutil.Map.SortedListWord.
+Require riscv.Utility.InstructionNotations.
+Import Syntax.Coercions.
+Local Open Scope string_scope.
+
+(* TODO: we actually need a different word implementation than Naive here; in
+   corner cases such as a shift argument greater than the width of the word,
+   the naive implementation violates the riscv_ok requirements *)
+Axiom naive_riscv_ok : word.riscv_ok (Naive.word 32).
+Instance p : MMIO.parameters :=
+  {| MMIO.word := Naive.word 32;
+     MMIO.word_ok := Naive.word32_ok;
+     MMIO.word_riscv_ok := naive_riscv_ok;
+     MMIO.mem := SortedListWord.map _ _;
+     MMIO.mem_ok := _;
+     MMIO.locals := Zkeyed_map _;
+     MMIO.locals_ok := Zkeyed_map_ok _;
+     MMIO.funname_env := SortedListString.map;
+     MMIO.funname_env_ok := SortedListString.ok;
+  |}.
+
+Definition ml: MemoryLayout := {|
+  MemoryLayout.code_start    := word.of_Z 0;
+  MemoryLayout.code_pastend  := word.of_Z (4*2^10);
+  MemoryLayout.heap_start    := word.of_Z (4*2^10);
+  MemoryLayout.heap_pastend  := word.of_Z (8*2^10);
+  MemoryLayout.stack_start   := word.of_Z (8*2^10);
+  MemoryLayout.stack_pastend := word.of_Z (16*2^10);
+                              |}.
+
+(* Magic number for aes base address found in
+   third_party/opentitan/hw/top_earlgrey/sw/autogen/top_earlgrey.h:
+
+   #define TOP_EARLGREY_AES_BASE_ADDR 0x40110000u *)
+Definition AES_BASE_ADDR : Z := Ox"40110000".
+
+Local Infix "<<" := Z.shiftl (at level 40) : Z_scope.
+Instance consts : aes_constants Z :=
+  {|
+  (**** Constants from aes_regs.h ****)
+
+  (* #define AES_KEY0(id) (AES##id##_BASE_ADDR + 0x0) *)
+  AES_KEY0 := AES_BASE_ADDR + Ox"0";
+
+  (* #define AES_IV0(id) (AES##id##_BASE_ADDR + 0x20) *)
+  AES_IV0 := AES_BASE_ADDR + Ox"20";
+
+  (* #define AES_DATA_IN0(id) (AES##id##_BASE_ADDR + 0x30) *)
+  AES_DATA_IN0 := AES_BASE_ADDR + Ox"30";
+
+  (* #define AES_DATA_OUT0(id) (AES##id##_BASE_ADDR + 0x40) *)
+  AES_DATA_OUT0 := AES_BASE_ADDR + Ox"40";
+
+  (* #define AES_CTRL(id) (AES##id##_BASE_ADDR + 0x50) *)
+  AES_CTRL := AES_BASE_ADDR + Ox"50";
+
+  (* #define AES_CTRL_REG_OFFSET 0x50
+     #define AES_CTRL_OPERATION 0
+     #define AES_CTRL_MODE_MASK 0x7
+     #define AES_CTRL_MODE_OFFSET 1
+     #define AES_CTRL_KEY_LEN_MASK 0x7
+     #define AES_CTRL_KEY_LEN_OFFSET 4
+     #define AES_CTRL_MANUAL_OPERATION 7 *)
+  AES_CTRL_OPERATION := 0;
+  AES_CTRL_MODE_MASK := Ox"7";
+  AES_CTRL_MODE_OFFSET := 1;
+  AES_CTRL_KEY_LEN_MASK := Ox"7";
+  AES_CTRL_KEY_LEN_OFFSET := 4;
+  AES_CTRL_MANUAL_OPERATION := 7;
+
+  (* #define AES_STATUS(id) (AES##id##_BASE_ADDR + 0x58) *)
+  AES_STATUS := AES_BASE_ADDR + Ox"58";
+
+  (* #define AES_STATUS_IDLE 0
+     #define AES_STATUS_STALL 1
+     #define AES_STATUS_OUTPUT_VALID 2
+     #define AES_STATUS_INPUT_READY 3 *)
+  AES_STATUS_IDLE := 0;
+  AES_STATUS_STALL := 1;
+  AES_STATUS_OUTPUT_VALID := 2;
+  AES_STATUS_INPUT_READY := 3;
+
+  (* #define AES_PARAM_NUMREGSKEY 8 *)
+  AES_NUM_REGS_KEY := 8;
+
+  (* #define AES_PARAM_NUMREGSIV 4 *)
+  AES_NUM_REGS_IV := 4;
+
+  (* #define AES_PARAM_NUMREGSDATA 4 *)
+  AES_NUM_REGS_DATA := 4;
+
+  (**** Enums from aes.h ****)
+
+  (* typedef enum aes_op { kAesEnc = 0, kAesDec = 1 } aes_op_t; *)
+  kAesEnc := 0;
+  kAesDec := 1;
+
+  (* typedef enum aes_mode {
+       kAesEcb = 1 << 0,
+       kAesCbc = 1 << 1,
+       kAesCtr = 1 << 2
+     } aes_mode_t; *)
+  kAesEcb := 1 << 0;
+  kAesCbc := 1 << 1;
+  kAesCtr := 1 << 2;
+
+  (* typedef enum aes_key_len {
+       kAes128 = 1 << 0,
+       kAes192 = 1 << 1,
+       kAes256 = 1 << 2
+     } aes_key_len_t; *)
+  kAes128 := 1 << 0;
+  kAes192 := 1 << 1;
+  kAes256 := 1 << 2;
+
+  |}.
+
+Instance aes_timing : timing := {| timing.ndelays_core := 14%nat |}.
+
+Instance aes_parameters : AesSemantics.parameters.parameters :=
+  {| AesSemantics.parameters.word := MMIO.word;
+     AesSemantics.parameters.mem := MMIO.mem;
+     AesSemantics.parameters.aes_spec := fun _ _ _ x => x (* TODO: replace with real AES spec *);
+  |}.
+
+Instance aes_parameters_ok : AesSemantics.parameters.ok aes_parameters :=
+  {| AesSemantics.parameters.word_ok := MMIO.word_ok;
+     AesSemantics.parameters.mem_ok := MMIO.mem_ok;
+  |}.
+
+Existing Instances Words32 semantics_parameters StateMachineSemantics.ok state_machine_parameters
+         compilation_params StateMachineMMIOSpec FlatToRiscv_params constant_words.
+
+(* add a stronger hint for state_machine_parameters *)
+Local Hint Extern 1 (StateMachineSemantics.parameters _ _ _) =>
+exact state_machine_parameters : typeclass_instances.
+
+Instance pipeline_params : Pipeline.parameters :=
+  {|
+  Pipeline.W := Words32;
+  Pipeline.mem := _;
+  Pipeline.Registers := _;
+  Pipeline.string_keyed_map := _;
+  Pipeline.ext_spec := @FlatToRiscvCommon.ext_spec FlatToRiscv_params;
+  Pipeline.compile_ext_call := (@FlatToRiscvDef.compile_ext_call compilation_params);
+  Pipeline.M := _;
+  Pipeline.MM := _;
+  Pipeline.RVM := MetricMinimalMMIO.IsRiscvMachine;
+  Pipeline.PRParams := @FlatToRiscvCommon.PRParams FlatToRiscv_params
+  |}.
+
+Definition funcs := [aes_init
+                     ; aes_key_put
+                     ; aes_iv_put
+                     ; aes_data_put
+                     ; aes_data_get
+                     ; aes_data_ready
+                     ; aes_data_valid
+                     ; aes_idle
+                     ; aes_data_put_wait
+                     ; aes_data_get_wait].
+
+Derive aes_compile_result
+       SuchThat (compile (map.of_list funcs)
+                 = Some aes_compile_result)
+       As aes_compile_result_eq.
+Proof.
+  (* doing a more surgical vm_compute in the lhs only avoids fully computing the map
+     type, which would slow eq_refl and Qed dramatically *)
+  lazymatch goal with
+    |- ?lhs = _ =>
+    let x := (eval vm_compute in lhs) in
+    change lhs with x
+  end.
+  exact eq_refl.
+Qed.
+
+Definition aes_asm := Eval compute in fst (fst aes_compile_result).
+
+Module PrintAssembly.
+  Import riscv.Utility.InstructionNotations.
+  Redirect "aes.s" Print aes_asm.
+End PrintAssembly.


### PR DESCRIPTION
Compile the AES firmware to assembly! :tada: 

Unfortunately, the bedrock2 compiler has a restriction on the number of arguments a function can have (arguments + return values + 5 < 32), which meant the previous strategy of passing all global constants into all functions would result in too many arguments. This PR therefore modifies each function to take only the globals it actually needs as arguments.