### PR TITLE
Proofs about AES assembly

### DIFF
--- a/investigations/bedrock2/Aes/AesExampleProperties.v
+++ b/investigations/bedrock2/Aes/AesExampleProperties.v
@@ -47,8 +47,7 @@ Section Proofs.
                     key0 key1 key2 key3 key4 key5 key6 key7
                     iv0 iv1 iv2 iv3 : Semantics.word)
         (* initial values of output array (used only for determining length) *)
-        (ciphertext_arr : list Semantics.word)
-        (s : state),
+        (ciphertext_arr : list Semantics.word),
         let plaintext_arr := [plaintext0; plaintext1; plaintext2; plaintext3] in
         let key_arr := [key0; key1; key2; key3; key4; key5; key6; key7] in
         let iv_arr := [iv0; iv1; iv2; iv3] in

--- a/investigations/bedrock2/Aes/AesExampleToRiscV.v
+++ b/investigations/bedrock2/Aes/AesExampleToRiscV.v
@@ -1,0 +1,79 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Strings.String.
+Require Import Coq.micromega.Lia.
+Require Import Coq.derive.Derive.
+Require Import bedrock2.Syntax.
+Require Import compiler.FlatToRiscvDef.
+Require Import compiler.MemoryLayout.
+Require Import compiler.Pipeline.
+Require Import compiler.RiscvWordProperties.
+Require Import coqutil.Word.Interface.
+Require Import coqutil.Map.Z_keyed_SortedListMap.
+Require Import coqutil.Z.HexNotation.
+Require Import Bedrock2Experiments.WordProperties.
+Require Import Bedrock2Experiments.StateMachineMMIO.
+Require Import Bedrock2Experiments.StateMachineSemantics.
+Require Import Bedrock2Experiments.Aes.Constants.
+Require Import Bedrock2Experiments.Aes.Aes.
+Require Import Bedrock2Experiments.Aes.AesExample.
+Require Import Bedrock2Experiments.Aes.AesToRiscV.
+Require Import Bedrock2Experiments.Aes.AesSemantics.
+Require coqutil.Word.Naive.
+Require coqutil.Map.SortedListWord.
+Require riscv.Utility.InstructionNotations.
+Import Syntax.Coercions.
+Local Open Scope string_scope.
+
+(* use literals for the main function *)
+Existing Instance constant_literals.
+
+(* pointers to input and output memory locations (these are dummy values) *)
+Definition input_data_ptr := AES_BASE_ADDR + Ox"70".
+Definition input_iv_ptr := AES_BASE_ADDR + Ox"80".
+Definition input_key_ptr := AES_BASE_ADDR + Ox"90".
+Definition output_ptr := AES_BASE_ADDR + Ox"70".
+
+(* main function: simply call aes_encrypt with literal constants and pointers *)
+Definition main_body : cmd :=
+  cmd.call []
+           aes_encrypt
+           [AES_CTRL; AES_CTRL_OPERATION;
+           AES_CTRL_MODE_MASK; AES_CTRL_MODE_OFFSET;
+           AES_CTRL_KEY_LEN_MASK; AES_CTRL_KEY_LEN_OFFSET;
+           AES_CTRL_MANUAL_OPERATION; kAesEnc; kAesEcb;
+           AES_KEY0; AES_NUM_REGS_KEY; kAes256; kAes192;
+           AES_IV0; AES_NUM_REGS_IV;
+           AES_DATA_IN0; AES_NUM_REGS_DATA;
+           AES_STATUS; AES_STATUS_INPUT_READY;
+           AES_DATA_OUT0; AES_STATUS_OUTPUT_VALID;
+           expr.literal input_data_ptr;
+           expr.literal input_key_ptr;
+           expr.literal input_iv_ptr;
+           expr.literal output_ptr].
+
+Definition main : func :=
+  ("main", ([], [], main_body)).
+
+Definition funcs : list func := [main; aes_encrypt].
+
+Derive aes_example_compile_result
+       SuchThat (compile (map.of_list (funcs ++ AesToRiscV.funcs))
+                 = Some aes_example_compile_result)
+       As aes_example_compile_result_eq.
+Proof.
+  (* doing a more surgical vm_compute in the lhs only avoids fully computing the map
+     type, which would slow eq_refl and Qed dramatically *)
+  lazymatch goal with
+    |- ?lhs = _ =>
+    let x := (eval vm_compute in lhs) in
+    change lhs with x
+  end.
+  exact eq_refl.
+Qed.
+
+Definition aes_example_asm := Eval compute in fst (fst aes_example_compile_result).
+
+Module PrintAssembly.
+  Import riscv.Utility.InstructionNotations.
+  Redirect "aes_example.s" Print aes_example_asm.
+End PrintAssembly.

--- a/investigations/bedrock2/Aes/AesExampleToRiscVProperties.v
+++ b/investigations/bedrock2/Aes/AesExampleToRiscVProperties.v
@@ -1,0 +1,266 @@
+Require Import Coq.derive.Derive.
+Require Import Coq.Lists.List.
+Require Import Coq.Strings.String.
+Require Import Coq.ZArith.ZArith.
+Require Import bedrock2.Array.
+Require Import bedrock2.Map.Separation.
+Require Import bedrock2.Map.SeparationLogic.
+Require Import bedrock2.MetricLogging.
+Require Import bedrock2.ProgramLogic.
+Require Import bedrock2.Semantics.
+Require Import bedrock2.Scalars.
+Require Import bedrock2.Syntax.
+Require Import bedrock2.WeakestPreconditionProperties.
+Require Import compiler.FlatToRiscvCommon.
+Require Import compiler.Pipeline.
+Require Import Cava.Util.Tactics.
+Require Import Bedrock2Experiments.List.
+Require Import Bedrock2Experiments.Tactics.
+Require Import Bedrock2Experiments.StateMachineMMIO.
+Require Import Bedrock2Experiments.StateMachineSemantics.
+Require Import Bedrock2Experiments.Aes.Constants.
+Require Import Bedrock2Experiments.Aes.AesExample.
+Require Import Bedrock2Experiments.Aes.AesExampleProperties.
+Require Import Bedrock2Experiments.Aes.AesProperties.
+Require Import Bedrock2Experiments.Aes.AesSemantics.
+Require Import Bedrock2Experiments.Aes.AesToRiscV.
+Require Import Bedrock2Experiments.Aes.AesExampleToRiscV.
+Import Syntax.Coercions.
+Import ListNotations.
+Local Open Scope string_scope.
+
+Local Hint Resolve FlattenExpr.mk_Semantics_params_ok FlattenExpr_hyps : typeclass_instances.
+Existing Instances constant_words spec_of_aes_encrypt.
+
+(* add a stronger hint for state_machine_parameters *)
+Local Hint Extern 1 (StateMachineSemantics.parameters _ _ _) =>
+exact state_machine_parameters : typeclass_instances.
+
+Instance consts_ok : aes_constants_ok (constant_words (word_ok:=parameters.word_ok)).
+Proof.
+  apply Build_aes_constants_ok with (mode_size:=3) (key_len_size:=3).
+  { reflexivity. }
+  { repeat constructor. }
+  { repeat constructor.
+    all:vm_compute; congruence. }
+  { reflexivity. }
+  { repeat constructor. }
+  { reflexivity. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { vm_compute; ssplit; congruence. }
+  { repeat constructor;
+    vm_compute; ssplit; congruence. }
+  { repeat constructor;
+    vm_compute; ssplit; congruence. }
+  { repeat constructor;
+    vm_compute; ssplit; congruence. }
+Qed.
+
+Instance Pipeline_assumptions : Pipeline.assumptions.
+Proof.
+  constructor.
+  { apply MMIO.word_riscv_ok. }
+  { exact MMIO.funname_env_ok. }
+  { exact MMIO.locals_ok. }
+  { exact PR. }
+  { exact FlatToRiscv_hyps. }
+  { exact (ext_spec_ok (p:=state_machine_parameters)). }
+  { exact (compile_ext_call_correct (state_machine_parameters_ok:=state_machine_parameters_ok)). }
+  { reflexivity. }
+Qed.
+
+Definition post_main
+           (in0 in1 in2 in3 iv0 iv1 iv2 iv3
+                key0 key1 key2 key3 key4 key5 key6 key7
+            : parameters.word) R
+           (t' : trace) (m' : Semantics.mem) : Prop :=
+  let '(out0,out1,out2,out3) :=
+      parameters.aes_spec
+        false (key0, key1, key2, key3, key4, key5, key6, key7)
+        (iv0, iv1, iv2, iv3) (in0, in1, in2, in3) in
+  (* trace is valid and leads to IDLE state *)
+  (exists data, execution t' (IDLE data))
+  (* input is unchanged and output holds the result of AES encrypt *)
+  /\ (array scalar32 (word.of_Z 4) (word.of_Z input_data_ptr) [in0;in1;in2;in3]
+     * array scalar32 (word.of_Z 4) (word.of_Z input_key_ptr)
+             [key0;key1;key2;key3;key4;key5;key6;key7]
+     * array scalar32 (word.of_Z 4) (word.of_Z input_iv_ptr) [iv0;iv1;iv2;iv3]
+     * array scalar32 (word.of_Z 4) (word.of_Z output_ptr) [out0;out1;out2;out3]
+     * R)%sep m'.
+
+Local Ltac simplify_implicits :=
+  change (FlattenExpr.mk_Semantics_params
+          Pipeline.FlattenExpr_parameters) with semantics_parameters in *;
+  change Semantics.width with 32 in *;
+  change Semantics.word with parameters.word in *.
+
+Lemma main_correct
+      fs in0 in1 in2 in3 iv0 iv1 iv2 iv3
+      key0 key1 key2 key3 key4 key5 key6 key7
+      output_placeholder
+      R (t : @trace semantics_parameters) m l :
+  (array scalar32 (word.of_Z 4) (word.of_Z input_data_ptr) [in0;in1;in2;in3]
+   * array scalar32 (word.of_Z 4) (word.of_Z input_key_ptr)
+           [key0;key1;key2;key3;key4;key5;key6;key7]
+   * array scalar32 (word.of_Z 4) (word.of_Z input_iv_ptr) [iv0;iv1;iv2;iv3]
+   * array scalar32 (word.of_Z 4) (word.of_Z output_ptr) output_placeholder
+   * R)%sep m ->
+  length output_placeholder = 4%nat ->
+  spec_of_aes_encrypt fs ->
+  execution (p:=state_machine_parameters) t UNINITIALIZED ->
+  WeakestPrecondition.cmd
+    (WeakestPrecondition.call fs)
+    main_body t m l
+    (fun t' m' _ =>
+       post_main in0 in1 in2 in3 iv0 iv1 iv2 iv3
+                 key0 key1 key2 key3 key4 key5 key6 key7
+                 R t' m').
+Proof.
+  intros. repeat straightline.
+  straightline_call; [ simplify_implicits; ecancel_assumption | assumption .. | ].
+  cbv [post_main]. simplify_implicits.
+  repeat destruct_one_match_hyp.
+  repeat straightline.
+  ssplit; [ solve [eauto] | ].
+  ecancel_assumption.
+Qed.
+
+Lemma exec_main
+      fs in0 in1 in2 in3 iv0 iv1 iv2 iv3
+      key0 key1 key2 key3 key4 key5 key6 key7
+      output_placeholder R
+      (t : trace) (m : Semantics.mem) (l : Semantics.locals) mc :
+  (array scalar32 (word.of_Z 4) (word.of_Z input_data_ptr) [in0;in1;in2;in3]
+   * array scalar32 (word.of_Z 4) (word.of_Z input_key_ptr)
+           [key0;key1;key2;key3;key4;key5;key6;key7]
+   * array scalar32 (word.of_Z 4) (word.of_Z input_iv_ptr) [iv0;iv1;iv2;iv3]
+   * array scalar32 (word.of_Z 4) (word.of_Z output_ptr) output_placeholder
+   * R)%sep m ->
+  length output_placeholder = 4%nat ->
+  spec_of_aes_encrypt (main :: fs) ->
+  execution t UNINITIALIZED ->
+  NoDup (map fst (main :: fs)) ->
+  exec (map.of_list (main :: fs))
+       main_body t m l mc
+       (fun t' m' _ _=>
+          post_main in0 in1 in2 in3 iv0 iv1 iv2 iv3
+                    key0 key1 key2 key3 key4 key5 key6 key7
+                    R t' m').
+Proof.
+  intros. apply sound_cmd; [ assumption | ].
+  eapply main_correct; eauto.
+Qed.
+
+(* Location in the instructions that marks the start of the [main] routine *)
+Definition main_relative_pos : Z.
+  let x := constr:(map.get
+                     (snd (fst aes_example_compile_result))
+                     main) in
+  let x := eval vm_compute in x in
+      lazymatch x with
+      | Some ?y => exact y
+      end.
+Defined.
+
+Lemma aes_example_asm_correct
+      in0 in1 in2 in3 iv0 iv1 iv2 iv3
+      key0 key1 key2 key3 key4 key5 key6 key7
+      output_placeholder R Rdata Rexec
+      (p_functions p_call : Utility.word)
+      (mem : Pipeline.mem)
+      (initial : MetricRiscvMachine) :
+  (* given that the input and output pointers are valid and the input pointers
+     point to the in, key, and iv values... *)
+  (array scalar32 (word.of_Z 4) (word.of_Z input_data_ptr) [in0;in1;in2;in3]
+   * array scalar32 (word.of_Z 4) (word.of_Z input_key_ptr)
+           [key0;key1;key2;key3;key4;key5;key6;key7]
+   * array scalar32 (word.of_Z 4) (word.of_Z input_iv_ptr) [iv0;iv1;iv2;iv3]
+   * array scalar32 (word.of_Z 4) (word.of_Z output_ptr) output_placeholder
+   * R)%sep mem ->
+  (* ...and there is enough space for the output *)
+  length output_placeholder = 4%nat ->
+  (* ...and the trace so far leads to an UNINITIALIZED state... *)
+  execution (getLog initial) UNINITIALIZED ->
+  (* ...and the current machine state is OK... *)
+  let instrs := fst (fst (aes_example_compile_result)) in
+  LowerPipeline.machine_ok
+    p_functions main_relative_pos
+    (stack_start ml) (stack_pastend ml)
+    instrs p_call p_call mem Rdata Rexec initial ->
+  (* ...then, after the [main] routine is executed... *)
+  runsTo initial
+         (fun final : MetricRiscvMachine =>
+            exists mem',
+              (* ...the postcondition of [main] holds on the new trace and
+                 memory... *)
+              post_main in0 in1 in2 in3 iv0 iv1 iv2 iv3
+                        key0 key1 key2 key3 key4 key5 key6 key7
+                        R (getLog final) mem'
+              (* ...and the new machine state is OK *)
+              /\ LowerPipeline.machine_ok
+                  p_functions main_relative_pos
+                  (stack_start ml) (stack_pastend ml)
+                  instrs p_call (word.add p_call (word.of_Z 4)) mem' Rdata Rexec final).
+Proof.
+  intros.
+  let fs := constr:(map.of_list (funcs ++ AesToRiscV.funcs)) in
+  eapply compiler_correct
+    with (functions:=fs)
+         (mc:=bedrock2.MetricLogging.EmptyMetricLog)
+         (f_entry_name := main)
+         (postH:=post_main
+                   in0 in1 in2 in3 iv0 iv1 iv2 iv3
+                   key0 key1 key2 key3 key4 key5 key6 key7 R).
+  { constructor; vm_compute; congruence. }
+  { cbv [ExprImp.valid_funs]. intros *.
+    cbv [map.of_list
+           List.app
+           aes_encrypt main
+           Aes.aes_init Aes.aes_key_put
+           Aes.aes_iv_put Aes.aes_data_put
+           Aes.aes_data_get Aes.aes_data_ready
+           Aes.aes_data_valid Aes.aes_idle
+           Aes.aes_data_put_wait Aes.aes_data_get_wait
+           funcs AesToRiscV.funcs].
+    rewrite !map.get_put_dec, map.get_empty.
+    repeat destruct_one_match; inversion 1; cbv [ExprImp.valid_fun].
+    all:ssplit.
+    all:apply dedup_NoDup_iff with (aeqb_spec:=String.eqb_spec).
+    all:reflexivity. }
+  { exact aes_example_compile_result_eq. }
+  { cbv [map.of_list
+           List.app
+           aes_encrypt main
+           Aes.aes_init Aes.aes_key_put
+           Aes.aes_iv_put Aes.aes_data_put
+           Aes.aes_data_get Aes.aes_data_ready
+           Aes.aes_data_valid Aes.aes_idle
+           Aes.aes_data_put_wait Aes.aes_data_get_wait
+           funcs AesToRiscV.funcs].
+    rewrite !map.get_put_dec, map.get_empty.
+    rewrite String.eqb_refl. reflexivity. }
+  { reflexivity. }
+  { vm_compute. congruence. }
+  { eapply exec_main; eauto.
+    { apply aes_encrypt_correct.
+      { apply aes_init_correct. }
+      { apply aes_key_put_correct. }
+      { apply aes_iv_put_correct. }
+      { apply aes_data_put_wait_correct.
+        { apply aes_data_ready_correct. }
+        { apply aes_data_put_correct. } }
+      { apply aes_data_get_wait_correct.
+        { apply aes_data_valid_correct. }
+        { apply aes_data_get_correct. } } }
+    { apply dedup_NoDup_iff with (aeqb_spec:=String.eqb_spec).
+      reflexivity. } }
+  { eauto. }
+Qed.

--- a/investigations/bedrock2/Aes/AesToRiscV.v
+++ b/investigations/bedrock2/Aes/AesToRiscV.v
@@ -136,10 +136,17 @@ Instance consts : aes_constants Z :=
 
 Instance aes_timing : timing := {| timing.ndelays_core := 14%nat |}.
 
+(* TODO: fill in with real circuit spec *)
+Axiom aes_spec
+  : bool ->
+    MMIO.word * MMIO.word * MMIO.word * MMIO.word * MMIO.word * MMIO.word * MMIO.word * MMIO.word ->
+    MMIO.word * MMIO.word * MMIO.word * MMIO.word -> MMIO.word * MMIO.word * MMIO.word * MMIO.word ->
+    MMIO.word * MMIO.word * MMIO.word * MMIO.word.
+
 Instance aes_parameters : AesSemantics.parameters.parameters :=
   {| AesSemantics.parameters.word := MMIO.word;
      AesSemantics.parameters.mem := MMIO.mem;
-     AesSemantics.parameters.aes_spec := fun _ _ _ x => x (* TODO: replace with real AES spec *);
+     AesSemantics.parameters.aes_spec := aes_spec;
   |}.
 
 Instance aes_parameters_ok : AesSemantics.parameters.ok aes_parameters :=

--- a/investigations/bedrock2/Aes/AesToRiscV.v
+++ b/investigations/bedrock2/Aes/AesToRiscV.v
@@ -168,16 +168,16 @@ Instance pipeline_params : Pipeline.parameters :=
   Pipeline.PRParams := @FlatToRiscvCommon.PRParams FlatToRiscv_params
   |}.
 
-Definition funcs := [aes_init
+Definition funcs := [aes_data_put_wait
+                     ; aes_data_get_wait
+                     ; aes_init
                      ; aes_key_put
                      ; aes_iv_put
                      ; aes_data_put
                      ; aes_data_get
                      ; aes_data_ready
                      ; aes_data_valid
-                     ; aes_idle
-                     ; aes_data_put_wait
-                     ; aes_data_get_wait].
+                     ; aes_idle].
 
 Derive aes_compile_result
        SuchThat (compile (map.of_list funcs)

--- a/investigations/bedrock2/Aes/Constants.v
+++ b/investigations/bedrock2/Aes/Constants.v
@@ -84,6 +84,40 @@ Definition constant_vars
      kAes256 := expr.var kAes256;
   |}.
 
+(* Given the Z values of all the constants, coerce them to bedrock2
+   expressions with expr.literal *)
+Definition constant_literals
+           {vals : aes_constants Z}
+  : aes_constants expr :=
+  {| AES_KEY0 := expr.literal AES_KEY0;
+     AES_IV0 := expr.literal AES_IV0;
+     AES_DATA_IN0 := expr.literal AES_DATA_IN0;
+     AES_DATA_OUT0 := expr.literal AES_DATA_OUT0;
+     AES_CTRL := expr.literal AES_CTRL;
+     AES_CTRL_OPERATION := expr.literal AES_CTRL_OPERATION;
+     AES_CTRL_MODE_MASK := expr.literal AES_CTRL_MODE_MASK;
+     AES_CTRL_MODE_OFFSET := expr.literal AES_CTRL_MODE_OFFSET;
+     AES_CTRL_KEY_LEN_MASK := expr.literal AES_CTRL_KEY_LEN_MASK;
+     AES_CTRL_KEY_LEN_OFFSET := expr.literal AES_CTRL_KEY_LEN_OFFSET;
+     AES_CTRL_MANUAL_OPERATION := expr.literal AES_CTRL_MANUAL_OPERATION;
+     AES_STATUS := expr.literal AES_STATUS;
+     AES_STATUS_IDLE := expr.literal AES_STATUS_IDLE;
+     AES_STATUS_STALL := expr.literal AES_STATUS_STALL;
+     AES_STATUS_OUTPUT_VALID := expr.literal AES_STATUS_OUTPUT_VALID;
+     AES_STATUS_INPUT_READY := expr.literal AES_STATUS_INPUT_READY;
+     AES_NUM_REGS_KEY := expr.literal AES_NUM_REGS_KEY;
+     AES_NUM_REGS_IV := expr.literal AES_NUM_REGS_IV;
+     AES_NUM_REGS_DATA := expr.literal AES_NUM_REGS_DATA;
+     kAesEnc := expr.literal kAesEnc;
+     kAesDec := expr.literal kAesDec;
+     kAesEcb := expr.literal kAesEcb;
+     kAesCbc := expr.literal kAesCbc;
+     kAesCtr := expr.literal kAesCtr;
+     kAes128 := expr.literal kAes128;
+     kAes192 := expr.literal kAes192;
+     kAes256 := expr.literal kAes256;
+  |}.
+
 (* Given the Z values of all the constants, convert them to words with
    word.of_Z *)
 Definition constant_words


### PR DESCRIPTION
- Compiles the AES example program (which uses the AES API to perform a full round of encryption)
- Uses the bedrock2 compiler proofs to show that the compiled assembly has the expected behavior

Right now, the specification that describes what exactly the circuit does with the input is an axiom. I think a good next step from here would possibly be to plug in the real AES spec from our circuit verification, create an example program that runs _decryption_, and prove that composing the two is the identity all the way at the assembly level -- that would give us some assurance that we can build on top of the proofs.