### PR TITLE
Interactive circuit retiming

### DIFF
--- a/cava/Cava/Core/CavaClass.v
+++ b/cava/Cava/Core/CavaClass.v
@@ -36,7 +36,6 @@ Class Cava {signal : sdenote} := {
   constantV : forall {A} {n : nat}, Vector.t (signal A) n -> signal (Vec A n);
   (* Default values. *)
   defaultSignal : forall {t: SignalType}, signal t;
-  defaultValue : forall {t : type}, value t := fun t => default_value (@defaultSignal) t;
   (* SystemVerilog primitive gates *)
   inv : signal Bit -> cava (signal Bit);
   and2 : signal Bit * signal Bit -> cava (signal Bit);
@@ -85,6 +84,9 @@ Class Cava {signal : sdenote} := {
       value (circuitInputs intf) -> cava (value (circuitOutputs intf));
 }.
 Global Arguments Cava : clear implicits.
+
+Definition defaultValue `{semantics : Cava} {t : type} : value t :=
+  default_value (@defaultSignal _ _) t.
 
 Require Import Cava.Util.Vector.
 Require Import ExtLib.Structures.Monads.

--- a/cava/Cava/Core/Circuit.v
+++ b/cava/Cava/Core/Circuit.v
@@ -35,9 +35,9 @@ Section WithCava.
   | First : forall {i o t}, Circuit i o -> Circuit (i * t) (o * t)
   | Second : forall {i o t}, Circuit i o -> Circuit (t * i) (t * o)
   | LoopInitCE :
-      forall {i o : type} {s : SignalType} (resetval : combType s),
+      forall {i o s : type} (resetval : value (signal:=combType) s),
         Circuit (i * s) (o * s) -> Circuit (i * Bit) o
-  | DelayInitCE : forall {t} (resetval : combType t), Circuit (t * Bit) t
+  | DelayInitCE : forall {t} (resetval : value (signal:=combType) t), Circuit (t * Bit) t
   .
 
   (* Internal state of the circuit (register values) *)
@@ -64,31 +64,32 @@ Section WithCava.
     end.
 
   (* Loop with no enable; set enable to always be true *)
-  Definition LoopInit {i o s} (resetval : combType s)
+  Definition LoopInit {i o s} (resetval : value (signal:=combType) s)
              (body : Circuit (i * s) (o * s))
     : Circuit i o :=
     Compose (Comb (fun i => ret (i, constant true)))
             (LoopInitCE resetval body).
   (* Delay with no enable; set enable to always be true *)
-  Definition DelayInit {t} (resetval : combType t)
+  Definition DelayInit {t} (resetval : value (signal:=combType) t)
     : Circuit t t :=
     Compose (Comb (fun i => ret (i, constant true))) (DelayInitCE resetval).
 
   (* Loop with the default signal as its reset value *)
-  Definition LoopCE {i o} {s : SignalType}
+  Definition LoopCE {i o s}
     : Circuit (i * s) (o * s) -> Circuit (i * Bit) o :=
-    LoopInitCE (defaultCombValue s).
+    LoopInitCE (default_value defaultCombValue s).
   (* Delay with the default signal as its reset value *)
-  Definition DelayCE {t : SignalType} : Circuit (t * Bit) t :=
-    DelayInitCE (defaultCombValue t).
+  Definition DelayCE {t} : Circuit (t * Bit) t :=
+    DelayInitCE (default_value defaultCombValue t).
 
   (* Loop with the default signal as its reset value and no enable *)
-  Definition Loop {i o} {s : SignalType} (body : Circuit (i * s) (o * s))
-    : Circuit i o :=
-    Compose (Comb (fun i => ret (i, constant true))) (LoopInitCE (defaultCombValue s) body).
+  Definition Loop {i o s} (body : Circuit (i * s) (o * s)) : Circuit i o :=
+    Compose (Comb (fun i => ret (i, constant true)))
+            (LoopInitCE (default_value defaultCombValue s) body).
   (* Delay with the default signal as its reset value and no enable *)
-  Definition Delay {t : SignalType} : Circuit t t :=
-    Compose (Comb (fun i => ret (i, constant true))) (DelayInitCE (defaultCombValue t)).
+  Definition Delay {t} : Circuit t t :=
+    Compose (Comb (fun i => ret (i, constant true)))
+            (DelayInitCE (default_value defaultCombValue t)).
 
 End WithCava.
 

--- a/cava/Cava/Core/Circuit.v
+++ b/cava/Cava/Core/Circuit.v
@@ -32,7 +32,8 @@ Section WithCava.
   Inductive Circuit : type -> type -> Type :=
   | Comb : forall {i o}, (value i -> cava (value o)) -> Circuit i o
   | Compose : forall {i t o}, Circuit i t -> Circuit t o -> Circuit i o
-  | Par : forall {i1 i2 o1 o2}, Circuit i1 o1 -> Circuit i2 o2 -> Circuit (i1 * i2) (o1 * o2)
+  | First : forall {i o t}, Circuit i o -> Circuit (i * t) (o * t)
+  | Second : forall {i o t}, Circuit i o -> Circuit (t * i) (t * o)
   | LoopInitCE :
       forall {i o s : type} (resetval : value (signal:=combType) s),
         Circuit (i * s) (o * s) -> Circuit (i * Bit) o
@@ -44,7 +45,8 @@ Section WithCava.
     match c with
     | Comb _ => tzero
     | Compose f g => circuit_state f * circuit_state g
-    | Par f g => circuit_state f * circuit_state g
+    | First f => circuit_state f
+    | Second f => circuit_state f
     | @LoopInitCE i o s _ f => circuit_state f * s
     | @DelayInit t _ => t
     end.
@@ -55,7 +57,8 @@ Section WithCava.
     match c as c return value (circuit_state c) with
     | Comb _ => tt
     | Compose f g => (reset_state f, reset_state g)
-    | Par f g => (reset_state f, reset_state g)
+    | First f => reset_state f
+    | Second f => reset_state f
     | LoopInitCE resetval f => (reset_state f, resetval)
     | DelayInit resetval => resetval
     end.
@@ -86,10 +89,6 @@ Section WithCava.
             (LoopInitCE (default_value defaultCombValue s) body).
   (* Delay with the default signal as its reset value and no enable *)
   Definition Delay {t} : Circuit t t := DelayInit (default_value defaultCombValue t).
-
-  Definition Id {t} : Circuit t t := Comb ret.
-  Definition First {i o t} (f : Circuit i o) : Circuit (i * t) (o * t) := Par f Id.
-  Definition Second {i o t} (f : Circuit i o) : Circuit (t * i) (t * o) := Par Id f.
 
 End WithCava.
 

--- a/cava/Cava/Core/Circuit.v
+++ b/cava/Cava/Core/Circuit.v
@@ -37,8 +37,7 @@ Section WithCava.
   | LoopInitCE :
       forall {i o : type} {s : SignalType} (resetval : combType s),
         Circuit (i * s) (o * s) -> Circuit (i * Bit) o
-  | DelayInitCE :
-      forall {t} (resetval : combType t), Circuit (t * Bit) t
+  | DelayInitCE : forall {t} (resetval : combType t), Circuit (t * Bit) t
   .
 
   (* Internal state of the circuit (register values) *)

--- a/cava/Cava/Core/Signal.v
+++ b/cava/Cava/Core/Signal.v
@@ -76,15 +76,13 @@ Instance combType : sdenote :=
     | ExternalType _ => unit (* No semantics for combinational interpretation. *)
     end.
 
-Fixpoint defaultCombSignal (t: SignalType) : combType t :=
+Fixpoint defaultCombValue (t: SignalType) : combType t :=
   match t  with
   | Void => tt
   | Bit => false
-  | Vec t2 sz => Vector.const (defaultCombSignal t2) sz
+  | Vec t2 sz => Vector.const (defaultCombValue t2) sz
   | ExternalType _ => tt
   end.
-
-Definition defaultCombValue := default_value defaultCombSignal.
 
 (******************************************************************************)
 (* Netlist AST representation for signal expressions.                         *)
@@ -133,7 +131,6 @@ Fixpoint defaultNetSignal (t: SignalType) : Signal t :=
   | Vec vt s => VecLit (Vector.const (defaultNetSignal vt) s)
   | ExternalType s => UninterpretedSignal "default-defaultSignal"
   end.
-Definition defaultNetValue := default_value defaultNetSignal.
 
 (* To allow us to represent a heterogenous list of Signal t values where
    the Signal t varies we make a wrapper that erase the Kind index type.

--- a/cava/Cava/Lib/AddersProperties.v
+++ b/cava/Cava/Lib/AddersProperties.v
@@ -119,13 +119,17 @@ Proof.
       reflexivity | ].
   simpl_ident. cbn [unsignedAdd CombinationalSemantics].
   cbv [unsignedAddBool one]. simpl_ident.
+  rewrite VecProperties.resize_default_correct with (A:=Bit) (m:=S (S n)).
   Set Printing All.
-  Fail rewrite VecProperties.resize_default_correct.
-  cbv [Bvector.Bvector] in *. cbn [value combType] in *.
-  Set Printing All.
-  Print combType.
-  About VecProperties.resize_default_correct.
-  rewrite VecProperties.resize_default_correct with (A:=Bit) (n:=(1 + Nat.max (S n) 1)%nat).
+  About VecProperties.shiftout_correct.
+  About Vec.shiftout.
+  rewrite VecProperties.shiftout_correct.
+  pose proof VecProperties.shiftout_correct.
+  cbn [cava CombinationalSemantics ident] in *.
+  Print ident.
+  About Vec.shiftout.
+  rewrite H.
+  simpl_ident.
   change (Bv2N [true]) with 1.
 
   (* remove resize by proving lengths are equal *)

--- a/cava/Cava/Lib/AddersProperties.v
+++ b/cava/Cava/Lib/AddersProperties.v
@@ -105,7 +105,7 @@ Lemma addN_correct n inputs :
   addN (n:=n) inputs = N2Bv_sized n sum.
 Proof.
   cbv [addN zero]. simpl_ident. repeat destruct_pair_let.
-  cbn [N.b2n]. rewrite (addC_correct n), N.add_0_r. reflexivity.
+  cbn [N.b2n]. rewrite N.add_0_r. reflexivity.
 Qed.
 Hint Rewrite @addN_correct using solve [eauto] : simpl_ident.
 
@@ -119,34 +119,12 @@ Proof.
       reflexivity | ].
   simpl_ident. cbn [unsignedAdd CombinationalSemantics].
   cbv [unsignedAddBool one]. simpl_ident.
-  Set Printing All.
-  pose proof VecProperties.shiftout_correct.
-  fold combType in *. cbn [combType] in *.
-  rewrite H.
-  rewrite VecProperties.shiftout_correct.
-  rewrite VecProperties.resize_default_correct with (A:=Bit) (m:=S (S n)).
-  About VecProperties.shiftout_correct.
-  About Vec.shiftout.
-  pose proof VecProperties.shiftout_correct.
-  fold combType in *. cbn [combType] in *.
-  Hint Transparent CombinationalSemantics.
-  rewrite H.
-  rewrite VecProperties.shiftout_correct.
-  cbn [cava CombinationalSemantics ident] in *.
-  Print ident.
-  About Vec.shiftout.
-  rewrite H.
-  simpl_ident.
   change (Bv2N [true]) with 1.
 
   (* remove resize by proving lengths are equal *)
   assert ((1 + Nat.max (S n) 1)%nat = S (S n)) as Hresize by lia.
   generalize dependent (1 + Nat.max (S n) 1)%nat; intros; subst.
-  Search Vec.shiftout.
-  rewrite VecProperties.shiftout_correct.
-  rewrite shiftout_correct.
   rewrite resize_default_id.
-
   rewrite N2Bv_sized_shiftout, N2Bv_sized_last.
   reflexivity.
 Qed.

--- a/cava/Cava/Lib/AddersProperties.v
+++ b/cava/Cava/Lib/AddersProperties.v
@@ -119,12 +119,19 @@ Proof.
       reflexivity | ].
   simpl_ident. cbn [unsignedAdd CombinationalSemantics].
   cbv [unsignedAddBool one]. simpl_ident.
-  rewrite VecProperties.resize_default_correct with (A:=Bit) (m:=S (S n)).
   Set Printing All.
+  pose proof VecProperties.shiftout_correct.
+  fold combType in *. cbn [combType] in *.
+  rewrite H.
+  rewrite VecProperties.shiftout_correct.
+  rewrite VecProperties.resize_default_correct with (A:=Bit) (m:=S (S n)).
   About VecProperties.shiftout_correct.
   About Vec.shiftout.
-  rewrite VecProperties.shiftout_correct.
   pose proof VecProperties.shiftout_correct.
+  fold combType in *. cbn [combType] in *.
+  Hint Transparent CombinationalSemantics.
+  rewrite H.
+  rewrite VecProperties.shiftout_correct.
   cbn [cava CombinationalSemantics ident] in *.
   Print ident.
   About Vec.shiftout.

--- a/cava/Cava/Lib/CircuitTransforms.v
+++ b/cava/Cava/Lib/CircuitTransforms.v
@@ -15,10 +15,15 @@
 (****************************************************************************)
 
 Require Import Cava.Core.Core.
+Import Circuit.Notations.
 
 Section WithCava.
   Context `{semantics : Cava}.
 
   (* identity circuit *)
   Definition Id {t} : Circuit t t := Comb Monad.ret.
+
+  Definition Par {i1 i2 o1 o2} (c1 : Circuit i1 o1) (c2 : Circuit i2 o2)
+    : Circuit (i1 * i2) (o1 * o2) :=
+    First c1 >==> Second c2.
 End WithCava.

--- a/cava/Cava/Lib/CircuitTransformsProperties.v
+++ b/cava/Cava/Lib/CircuitTransformsProperties.v
@@ -16,6 +16,7 @@
 
 Require Import Coq.Classes.Morphisms.
 Require Import coqutil.Tactics.Tactics.
+Require Import ExtLib.Structures.Monad.
 Require Import Cava.Core.Core.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Semantics.Equivalence.
@@ -26,7 +27,7 @@ Require Import Cava.Semantics.Simulation.
 Require Import Cava.Lib.CircuitTransforms.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
-Import Circuit.Notations.
+Import MonadNotation Circuit.Notations.
 
 Local Ltac simplify :=
   cbn [circuit_state step Id value]; intros;
@@ -34,19 +35,19 @@ Local Ltac simplify :=
   repeat (destruct_pair_let; cbn [fst snd]);
   logical_simplify; simpl_ident; subst.
 
-Lemma First_Id t1 t2 : @cequiv (t1 * t2) (t1 * t2) (First Id) Id.
+Lemma First_Id {t1 t2} : @cequiv (t1 * t2) (t1 * t2) (First Id) Id.
 Proof.
   exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @First_Id using solve [eauto] : circuitsimpl.
 
-Lemma Second_Id t1 t2 : @cequiv (t1 * t2) (t1 * t2) (Second Id) Id.
+Lemma Second_Id {t1 t2} : @cequiv (t1 * t2) (t1 * t2) (Second Id) Id.
 Proof.
   exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Second_Id using solve [eauto] : circuitsimpl.
 
-Lemma Compose_Id_l i o c : @cequiv i o (Id >==> c) c.
+Lemma Compose_Id_l {i o} c : @cequiv i o (Id >==> c) c.
 Proof.
   exists (fun (st1 : unit * value (circuit_state c))
        (st2 : value (circuit_state c)) => st1 = (tt, st2)).
@@ -54,7 +55,7 @@ Proof.
 Qed.
 Hint Rewrite @Compose_Id_l using solve [eauto] : circuitsimpl.
 
-Lemma Compose_Id_r i o c : @cequiv i o (c >==> Id) c.
+Lemma Compose_Id_r {i o} c : @cequiv i o (c >==> Id) c.
 Proof.
   exists (fun (st1 : value (circuit_state c) * unit)
        (st2 : value (circuit_state c)) => st1 = (st2, tt)).
@@ -62,7 +63,7 @@ Proof.
 Qed.
 Hint Rewrite @Compose_Id_r using solve [eauto] : circuitsimpl.
 
-Lemma Compose_assoc A B C D
+Lemma Compose_assoc {A B C D}
       (f : Circuit A B) (g : Circuit B C) (h : Circuit C D) :
   cequiv (f >==> (g >==> h)) (f >==> g >==> h).
 Proof.
@@ -71,22 +72,23 @@ Proof.
        st1 = (fst (fst st2), (snd (fst st2), snd st2))).
   ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
+Hint Rewrite @Compose_assoc : circuitsimpl.
 
-Lemma First_Compose A B C D (f : Circuit A B) (g : Circuit B C) :
+Lemma First_Compose {A B C D} (f : Circuit A B) (g : Circuit B C) :
   @cequiv (A * D) (C * D) (First (f >==> g)) (First f >==> First g).
 Proof.
   exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @First_Compose using solve [eauto] : circuitsimpl.
 
-Lemma Second_Compose A B C D (f : Circuit A B) (g : Circuit B C) :
+Lemma Second_Compose {A B C D} (f : Circuit A B) (g : Circuit B C) :
   @cequiv (D * A) (D * C) (Second (f >==> g)) (Second f >==> Second g).
 Proof.
   exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Second_Compose using solve [eauto] : circuitsimpl.
 
-Lemma LoopInitCE_First_r A B C (s : SignalType) reset
+Lemma LoopInitCE_First_r {A B C} (s : SignalType) reset
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (LoopInitCE reset (body >==> First f)) (LoopInitCE reset body >==> f).
 Proof.
@@ -97,7 +99,7 @@ Proof.
 Qed.
 Hint Rewrite @LoopInitCE_First_r using solve [eauto] : push_loop.
 
-Lemma LoopInit_First_r A B C (s : SignalType) reset
+Lemma LoopInit_First_r {A B C} (s : SignalType) reset
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (LoopInit reset (body >==> First f)) (LoopInit reset body >==> f).
 Proof.
@@ -105,19 +107,19 @@ Proof.
 Qed.
 Hint Rewrite @LoopInit_First_r using solve [eauto] : push_loop.
 
-Lemma LoopCE_First_r A B C (s : SignalType)
+Lemma LoopCE_First_r {A B C} (s : SignalType)
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (LoopCE (body >==> First f)) (LoopCE body >==> f).
 Proof. apply LoopInitCE_First_r. Qed.
 Hint Rewrite @LoopCE_First_r using solve [eauto] : push_loop.
 
-Lemma Loop_First_r A B C (s : SignalType)
+Lemma Loop_First_r {A B C} (s : SignalType)
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (Loop (body >==> First f)) (Loop body >==> f).
 Proof. apply LoopInit_First_r. Qed.
 Hint Rewrite @Loop_First_r using solve [eauto] : push_loop.
 
-Lemma simulate_Id t input : simulate (i:=t) Id input = input.
+Lemma simulate_Id {t} input : simulate (i:=t) Id input = input.
 Proof.
   cbv [Id]; autorewrite with push_simulate.
   apply List.map_id_ext; intros.
@@ -125,7 +127,7 @@ Proof.
 Qed.
 Hint Rewrite @simulate_Id using solve [eauto] : push_simulate.
 
-Lemma simulate_Par A B C D c1 c2 input :
+Lemma simulate_Par {A B C D} c1 c2 input :
   simulate (@Par _ _ A B C D c1 c2) input
   = combine (simulate c1 (map fst input))
             (simulate c2 (map snd input)).
@@ -144,60 +146,68 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma First_Id_w t1 t2 : @wequiv (t1 * t2) (t1 * t2) (First Id) Id.
+Lemma Par_Id_l {i o t} (f : Circuit i o) : cequiv (Par f (Id (t:=t))) (First f).
+Proof. cbv [Par]. autorewrite with circuitsimpl. reflexivity. Qed.
+Hint Rewrite @Par_Id_l using solve [eauto] : circuitsimpl.
+
+Lemma Par_Id_r {i o t} (f : Circuit i o) : cequiv (Par (Id (t:=t)) f) (Second f).
+Proof. cbv [Par]. autorewrite with circuitsimpl. reflexivity. Qed.
+Hint Rewrite @Par_Id_r using solve [eauto] : circuitsimpl.
+
+Lemma Second_Comb {i o t} f :
+  cequiv (Second (Comb f)) (Comb (i:=t*i) (o:=t*o) (fun x => (fst x, f (snd x)))).
 Proof.
-  split; [ reflexivity | ]; intros.
-  cbn [cpath Id].
-  exists (fun i s1 s2 => i = 0 /\ s1 = s2); cbn [step circuit_state value Id fst snd].
-  simpl_ident. ssplit; intros; destruct_products;
-                 subst; ssplit; try reflexivity; discriminate.
+  exists (fun _ _ => True). ssplit; [ tauto | ].
+  cbn [value circuit_state]; intros. destruct_products.
+  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  ssplit; reflexivity.
 Qed.
-Hint Rewrite @First_Id_w using solve [eauto] : circuitsimplw.
+Hint Rewrite @Second_Comb using solve [eauto] : pull_comb.
 
-Lemma Second_Id_w t1 t2 : @wequiv (t1 * t2) (t1 * t2) (Second Id) Id.
+Lemma First_Comb {i o t} f :
+  cequiv (First (Comb f)) (Comb (i:=i*t) (o:=o*t) (fun x => (f (fst x), snd x))).
 Proof.
-  split; [ reflexivity | ]; intros.
-  cbn [cpath Id].
-  exists (fun i s1 s2 => i = 0 /\ s1 = s2); cbn [step circuit_state value Id fst snd].
-  simpl_ident. ssplit; intros; destruct_products;
-                 subst; ssplit; try reflexivity; discriminate.
+  exists (fun _ _ => True). ssplit; [ tauto | ].
+  cbn [value circuit_state]; intros. destruct_products.
+  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  ssplit; reflexivity.
 Qed.
-Hint Rewrite @Second_Id_w using solve [eauto] : circuitsimplw.
+Hint Rewrite @First_Comb using solve [eauto] : pull_comb.
 
-Lemma Compose_Id_l_w i o c : @wequiv i o (Id >==> c) c.
-Admitted.
-Hint Rewrite @Compose_Id_l_w using solve [eauto] : circuitsimplw.
-
-Lemma Compose_Id_r_w i o c : @wequiv i o (c >==> Id) c.
-Admitted.
-Hint Rewrite @Compose_Id_r_w using solve [eauto] : circuitsimplw.
-
-Lemma Par_Id_w t1 t2 : @wequiv (t1 * t2) (t1 * t2) (Par Id Id) Id.
+Lemma Compose_Comb {i t o} f g :
+  cequiv (@Compose _ _ i t o (Comb f) (Comb g)) (Comb (f >=> g)).
 Proof.
-  cbv [Par]. autorewrite with circuitsimplw. reflexivity.
+  exists (fun _ _ => True). ssplit; [ tauto | ].
+  cbn [value circuit_state]; intros. destruct_products.
+  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  ssplit; reflexivity.
 Qed.
-Hint Rewrite @Par_Id_w using solve [eauto] : circuitsimplw.
+Hint Rewrite @Compose_Comb using solve [eauto] : pull_comb.
 
-Lemma Compose_assoc_w A B C D
-      (f : Circuit A B) (g : Circuit B C) (h : Circuit C D) :
-  wequiv (f >==> (g >==> h)) (f >==> g >==> h).
-Admitted.
-Hint Rewrite @Compose_assoc_w using solve [eauto] : circuitsimplw.
-
-Lemma First_Compose_w A B C D (f : Circuit A B) (g : Circuit B C) :
-  @wequiv (A * D) (C * D) (First (f >==> g)) (First f >==> First g).
-Admitted.
-Hint Rewrite @First_Compose_w using solve [eauto] : circuitsimplw.
-
-Lemma Second_Compose_w A B C D (f : Circuit A B) (g : Circuit B C) :
-  @wequiv (D * A) (D * C) (Second (f >==> g)) (Second f >==> Second g).
-Admitted.
-Hint Rewrite @Second_Compose_w using solve [eauto] : circuitsimplw.
-
-Global Instance Proper_Par_w {A B C D} :
-  Proper (wequiv ==> wequiv ==> wequiv) (@Par _ _ A B C D).
+Lemma Compose_Comb_r {i t1 t2 o} c f g :
+  cequiv (@Compose _ _ i t2 o (@Compose _ _ i t1 t2 c (Comb f)) (Comb g))
+         (c >==> Comb (f >=> g)).
 Proof.
-  cbv [Par]. repeat intro.
-  repeat match goal with H : wequiv _ _ |- _ => rewrite H end.
-  reflexivity.
+  rewrite <-Compose_Comb. autorewrite with circuitsimpl. reflexivity.
+Qed.
+Hint Rewrite @Compose_Comb_r using solve [eauto] : pull_comb.
+
+Lemma First_Second_comm {i1 i2 o1 o2} (c1 : Circuit i1 o1) (c2 : Circuit i2 o2) :
+  cequiv (First c1 >==> Second c2) (Second c2 >==> First c1).
+Proof.
+  exists (fun s1 s2 => s1 = (snd s2, fst s2)).
+  ssplit; [ reflexivity | ]. cbn [value circuit_state].
+  intros; destruct_products. cbn [fst snd] in *.
+  logical_simplify. ssplit; reflexivity.
+Qed.
+Hint Rewrite <- @First_Second_comm using solve [eauto] : circuitsimpl.
+
+Lemma Comb_ext {i o} (f g : value i -> cava (value o)) :
+  (forall x, f x = g x) -> cequiv (Comb f) (Comb g).
+Proof.
+  intro Hfg. exists (fun _ _ => True). ssplit; [ tauto | ].
+  cbn [value circuit_state]; intros. destruct_products.
+  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  cbn [step]. rewrite Hfg.
+  ssplit; [ reflexivity | tauto ].
 Qed.

--- a/cava/Cava/Lib/CircuitTransformsProperties.v
+++ b/cava/Cava/Lib/CircuitTransformsProperties.v
@@ -37,13 +37,13 @@ Local Ltac simplify :=
 
 Lemma First_Id {t1 t2} : @cequiv (t1 * t2) (t1 * t2) (First Id) Id.
 Proof.
-  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @First_Id using solve [eauto] : circuitsimpl.
 
 Lemma Second_Id {t1 t2} : @cequiv (t1 * t2) (t1 * t2) (Second Id) Id.
 Proof.
-  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Second_Id using solve [eauto] : circuitsimpl.
 
@@ -52,7 +52,7 @@ Proof.
   exists (fun (st1 : unit * value (circuit_state c))
        (st2 : value (circuit_state c)) => st1 = (tt, st2)).
   cbn [value circuit_state Id] in *.
-  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Compose_Id_l using solve [eauto] : circuitsimpl.
 
@@ -61,7 +61,7 @@ Proof.
   exists (fun (st1 : value (circuit_state c) * unit)
        (st2 : value (circuit_state c)) => st1 = (st2, tt)).
   cbn [value circuit_state Id] in *.
-  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Compose_Id_r using solve [eauto] : circuitsimpl.
 
@@ -73,37 +73,37 @@ Proof.
        (st2 : value (circuit_state f) * value (circuit_state g) * value (circuit_state h)) =>
        st1 = (fst (fst st2), (snd (fst st2), snd st2))).
   cbn [value circuit_state Id] in *.
-  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Compose_assoc : circuitsimpl.
 
 Lemma First_Compose {A B C D} (f : Circuit A B) (g : Circuit B C) :
   @cequiv (A * D) (C * D) (First (f >==> g)) (First f >==> First g).
 Proof.
-  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @First_Compose using solve [eauto] : circuitsimpl.
 
 Lemma Second_Compose {A B C D} (f : Circuit A B) (g : Circuit B C) :
   @cequiv (D * A) (D * C) (Second (f >==> g)) (Second f >==> Second g).
 Proof.
-  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Second_Compose using solve [eauto] : circuitsimpl.
 
-Lemma LoopInitCE_First_r {A B C} (s : SignalType) reset
+Lemma LoopInitCE_First_r {A B C} (s : type) reset
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (LoopInitCE reset (body >==> First f)) (LoopInitCE reset body >==> f).
 Proof.
-  exists (fun (st1 : value (circuit_state body) * value (circuit_state f) * combType s)
-       (st2 : value (circuit_state body) * combType s * value (circuit_state f)) =>
+  exists (fun (st1 : value (circuit_state body) * value (circuit_state f) * value s)
+       (st2 : value (circuit_state body) * value s * value (circuit_state f)) =>
        st1 = (fst (fst st2), snd st2, snd (fst st2))).
   cbn [value circuit_state] in *.
-  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
+  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @LoopInitCE_First_r using solve [eauto] : push_loop.
 
-Lemma LoopInit_First_r {A B C} (s : SignalType) reset
+Lemma LoopInit_First_r {A B C} (s : type) reset
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (LoopInit reset (body >==> First f)) (LoopInit reset body >==> f).
 Proof.
@@ -111,13 +111,13 @@ Proof.
 Qed.
 Hint Rewrite @LoopInit_First_r using solve [eauto] : push_loop.
 
-Lemma LoopCE_First_r {A B C} (s : SignalType)
+Lemma LoopCE_First_r {A B C} (s : type)
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (LoopCE (body >==> First f)) (LoopCE body >==> f).
 Proof. apply LoopInitCE_First_r. Qed.
 Hint Rewrite @LoopCE_First_r using solve [eauto] : push_loop.
 
-Lemma Loop_First_r {A B C} (s : SignalType)
+Lemma Loop_First_r {A B C} (s : type)
       (body : Circuit (A * s) (B * s)) (f : Circuit B C) :
   cequiv (Loop (body >==> First f)) (Loop body >==> f).
 Proof. apply LoopInit_First_r. Qed.
@@ -161,7 +161,7 @@ Hint Rewrite @Par_Id_r using solve [eauto] : circuitsimpl.
 Lemma Second_Comb {i o t} f :
   cequiv (Second (Comb f)) (Comb (i:=t*i) (o:=t*o) (fun x => (fst x, f (snd x)))).
 Proof.
-  exists (fun _ _ => True). ssplit; [ solve_is_total | tauto | ].
+  exists (fun _ _ => True). ssplit; [ tauto | ].
   cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   ssplit; reflexivity.
 Qed.
@@ -170,7 +170,7 @@ Hint Rewrite @Second_Comb using solve [eauto] : pull_comb.
 Lemma First_Comb {i o t} f :
   cequiv (First (Comb f)) (Comb (i:=i*t) (o:=o*t) (fun x => (f (fst x), snd x))).
 Proof.
-  exists (fun _ _ => True). ssplit; [ solve_is_total | tauto | ].
+  exists (fun _ _ => True). ssplit; [ tauto | ].
   cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   ssplit; reflexivity.
 Qed.
@@ -180,7 +180,7 @@ Lemma Compose_Comb {i t o} f g :
   cequiv (@Compose _ _ i t o (Comb f) (Comb g)) (Comb (f >=> g)).
 Proof.
   exists (fun _ _ => True). cbn [value circuit_state].
-  ssplit; [ solve_is_total | tauto | ].
+  ssplit; [ tauto | ].
   cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   ssplit; reflexivity.
 Qed.
@@ -200,7 +200,7 @@ Proof.
   exists (fun (s1 : value (circuit_state c1) * value (circuit_state c2)) s2 =>
        s1 = (snd s2, fst s2)).
   cbn [value circuit_state].
-  ssplit; [ solve_is_total | reflexivity | ].
+  ssplit; [ reflexivity | ].
   intros; destruct_products. cbn [fst snd] in *.
   logical_simplify. ssplit; reflexivity.
 Qed.
@@ -209,7 +209,7 @@ Hint Rewrite <- @First_Second_comm using solve [eauto] : circuitsimpl.
 Lemma Comb_ext {i o} (f g : value i -> cava (value o)) :
   (forall x, f x = g x) -> cequiv (Comb f) (Comb g).
 Proof.
-  intro Hfg. exists (fun _ _ => True). ssplit; [ solve_is_total | tauto | ].
+  intro Hfg. exists (fun _ _ => True). ssplit; [ tauto | ].
   cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   cbn [step]. rewrite Hfg.
   ssplit; [ reflexivity | tauto ].

--- a/cava/Cava/Lib/CircuitTransformsProperties.v
+++ b/cava/Cava/Lib/CircuitTransformsProperties.v
@@ -111,3 +111,11 @@ Lemma Loop_First_r A B C (s : SignalType)
   cequiv (Loop (body >==> First f)) (Loop body >==> f).
 Proof. apply LoopInit_First_r. Qed.
 Hint Rewrite @Loop_First_r using solve [eauto] : push_loop.
+
+Global Instance Proper_Par {A B C D} :
+  Proper (cequiv ==> cequiv ==> cequiv) (@Par _ _ A B C D).
+Proof.
+  cbv [Par]. repeat intro.
+  repeat match goal with H : cequiv _ _ |- _ => rewrite H end.
+  reflexivity.
+Qed.

--- a/cava/Cava/Lib/CircuitTransformsProperties.v
+++ b/cava/Cava/Lib/CircuitTransformsProperties.v
@@ -19,6 +19,9 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Core.Core.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Semantics.Equivalence.
+Require Import Cava.Semantics.Loopless.
+Require Import Cava.Semantics.LooplessProperties.
+Require Import Cava.Semantics.WeakEquivalence.
 Require Import Cava.Semantics.Simulation.
 Require Import Cava.Lib.CircuitTransforms.
 Require Import Cava.Util.List.
@@ -138,5 +141,63 @@ Global Instance Proper_Par {A B C D} :
 Proof.
   cbv [Par]. repeat intro.
   repeat match goal with H : cequiv _ _ |- _ => rewrite H end.
+  reflexivity.
+Qed.
+
+Lemma First_Id_w t1 t2 : @wequiv (t1 * t2) (t1 * t2) (First Id) Id.
+Proof.
+  split; [ reflexivity | ]; intros.
+  cbn [cpath Id].
+  exists (fun i s1 s2 => i = 0 /\ s1 = s2); cbn [step circuit_state value Id fst snd].
+  simpl_ident. ssplit; intros; destruct_products;
+                 subst; ssplit; try reflexivity; discriminate.
+Qed.
+Hint Rewrite @First_Id_w using solve [eauto] : circuitsimplw.
+
+Lemma Second_Id_w t1 t2 : @wequiv (t1 * t2) (t1 * t2) (Second Id) Id.
+Proof.
+  split; [ reflexivity | ]; intros.
+  cbn [cpath Id].
+  exists (fun i s1 s2 => i = 0 /\ s1 = s2); cbn [step circuit_state value Id fst snd].
+  simpl_ident. ssplit; intros; destruct_products;
+                 subst; ssplit; try reflexivity; discriminate.
+Qed.
+Hint Rewrite @Second_Id_w using solve [eauto] : circuitsimplw.
+
+Lemma Compose_Id_l_w i o c : @wequiv i o (Id >==> c) c.
+Admitted.
+Hint Rewrite @Compose_Id_l_w using solve [eauto] : circuitsimplw.
+
+Lemma Compose_Id_r_w i o c : @wequiv i o (c >==> Id) c.
+Admitted.
+Hint Rewrite @Compose_Id_r_w using solve [eauto] : circuitsimplw.
+
+Lemma Par_Id_w t1 t2 : @wequiv (t1 * t2) (t1 * t2) (Par Id Id) Id.
+Proof.
+  cbv [Par]. autorewrite with circuitsimplw. reflexivity.
+Qed.
+Hint Rewrite @Par_Id_w using solve [eauto] : circuitsimplw.
+
+Lemma Compose_assoc_w A B C D
+      (f : Circuit A B) (g : Circuit B C) (h : Circuit C D) :
+  wequiv (f >==> (g >==> h)) (f >==> g >==> h).
+Admitted.
+Hint Rewrite @Compose_assoc_w using solve [eauto] : circuitsimplw.
+
+Lemma First_Compose_w A B C D (f : Circuit A B) (g : Circuit B C) :
+  @wequiv (A * D) (C * D) (First (f >==> g)) (First f >==> First g).
+Admitted.
+Hint Rewrite @First_Compose_w using solve [eauto] : circuitsimplw.
+
+Lemma Second_Compose_w A B C D (f : Circuit A B) (g : Circuit B C) :
+  @wequiv (D * A) (D * C) (Second (f >==> g)) (Second f >==> Second g).
+Admitted.
+Hint Rewrite @Second_Compose_w using solve [eauto] : circuitsimplw.
+
+Global Instance Proper_Par_w {A B C D} :
+  Proper (wequiv ==> wequiv ==> wequiv) (@Par _ _ A B C D).
+Proof.
+  cbv [Par]. repeat intro.
+  repeat match goal with H : wequiv _ _ |- _ => rewrite H end.
   reflexivity.
 Qed.

--- a/cava/Cava/Lib/CircuitTransformsProperties.v
+++ b/cava/Cava/Lib/CircuitTransformsProperties.v
@@ -19,7 +19,9 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Core.Core.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Semantics.Equivalence.
+Require Import Cava.Semantics.Simulation.
 Require Import Cava.Lib.CircuitTransforms.
+Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 Import Circuit.Notations.
 
@@ -111,6 +113,25 @@ Lemma Loop_First_r A B C (s : SignalType)
   cequiv (Loop (body >==> First f)) (Loop body >==> f).
 Proof. apply LoopInit_First_r. Qed.
 Hint Rewrite @Loop_First_r using solve [eauto] : push_loop.
+
+Lemma simulate_Id t input : simulate (i:=t) Id input = input.
+Proof.
+  cbv [Id]; autorewrite with push_simulate.
+  apply List.map_id_ext; intros.
+  reflexivity.
+Qed.
+Hint Rewrite @simulate_Id using solve [eauto] : push_simulate.
+
+Lemma simulate_Par A B C D c1 c2 input :
+  simulate (@Par _ _ A B C D c1 c2) input
+  = combine (simulate c1 (map fst input))
+            (simulate c2 (map snd input)).
+Proof.
+  cbv [Par]; autorewrite with push_simulate.
+  rewrite map_fst_combine, map_snd_combine by length_hammer.
+  reflexivity.
+Qed.
+Hint Rewrite @simulate_Par using solve [eauto] : push_simulate.
 
 Global Instance Proper_Par {A B C D} :
   Proper (cequiv ==> cequiv ==> cequiv) (@Par _ _ A B C D).

--- a/cava/Cava/Lib/CircuitTransformsProperties.v
+++ b/cava/Cava/Lib/CircuitTransformsProperties.v
@@ -37,13 +37,13 @@ Local Ltac simplify :=
 
 Lemma First_Id {t1 t2} : @cequiv (t1 * t2) (t1 * t2) (First Id) Id.
 Proof.
-  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @First_Id using solve [eauto] : circuitsimpl.
 
 Lemma Second_Id {t1 t2} : @cequiv (t1 * t2) (t1 * t2) (Second Id) Id.
 Proof.
-  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Second_Id using solve [eauto] : circuitsimpl.
 
@@ -51,7 +51,8 @@ Lemma Compose_Id_l {i o} c : @cequiv i o (Id >==> c) c.
 Proof.
   exists (fun (st1 : unit * value (circuit_state c))
        (st2 : value (circuit_state c)) => st1 = (tt, st2)).
-  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  cbn [value circuit_state Id] in *.
+  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Compose_Id_l using solve [eauto] : circuitsimpl.
 
@@ -59,7 +60,8 @@ Lemma Compose_Id_r {i o} c : @cequiv i o (c >==> Id) c.
 Proof.
   exists (fun (st1 : value (circuit_state c) * unit)
        (st2 : value (circuit_state c)) => st1 = (st2, tt)).
-  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  cbn [value circuit_state Id] in *.
+  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Compose_Id_r using solve [eauto] : circuitsimpl.
 
@@ -70,21 +72,22 @@ Proof.
   exists (fun (st1 : value (circuit_state f) * (value (circuit_state g) * value (circuit_state h)))
        (st2 : value (circuit_state f) * value (circuit_state g) * value (circuit_state h)) =>
        st1 = (fst (fst st2), (snd (fst st2), snd st2))).
-  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  cbn [value circuit_state Id] in *.
+  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Compose_assoc : circuitsimpl.
 
 Lemma First_Compose {A B C D} (f : Circuit A B) (g : Circuit B C) :
   @cequiv (A * D) (C * D) (First (f >==> g)) (First f >==> First g).
 Proof.
-  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @First_Compose using solve [eauto] : circuitsimpl.
 
 Lemma Second_Compose {A B C D} (f : Circuit A B) (g : Circuit B C) :
   @cequiv (D * A) (D * C) (Second (f >==> g)) (Second f >==> Second g).
 Proof.
-  exists eq. ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  exists eq. ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @Second_Compose using solve [eauto] : circuitsimpl.
 
@@ -95,7 +98,8 @@ Proof.
   exists (fun (st1 : value (circuit_state body) * value (circuit_state f) * combType s)
        (st2 : value (circuit_state body) * combType s * value (circuit_state f)) =>
        st1 = (fst (fst st2), snd st2, snd (fst st2))).
-  ssplit; [ reflexivity | ]. simplify. ssplit; reflexivity.
+  cbn [value circuit_state] in *.
+  ssplit; [ solve_is_total | reflexivity | ]. simplify. ssplit; reflexivity.
 Qed.
 Hint Rewrite @LoopInitCE_First_r using solve [eauto] : push_loop.
 
@@ -157,9 +161,8 @@ Hint Rewrite @Par_Id_r using solve [eauto] : circuitsimpl.
 Lemma Second_Comb {i o t} f :
   cequiv (Second (Comb f)) (Comb (i:=t*i) (o:=t*o) (fun x => (fst x, f (snd x)))).
 Proof.
-  exists (fun _ _ => True). ssplit; [ tauto | ].
-  cbn [value circuit_state]; intros. destruct_products.
-  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  exists (fun _ _ => True). ssplit; [ solve_is_total | tauto | ].
+  cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   ssplit; reflexivity.
 Qed.
 Hint Rewrite @Second_Comb using solve [eauto] : pull_comb.
@@ -167,9 +170,8 @@ Hint Rewrite @Second_Comb using solve [eauto] : pull_comb.
 Lemma First_Comb {i o t} f :
   cequiv (First (Comb f)) (Comb (i:=i*t) (o:=o*t) (fun x => (f (fst x), snd x))).
 Proof.
-  exists (fun _ _ => True). ssplit; [ tauto | ].
-  cbn [value circuit_state]; intros. destruct_products.
-  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  exists (fun _ _ => True). ssplit; [ solve_is_total | tauto | ].
+  cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   ssplit; reflexivity.
 Qed.
 Hint Rewrite @First_Comb using solve [eauto] : pull_comb.
@@ -177,9 +179,9 @@ Hint Rewrite @First_Comb using solve [eauto] : pull_comb.
 Lemma Compose_Comb {i t o} f g :
   cequiv (@Compose _ _ i t o (Comb f) (Comb g)) (Comb (f >=> g)).
 Proof.
-  exists (fun _ _ => True). ssplit; [ tauto | ].
-  cbn [value circuit_state]; intros. destruct_products.
-  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  exists (fun _ _ => True). cbn [value circuit_state].
+  ssplit; [ solve_is_total | tauto | ].
+  cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   ssplit; reflexivity.
 Qed.
 Hint Rewrite @Compose_Comb using solve [eauto] : pull_comb.
@@ -195,8 +197,10 @@ Hint Rewrite @Compose_Comb_r using solve [eauto] : pull_comb.
 Lemma First_Second_comm {i1 i2 o1 o2} (c1 : Circuit i1 o1) (c2 : Circuit i2 o2) :
   cequiv (First c1 >==> Second c2) (Second c2 >==> First c1).
 Proof.
-  exists (fun s1 s2 => s1 = (snd s2, fst s2)).
-  ssplit; [ reflexivity | ]. cbn [value circuit_state].
+  exists (fun (s1 : value (circuit_state c1) * value (circuit_state c2)) s2 =>
+       s1 = (snd s2, fst s2)).
+  cbn [value circuit_state].
+  ssplit; [ solve_is_total | reflexivity | ].
   intros; destruct_products. cbn [fst snd] in *.
   logical_simplify. ssplit; reflexivity.
 Qed.
@@ -205,9 +209,8 @@ Hint Rewrite <- @First_Second_comm using solve [eauto] : circuitsimpl.
 Lemma Comb_ext {i o} (f g : value i -> cava (value o)) :
   (forall x, f x = g x) -> cequiv (Comb f) (Comb g).
 Proof.
-  intro Hfg. exists (fun _ _ => True). ssplit; [ tauto | ].
-  cbn [value circuit_state]; intros. destruct_products.
-  repeat lazymatch goal with x : unit |- _ => destruct x end.
+  intro Hfg. exists (fun _ _ => True). ssplit; [ solve_is_total | tauto | ].
+  cbn [value circuit_state]; intros. destruct_products. logical_simplify.
   cbn [step]. rewrite Hfg.
   ssplit; [ reflexivity | tauto ].
 Qed.

--- a/cava/Cava/Lib/CombinationalProperties.v
+++ b/cava/Cava/Lib/CombinationalProperties.v
@@ -55,7 +55,7 @@ Section Indexing.
   Hint Rewrite @indexAt2_correct using solve [eauto] : simpl_ident.
 
   Lemma indexConst_eq {A sz} (v : combType (Vec A sz)) (n : nat) :
-    indexConst v n = nth_default (defaultCombValue _) n v.
+    indexConst v n = nth_default (defaultCombSignal _) n v.
   Proof. reflexivity. Qed.
   Hint Rewrite @indexConst_eq using solve [eauto] : simpl_ident.
 End Indexing.

--- a/cava/Cava/Lib/CombinationalProperties.v
+++ b/cava/Cava/Lib/CombinationalProperties.v
@@ -55,7 +55,7 @@ Section Indexing.
   Hint Rewrite @indexAt2_correct using solve [eauto] : simpl_ident.
 
   Lemma indexConst_eq {A sz} (v : combType (Vec A sz)) (n : nat) :
-    indexConst v n = nth_default (defaultCombSignal _) n v.
+    indexConst v n = nth_default (defaultCombValue _) n v.
   Proof. reflexivity. Qed.
   Hint Rewrite @indexConst_eq using solve [eauto] : simpl_ident.
 End Indexing.

--- a/cava/Cava/Lib/Decoder.v
+++ b/cava/Cava/Lib/Decoder.v
@@ -49,7 +49,7 @@ Section WithCava.
         (Vector.map (fun k => N2Bv_sized n (N.of_nat k))
                     (Vector.vseq 0 (2^n)))) ;;
     Vec.map2
-      (fun '(k, hot_sig) => mux2 hot_sig (defaultSignal, k))
+      (fun '(k, hot_sig) => mux2_signal hot_sig (defaultSignal, k))
       (consts, hot)
     >>= tree (Vec.map2 or2).
 

--- a/cava/Cava/Lib/DecoderProperties.v
+++ b/cava/Cava/Lib/DecoderProperties.v
@@ -91,8 +91,8 @@ Theorem fold_units' : forall A n (a:A) f unit decider,
   Vector.fold_left f unit vec' = a.
 Proof. intros. rewrite eq. apply @fold_units with (b:= fun x => a); assumption. Qed.
 
-Theorem enc_dev_inv (n:nat) input : simulate ((Comb (decoder (n:=n))) >==>
-  (Comb (encoder (n:=n)))) input = input.
+Theorem enc_dev_inv (n:nat) input : simulate ((Comb (i:=Vec Bit _) (o:=Vec Bit _) (decoder (n:=n))) >==>
+  (Comb (o:=Vec Bit _) (encoder (n:=n)))) input = input.
 Proof.
   (* Rewrite to [encoder ( decoder ) = id] *)
   autorewrite with push_simulate.

--- a/cava/Cava/Lib/DecoderProperties.v
+++ b/cava/Cava/Lib/DecoderProperties.v
@@ -286,14 +286,14 @@ Proof.
       [ | intros ; simpl_ident; trivial ].
     rewrite Vector.map_ext with
       (f:= fun x =>
-        mux2 (if (k =? x)%nat then one else zero)
+        mux2_signal (if (k =? x)%nat then one else zero)
           (defaultSignal,
            @Vec.bitvec_literal combType _ _ (N2Bv_sized n (N.of_nat x))))
       (g := fun x =>
         (if (k =? x)%nat
          then @Vec.bitvec_literal combType _ _ (N2Bv_sized n (N.of_nat x))
          else Vector.const false n)).
-    2:{ intro a0. rewrite mux2_correct.
+    2:{ intro a0. rewrite mux2_signal_correct.
         case_eq(k=?a0)%nat; trivial. }
     rewrite fold_units; [ | | | | | ].
     { intros H. case_eq (k=?a)%nat.

--- a/cava/Cava/Lib/Multiplexers.v
+++ b/cava/Cava/Lib/Multiplexers.v
@@ -32,13 +32,24 @@ Section WithCava.
 
   (* A two to one multiplexer that takes its two arguments as a pair rather
      than as a 2 element vector which is what indexAt works over. *)
-  Definition mux2 {A : SignalType}
+  Definition mux2_signal {A : SignalType}
              (sel : signal Bit)
              (ab : signal A * signal A) : cava (signal A) :=
     let '(a,b) := ab in
     v <- packV [a;b] ;;
     i <- packV [sel] ;;
     indexAt v i.
+  Fixpoint mux2 {A : type} (sel : signal Bit)
+    : value A * value A -> cava (value A) :=
+    match A with
+    | tzero => fun _ => ret tt
+    | tone t => mux2_signal sel
+    | tpair t1 t2 =>
+      fun '(x,y) =>
+        o1 <- mux2 sel (fst x, fst y) ;;
+        o2 <- mux2 sel (snd x, snd y) ;;
+        ret (o1, o2)
+    end.
 
   (* 4-element multiplexer *)
   Definition mux4 {t} (input : signal t * signal t * signal t * signal t)

--- a/cava/Cava/Lib/MultiplexersProperties.v
+++ b/cava/Cava/Lib/MultiplexersProperties.v
@@ -15,16 +15,26 @@
 (****************************************************************************)
 
 Require Import Coq.Vectors.Vector.
-
+Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Core.Core.
 Require Import Cava.Lib.Multiplexers.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Util.BitArithmeticProperties.
 
-Lemma mux2_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
-  mux2 sel (i0, i1) = if sel then i1 else i0.
+Lemma mux2_signal_correct {t} (i0 i1 : combType t) (sel : combType Bit) :
+  mux2_signal sel (i0, i1) = if sel then i1 else i0.
 Proof. destruct sel; reflexivity. Qed.
+Hint Rewrite @mux2_signal_correct using solve [eauto] : simpl_ident.
+
+Lemma mux2_correct {t} (i0 i1 : value t) (sel : combType Bit) :
+  mux2 sel (i0, i1) = if sel then i1 else i0.
+Proof.
+  induction t; cbn [mux2 value] in *; intros; simpl_ident;
+    repeat lazymatch goal with x : unit |- _ => destruct x end;
+      [ repeat destruct_one_match; reflexivity .. | ].
+  rewrite IHt1, IHt2. destruct_one_match; destruct_products; reflexivity.
+Qed.
 Hint Rewrite @mux2_correct using solve [eauto] : simpl_ident.
 
 Lemma mux4_correct {t} (i0 i1 i2 i3 : combType t) (sel : combType (Vec Bit 2)) :

--- a/cava/Cava/Lib/Multipliers.v
+++ b/cava/Cava/Lib/Multipliers.v
@@ -65,6 +65,6 @@ Section WithCava.
         odd_case <- addN (r_times4, y_times4_plus1) ;;
         (* based on bit 0 of input, select the odd or even case *)
         x0 <- Vec.hd x ;;
-        mux2 x0 (r_times4, odd_case)
+        mux2_signal x0 (r_times4, odd_case)
     end.
 End WithCava.

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -20,6 +20,7 @@ Require Import Cava.Core.Core.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Semantics.Equivalence.
 Require Import Cava.Semantics.Simulation.
+Require Import Cava.Semantics.Loopless.
 Require Import Cava.Semantics.WeakEquivalence.
 Require Import Cava.Lib.CircuitTransforms.
 Require Import Cava.Lib.Combinators.
@@ -30,119 +31,25 @@ Section WithCava.
   Context `{semantics : Cava}.
 
   (* make a circuit with one delay for each signal, given reset values *)
-  Fixpoint delays {t : type} : value (signal:=combType) t -> Circuit t t :=
+  Fixpoint delays {t : type} : Circuit t t :=
     match t with
-    | tzero => fun _ => Id
-    | tone t => DelayInit
-    | tpair t1 t2 => fun v => Par (delays (fst v)) (delays (snd v))
-    end.
-
-  (* get the value stored in the 1-delay circuit *)
-  Fixpoint delays_get {t : type}
-    : forall {v : value t}, value (circuit_state (delays v)) -> value t :=
-    match t with
-    | tzero => fun _ _ => tt
-    | tone _ => fun _ => snd
-    | tpair _ _ => fun _ st => (delays_get (fst st), delays_get (snd st))
+    | tzero => Id
+    | tone t => Delay
+    | tpair t1 t2 => Par delays delays
     end.
 
   (* make a circuit with repeated delays for each signal *)
-  Fixpoint ndelays {t : type} (v : list (value (signal:=combType) t)) : Circuit t t :=
-    match v with
-    | [] => Id
-    | v0 :: v => ndelays v >==> delays v0
+  Fixpoint ndelays {t : type} (n : nat) : Circuit t t :=
+    match n with
+    | 0 => Id
+    | S m => ndelays m >==> delays
     end.
-
-  (* get all the values stored in the n-delay circuit *)
-  Fixpoint ndelays_get {t v} : value (circuit_state (@ndelays t v)) -> list (value t) :=
-    match v with
-    | [] => fun _ => []
-    | _ :: _ => fun st => delays_get (snd st) :: ndelays_get (fst st)
-    end.
-
 End WithCava.
 
-Inductive is_delays : forall {t}, Circuit t t -> Prop :=
-| is_delays_delay : forall t resetval, is_delays (DelayInit (t:=t) resetval)
-| is_delays_par :
-    forall t1 t2 c1 c2,
-      is_delays c1 -> is_delays c2 ->
-      @is_delays (t1 * t2) (Par c1 c2)
-.
-
-Inductive is_ndelays : forall {t}, nat -> Circuit t t -> Prop :=
-| is_ndelays_id : forall t, is_ndelays (t:=t) 0 Id
-| is_ndelays_compose :
-    forall t n c1 c2,
-      is_ndelays (t:=t) n c1 -> is_delays c2 ->
-      is_ndelays (S n) (c1 >==> c2)
-.
-
-Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists delay_circuit,
-    is_ndelays n delay_circuit
-    /\ cequiv c1 (delay_circuit >==> c2).
-
-Fixpoint loops_state {i o} (c : Circuit i o) : type :=
-  match c with
-  | Comb _ => tzero
-  | First f => loops_state f
-  | Second f => loops_state f
-  | Compose f g => loops_state f * loops_state g
-  | @DelayInitCE _ _ t _ => tzero
-  | @LoopInitCE _ _ _ _ t _ body => loops_state body * t
-  end.
-
-Fixpoint loops_reset_state {i o} (c : Circuit i o)
-  : value (signal:=combType) (loops_state c) :=
-  match c with
-  | Comb _ => tt
-  | First f => loops_reset_state f
-  | Second f => loops_reset_state f
-  | Compose f g => (loops_reset_state f, loops_reset_state g)
-  | DelayInitCE _=> tt
-  | LoopInitCE resetval body => (loops_reset_state body, resetval)
-  end.
-
-Require Import ExtLib.Structures.Monad.
-Import MonadNotation.
-
-(* Pull the loops out of the circuit completely *)
-Fixpoint loopless {i o} (c : Circuit i o)
-  : Circuit (i * loops_state c) (o * loops_state c) :=
-  match c as c in Circuit i o
-        return Circuit (i * loops_state c) (o * loops_state c) with
-  | Comb f => First (Comb f)
-  | First f =>
-    Comb (i:=(_*_*_)) (fun '(x1,x2,st) => ret (x1,st,x2)) (* rearrange *)
-         >==> First (loopless f) (* recursive call *)
-         >==> Comb (i:=(_*_*_)) (fun '(y1,st,y2) => ret (y1,y2,st)) (* rearrange *)
-  | Second f =>
-    Comb (i:=(_*_*_)) (fun '(x1,x2,st) => ret (x1,(x2,st))) (* rearrange *)
-         >==> Second (loopless f) (* recursive call *)
-         >==> Comb (i:=(_*(_*_))) (fun '(y1,(y2,st)) => ret (y1,y2,st)) (* rearrange *)
-  | Compose f g =>
-    Comb (i:=(_*(_*_))) (fun '(x,(st1,st2)) => ret (x,st1,st2)) (* rearrange *)
-         >==> First (loopless f) (* recursive call *)
-         >==> Comb (i:=(_*_*_)) (fun '(y,st1,st2) => ret (y,st2,st1)) (* rearrange *)
-         >==> First (loopless g) (* recursive call *)
-         >==> Comb (i:=(_*_*_))  (fun '(z,st2,st1) => ret (z,(st1,st2))) (* rearrange *)
-  | DelayInitCE resetval => First (DelayInitCE resetval)
-  | @LoopInitCE _ _ _ _ s resetval body =>
-    (Comb (i:=(_*_*(_*_)))
-          (fun '(x,en,(body_st, loop_st)) =>
-             ret (en,loop_st,(x,loop_st,body_st)))) (* rearrange *)
-         >==> Second (loopless body) (* recursive call *)
-         >==> (Comb (i:=(Bit * _ * (_ * _ * _))) (o:=(_*(_* _)))
-                    (fun '(en, loop_st, (y, loop_st', body_st')) =>
-                       loop_st' <- mux2 en (loop_st,loop_st') ;;
-                       ret (y,(body_st',loop_st'))))
-  end.
-
+(* n is delays on state; m is delays on input *)
 Definition phase_retimed {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists state_resets input_resets,
-    length state_resets = n
-    /\ length input_resets = m
-    /\ cequiv c1 (LoopInit (loops_reset_state c2)
-                          (Par (ndelays input_resets) (ndelays state_resets)
-                           >==> loopless c2)).
+  exists (proj21 : value (loops_state c2) -> value (loops_state c1))
+    (proj12 : value (loops_state c1) -> value (loops_state c2)),
+    (forall x, proj12 (proj21 x) = x)
+    /\ wequiv (Second (Comb proj21) >==> loopless c1 >==> Second (Comb proj12))
+             (Par (ndelays m) (ndelays n)  >==> loopless c2).

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -1,0 +1,213 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Semantics.Equivalence.
+Require Import Cava.Semantics.Simulation.
+Require Import Cava.Lib.CircuitTransforms.
+Import Circuit.Notations.
+
+
+(*
+
+c1 := c2 >==> Delay
+
+retimed 1 c1 c2
+
+c1 [in0;?;in1;?;in2] = c2 [in0;in1;in2]
+
+Can't step the circuits at the same rate and expect matching output!!
+Need to step retimed version and *not* non-retimed!
+
+c1_t=0 : c1 []
+c2_t=0 : c2 []
+
+c1_t=1 : c1 [in0]
+c2_t=0 : c2 []
+
+
+ *)
+
+(*
+(* The retiming relation is similar to cequiv, except that the relation now
+   takes a natural-number argument signifying how many steps remain before the
+   output of c1 will match the stored output from c2 *)
+Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
+  exists (R : nat -> o -> circuit_state c1 -> circuit_state c2 -> Prop),
+    (* when c1 gets an input, R holds with n steps remaining *)
+    (forall st1 st2 input,
+        R n (snd (step c2 st2 input)) (fst (step c1 st1 input))
+          (fst (step c2 st2 input)))
+    (* if R holds for a 0 counter, then output of next step must match stored
+       output *)
+    /\ (forall st1 st2 input output,
+        R 0 output st1 st2 -> snd (step c1 st1 input) = output)
+    (* if R holds for a nonzero counter, continue stepping c1 *)
+    /\ (forall m st1 st2 input output,
+          R (S m) output st1 st2 ->
+          m < n ->
+          R m output (fst (step c1 st1 input)) st2).
+
+*)
+(*
+(* The retiming relation is similar to cequiv, except that the relation now
+   takes a natural-number argument signifying how many steps remain before the
+   outputs will match *)
+Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
+  exists (R : nat -> circuit_state c1 -> circuit_state c2 -> Prop),
+    R n (reset_state c1) (reset_state c2)
+    /\ (forall m st1 st2 input1 input2,
+          R m st1 st2 ->
+          m <= n ->
+          (* if the inputs match, R holds on the new states with a fresh counter *)
+          (input1 = input2 ->
+           R n (fst (step c1 st1 input1)) (fst (step c2 st2 input2)))
+          (* if the counter is 0, then the outputs match; otherwise R holds on
+             the decremented counter *)
+          /\ match m with
+            | 0 => snd (step c1 st1 input1) = snd (step c2 st2 input2)
+            | S m' => R m' (fst (step c1 st1 input1))
+                       (fst (step c2 st2 input2))
+            end).
+*)
+(*
+(* The retiming relation is similar to cequiv, except that the relation now
+   takes a natural-number argument signifying how many steps remain before the
+   outputs will match *)
+Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
+  exists (R : nat -> circuit_state c1 -> circuit_state c2 -> Prop),
+    (*R n (reset_state c1) (reset_state c2)
+    /\ *) (forall l st1 st2 input1 input2,
+          (* R holds for each counter in the list *)
+          Forall (fun m => R m st1 st2) l ->
+          (* list of counters has no duplicates *)
+          NoDup l ->
+          (* if one of the counters is now 0, outputs must match *)
+          (In 0 l -> snd (step c1 st1 input1) = snd (step c2 st2 input2))
+          (* R continues to hold on remaining counters *)
+          /\ Forall
+              (fun m =>
+                 R m (fst (step c1 st1 input1)) (fst (step c2 st2 input2)))
+              (map Nat.pred (remove Nat.eq_dec 0 l))
+          (* if inputs match, then R also holds for a new counter *)
+          /\ (input1 = input2 ->
+             R n (fst (step c1 st1 input1)) (fst (step c2 st2 input2)))).
+
+
+(* The retiming relation is similar to cequiv, except that the relation now
+   takes a natural-number argument signifying how many steps remain before the
+   outputs will match *)
+Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
+  exists (R : list nat -> circuit_state c1 -> circuit_state c2 -> Prop),
+    R [] (reset_state c1) (reset_state c2)
+    /\ (forall l st1 st2 input1 input2,
+          (* R holds *)
+          R l st1 st2 ->
+          (* no counter is > n *)
+          Forall (fun m => m <= n) l ->
+          (* list is strongly sorted, no duplicates *)
+          (forall i j 0, i < j < length l -> nth i l 0 < nth i j 0) ->
+          (* if one of the counters is now 0, outputs must match *)
+          (In 0 l -> snd (step c1 st1 input) = snd (step c2 st2 input))
+          (* if inputs match, enqueue another counter *)
+          (input1 = input2 ->
+           R (n :: map Nat.pred (remove 0 l))
+             (fst (step c1 st1 input)) (fst (step c2 st2 input)))
+          (* if inputs do not match, just *)
+          /\ (input1 <> input2 ->
+             R
+          match m with
+          | S m' =>
+            (* if there are steps remaining, the outputs might not match;
+               decrement steps remaining *)
+            R m' (fst (step c1 st1 input))
+              (fst (step c2 st2 input))
+          | 0 =>
+            (* if there are no steps remaining, the output must match and the
+               counter resets *)
+            snd (step c1 st1 input) = snd (step c2 st2 input)
+            /\ R n (fst (step c1 st1 input))
+                (fst (step c2 st2 input))
+          end).
+
+(* The retiming relation is similar to cequiv, except that the relation now
+   takes a natural-number argument signifying how many steps remain before the
+   outputs will match *)
+Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
+  exists (R : nat -> circuit_state c1 -> circuit_state c2 -> Prop),
+    R n (reset_state c1) (reset_state c2)
+    /\ (forall m st1 st2 input1 input2,
+          m <= n ->
+          R m st1 st2 ->
+          match m with
+          | S m' =>
+            (* if there are steps remaining, the outputs might not match;
+               decrement steps remaining *)
+            R m' (fst (step c1 st1 input))
+              (fst (step c2 st2 input))
+          | 0 =>
+            (* if there are no steps remaining, the output must match and the
+               counter resets *)
+            snd (step c1 st1 input) = snd (step c2 st2 input)
+            /\ R n (fst (step c1 st1 input))
+                (fst (step c2 st2 input))
+          end).
+ *)
+
+(* Define a restricted type format for the delay circuits to work with *)
+Section WithCava.
+  Context `{semantics : Cava}.
+  (* gives the shape of a collection of signals *)
+  Inductive itype : Type :=
+  | ione (t : SignalType)
+  | ipair (i1 i2 : itype)
+  .
+
+  (* gives the Gallina tuple for the collection of signals specified *)
+  Fixpoint ivalue (i : itype) : Type :=
+    match i with
+    | ione t => signal t
+    | ipair a b => ivalue a * ivalue b
+    end.
+End WithCava.
+
+Section WithCava.
+  Context `{semantics : Cava}.
+
+  (* make a circuit with one delay for each signal, given the delays' reset
+     values *)
+  Fixpoint delays (t : itype)
+    : ivalue (signal:=combType) t -> Circuit (ivalue t) (ivalue t) :=
+    match t with
+    | ione t => DelayInit
+    | ipair a b =>
+      fun resetvals =>
+        Par (delays a (fst resetvals)) (delays b (snd resetvals))
+    end.
+
+  (* make a circuit with repeated delays for each signal, given the delays'
+     reset values for each layer *)
+  Definition ndelays (t : itype) (resetvals : list (ivalue (signal:=combType) t))
+    : Circuit (ivalue t) (ivalue t) :=
+    fold_left (fun c resetvals => c >==> delays t resetvals) resetvals Id.
+End WithCava.
+
+Definition retimed {i o} (n : nat) (c1 c2 : Circuit i (ivalue o)) : Prop :=
+  exists resetvals,
+    length resetvals = n
+    /\ cequiv c1 (c2 >==> ndelays o resetvals).

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -39,11 +39,19 @@ End WithCava.
 
 (* n is the number of delays on the output, m is the number of delays on the
    loop state *)
-Definition retimed {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
+Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
   exists rvals,
     cequiv c1
            (LoopInit (loops_reset_state c2)
                      ((loopless c2)
-                        >==> (chreset (Par (ndelays o n)
-                                           (ndelays (loops_state c2) m))
-                                      rvals))).
+                        >==> chreset (ndelays (o * loops_state c2) n) rvals)).
+
+Fixpoint retime_loops {i o} (c : Circuit i o) : Circuit i o :=
+  match c with
+  | Comb f => Comb f
+  | Compose f g => Compose (retime_loops f) (retime_loops g)
+  | First f => First (retime_loops f)
+  | Second f => Second (retime_loops f)
+  | LoopInitCE r f => LoopInitCE r (f >==> Second Delay)
+  | DelayInit r => DelayInit r
+  end.

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -30,24 +30,19 @@ Import ListNotations Circuit.Notations.
 Section WithCava.
   Context `{semantics : Cava}.
   (* make a circuit with repeated delays for each signal *)
-  Fixpoint ndelays {t : type} (n : nat) : Circuit t t :=
+  Fixpoint ndelays (t : type) (n : nat) : Circuit t t :=
     match n with
     | 0 => Id
-    | S m => ndelays m >==> Delay
+    | S m => ndelays t m >==> Delay
     end.
 End WithCava.
 
 (* n is the number of delays on the output, m is the number of delays on the
    loop state *)
 Definition retimed {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
-  (* there exists some way of converting between the loop states of c1 and c2 *)
-  exists (proj21 : value (loops_state c2) -> value (loops_state c1))
-    (proj12 : value (loops_state c1) -> value (loops_state c2)),
-    (forall x, proj12 (proj21 x) = x)
-    (* ...and loopless c1 is equivalent to loopless c2 composed with the delay
-       circuits and the state projections *)
-    /\ cequiv (loopless c1)
-             (Second (Comb proj12)
-                     >==> loopless c2
-                     >==> Par (ndelays n) (ndelays m)
-                     >==> Second (Comb proj21)).
+  exists rvals,
+    cequiv c1
+           (LoopInit (loops_reset_state c2)
+                     ((loopless c2)
+                        >==> chreset (Par (ndelays o n)
+                                          (ndelays (loops_state c2) m)) rvals)).

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -26,77 +26,48 @@ Require Import Cava.Lib.Combinators.
 Require Import Cava.Lib.Multiplexers.
 Import ListNotations Circuit.Notations.
 
-(* Define a restricted type format for the delay circuits to work with *)
-Section WithCava.
-  Context `{semantics : Cava}.
-  (* gives the shape of a collection of signals *)
-  Inductive itype : Type :=
-  | ione (t : SignalType)
-  | ipair (i1 i2 : itype)
-  .
-  Scheme Equality for itype.
-
-  (* gives the Gallina tuple for the collection of signals specified *)
-  Fixpoint ivalue (i : itype) : Type :=
-    match i with
-    | ione t => signal t
-    | ipair a b => ivalue a * ivalue b
-    end.
-
-  Fixpoint idefault (i : itype) : ivalue i :=
-    match i with
-    | ione t => defaultSignal
-    | ipair a b => (idefault a, idefault b)
-    end.
-End WithCava.
-
 Section WithCava.
   Context `{semantics : Cava}.
 
-  (* make a circuit with one delay for each signal, given the delays' reset
-     values *)
-  Fixpoint delays (t : itype) : Circuit (ivalue t) (ivalue t) :=
+  (* make a circuit with one delay for each signal, given reset values *)
+  Fixpoint delays {t : type} : value (signal:=combType) t -> Circuit t t :=
     match t with
-    | ione t => Delay (t:=t)
-    | ipair a b => Par (delays a) (delays b)
+    | tzero => fun _ => Id
+    | tone t => DelayInit
+    | tpair t1 t2 => fun v => Par (delays (fst v)) (delays (snd v))
     end.
 
   (* get the value stored in the 1-delay circuit *)
-  Fixpoint delays_get {t : itype}
-    : circuit_state (delays t) -> ivalue t :=
+  Fixpoint delays_get {t : type}
+    : forall {v : value t}, value (circuit_state (delays v)) -> value t :=
     match t with
-    | ione _ => snd
-    | ipair _ _ => fun st => (delays_get (fst st), delays_get (snd st))
+    | tzero => fun _ _ => tt
+    | tone _ => fun _ => snd
+    | tpair _ _ => fun _ st => (delays_get (fst st), delays_get (snd st))
     end.
 
-  (* make a circuit with repeated delays for each signal, given the delays'
-     reset values for each layer *)
-  Fixpoint ndelays (n : nat) (t : itype) : Circuit (ivalue t) (ivalue t) :=
-    match n with
-    | 0 => Id
-    | S m => ndelays m t >==> delays t
+  (* make a circuit with repeated delays for each signal *)
+  Fixpoint ndelays {t : type} (v : list (value (signal:=combType) t)) : Circuit t t :=
+    match v with
+    | [] => Id
+    | v0 :: v => ndelays v >==> delays v0
     end.
 
   (* get all the values stored in the n-delay circuit *)
-  Fixpoint ndelays_get {n t} : circuit_state (ndelays n t) -> list (ivalue t) :=
-    match n with
-    | 0 => fun _ => []
-    | S _ => fun st => delays_get (snd st) :: ndelays_get (fst st)
+  Fixpoint ndelays_get {t v} : value (circuit_state (@ndelays t v)) -> list (value t) :=
+    match v with
+    | [] => fun _ => []
+    | _ :: _ => fun st => delays_get (snd st) :: ndelays_get (fst st)
     end.
+
 End WithCava.
 
-(* it's possible to define is_delays directly without using itype, but then
-   inversion can't handle the type mismatches if the types are not just plain
-   identifiers, and you get nonsensical cases where e.g. unit = t1 * t2 *)
-Inductive is_delays' : forall t, Circuit (ivalue t) (ivalue t) -> Prop :=
-| is_delays'_delay : forall t resetval, is_delays' (ione t) (DelayInit (t:=t) resetval)
-| is_delays'_par :
-    forall t1 t2 c1 c2,
-      is_delays' t1 c1 -> is_delays' t2 c2 ->
-      is_delays' (ipair t1 t2) (Par c1 c2)
-.
 Inductive is_delays : forall {t}, Circuit t t -> Prop :=
-| is_delays_is_delays' : forall t c, is_delays' t c -> is_delays c
+| is_delays_delay : forall t resetval, is_delays (DelayInit (t:=t) resetval)
+| is_delays_par :
+    forall t1 t2 c1 c2,
+      is_delays c1 -> is_delays c2 ->
+      @is_delays (t1 * t2) (Par c1 c2)
 .
 
 Inductive is_ndelays : forall {t}, nat -> Circuit t t -> Prop :=
@@ -112,69 +83,66 @@ Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
     is_ndelays n delay_circuit
     /\ cequiv c1 (delay_circuit >==> c2).
 
-Definition mealy {i o} (c : Circuit i o)
-  : Circuit (i * circuit_state c) (o * circuit_state c) :=
-  Comb (fun '(input, st) =>
-          let st_out := step c st input in
-          (snd st_out, fst st_out)).
-
-(* we don't really want *full* mealy; just for loops -- and this state can be itype!! *)
-
-Fixpoint loops_state {i o} (c : Circuit i o) : itype :=
+Fixpoint loops_state {i o} (c : Circuit i o) : type :=
   match c with
-  | Comb _ => ione Void
+  | Comb _ => tzero
   | First f => loops_state f
   | Second f => loops_state f
-  | Compose f g => ipair (loops_state f) (loops_state g)
-  | @DelayInitCE _ _ t _ => ione Void
-  | @LoopInitCE _ _ _ _ t _ body => ipair (loops_state body) (ione t)
+  | Compose f g => loops_state f * loops_state g
+  | @DelayInitCE _ _ t _ => tzero
+  | @LoopInitCE _ _ _ _ t _ body => loops_state body * t
   end.
+
+Fixpoint loops_reset_state {i o} (c : Circuit i o)
+  : value (signal:=combType) (loops_state c) :=
+  match c with
+  | Comb _ => tt
+  | First f => loops_reset_state f
+  | Second f => loops_reset_state f
+  | Compose f g => (loops_reset_state f, loops_reset_state g)
+  | DelayInitCE _=> tt
+  | LoopInitCE resetval body => (loops_reset_state body, resetval)
+  end.
+
 Require Import ExtLib.Structures.Monad.
 Import MonadNotation.
 
 (* Pull the loops out of the circuit completely *)
-(* TODO: ask Ben B to remind me whose idea this was so they can be credited here *)
 Fixpoint loopless {i o} (c : Circuit i o)
-  : Circuit (i * ivalue (loops_state c)) (o * ivalue (loops_state c)) :=
+  : Circuit (i * loops_state c) (o * loops_state c) :=
   match c as c in Circuit i o
-        return Circuit (i * ivalue (loops_state c))
-                       (o * ivalue (loops_state c)) with
+        return Circuit (i * loops_state c) (o * loops_state c) with
   | Comb f => First (Comb f)
   | First f =>
-    Comb (fun '(x1,x2,st) => ret (x1,st,x2)) (* rearrange *)
+    Comb (i:=(_*_*_)) (fun '(x1,x2,st) => ret (x1,st,x2)) (* rearrange *)
          >==> First (loopless f) (* recursive call *)
-         >==> Comb (fun '(y1,st,y2) => ret (y1,y2,st)) (* rearrange *)
+         >==> Comb (i:=(_*_*_)) (fun '(y1,st,y2) => ret (y1,y2,st)) (* rearrange *)
   | Second f =>
-    Comb (fun '(x1,x2,st) => ret (x1,(x2,st))) (* rearrange *)
+    Comb (i:=(_*_*_)) (fun '(x1,x2,st) => ret (x1,(x2,st))) (* rearrange *)
          >==> Second (loopless f) (* recursive call *)
-         >==> Comb (fun '(y1,(y2,st)) => ret (y1,y2,st)) (* rearrange *)
+         >==> Comb (i:=(_*(_*_))) (fun '(y1,(y2,st)) => ret (y1,y2,st)) (* rearrange *)
   | Compose f g =>
-    Comb (fun '(x,(st1,st2)) => ret (x,st1,st2)) (* rearrange *)
+    Comb (i:=(_*(_*_))) (fun '(x,(st1,st2)) => ret (x,st1,st2)) (* rearrange *)
          >==> First (loopless f) (* recursive call *)
-         >==> Comb (fun '(y,st1,st2) => ret (y,st2,st1)) (* rearrange *)
+         >==> Comb (i:=(_*_*_)) (fun '(y,st1,st2) => ret (y,st2,st1)) (* rearrange *)
          >==> First (loopless g) (* recursive call *)
-         >==> Comb (fun '(z,st2,st1) => ret (z,(st1,st2))) (* rearrange *)
+         >==> Comb (i:=(_*_*_))  (fun '(z,st2,st1) => ret (z,(st1,st2))) (* rearrange *)
   | DelayInitCE resetval => First (DelayInitCE resetval)
-  | LoopInitCE resetval body =>
-    (* need : i * Bit * (lstate body * t) -> o * (lstate body * t) *)
-    (* loopless body : i * t * lstate body -> o * t * lstate body *)
-    Comb (fun '(x,en,(body_st, loop_st)) =>
-            ret (en,loop_st,(x,loop_st,body_st))) (* rearrange *)
+  | @LoopInitCE _ _ _ _ s resetval body =>
+    (Comb (i:=(_*_*(_*_)))
+          (fun '(x,en,(body_st, loop_st)) =>
+             ret (en,loop_st,(x,loop_st,body_st)))) (* rearrange *)
          >==> Second (loopless body) (* recursive call *)
-         >==> Comb (fun '(en, loop_st, (y, loop_st', body_st')) =>
-                      loop_st' <- mux2 en (loop_st,loop_st') ;;
-                      (y,(body_st',loop_st')))
+         >==> (Comb (i:=(Bit * _ * (_ * _ * _))) (o:=(_*(_* _)))
+                    (fun '(en, loop_st, (y, loop_st', body_st')) =>
+                       loop_st' <- mux2 en (loop_st,loop_st') ;;
+                       ret (y,(body_st',loop_st'))))
   end.
 
-
-(* can make a def that re-adds loops only to outside, then prove all circuits
-   equivalent to this transformation *)
-
 Definition phase_retimed {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists state_delays input_delays
-    (proj : ivalue (loops_state c1) -> ivalue (loops_state c2)),
-    is_ndelays n state_delays
-    /\ is_ndelays m input_delays
-    /\ cequiv (loopless c1 >==> Second (Comb (fun st => ret (proj st))))
-             (Par input_delays (Comb (fun st => ret (proj st)) >==> state_delays)
-                  >==> loopless c2).
+  exists state_resets input_resets,
+    length state_resets = n
+    /\ length input_resets = m
+    /\ cequiv c1 (LoopInit (loops_reset_state c2)
+                          (Par (ndelays input_resets) (ndelays state_resets)
+                           >==> loopless c2)).

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -44,5 +44,6 @@ Definition retimed {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
     cequiv c1
            (LoopInit (loops_reset_state c2)
                      ((loopless c2)
-                        >==> chreset (Par (ndelays o n)
-                                          (ndelays (loops_state c2) m)) rvals)).
+                        >==> (chreset (Par (ndelays o n)
+                                           (ndelays (loops_state c2) m))
+                                      rvals))).

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -30,29 +30,24 @@ Import ListNotations Circuit.Notations.
 Section WithCava.
   Context `{semantics : Cava}.
   (* make a circuit with repeated delays for each signal *)
-  Fixpoint ndelays {t : type} (r : list (@value combType t)) : Circuit t t :=
-    match r with
-    | [] => Id
-    | r0 :: r => ndelays r >==> DelayInit r0
+  Fixpoint ndelays {t : type} (n : nat) : Circuit t t :=
+    match n with
+    | 0 => Id
+    | S m => ndelays m >==> Delay
     end.
 End WithCava.
 
+(* n is the number of delays on the output, m is the number of delays on the
+   loop state *)
 Definition retimed {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
   (* there exists some way of converting between the loop states of c1 and c2 *)
   exists (proj21 : value (loops_state c2) -> value (loops_state c1))
     (proj12 : value (loops_state c1) -> value (loops_state c2)),
     (forall x, proj12 (proj21 x) = x)
-    (* ..and there exist two sets of delay values, one for the state and one for
-       the outputs *)
-    /\ exists (or : list (value o)) (sr : list (value (loops_state c2))),
-      (* ...and loopless c1 is equivalent to loopless c2 composed with the delay
-         circuits and the state projections *)
-      cequiv (loopless c1)
+    (* ...and loopless c1 is equivalent to loopless c2 composed with the delay
+       circuits and the state projections *)
+    /\ cequiv (loopless c1)
              (Second (Comb proj12)
                      >==> loopless c2
-                     >==> Par (ndelays or) (ndelays sr)
-                     >==> Second (Comb proj21))
-      (* ...and the number of output delays is n *)
-      /\ length or = n
-      (* ...and the number of loop state delays is m *)
-      /\ length sr = m.
+                     >==> Par (ndelays n) (ndelays m)
+                     >==> Second (Comb proj21)).

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -15,159 +15,13 @@
 (****************************************************************************)
 
 Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Lists.List.
 Require Import Cava.Core.Core.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Semantics.Equivalence.
 Require Import Cava.Semantics.Simulation.
 Require Import Cava.Lib.CircuitTransforms.
-Import Circuit.Notations.
-
-
-(*
-
-c1 := c2 >==> Delay
-
-retimed 1 c1 c2
-
-c1 [in0;?;in1;?;in2] = c2 [in0;in1;in2]
-
-Can't step the circuits at the same rate and expect matching output!!
-Need to step retimed version and *not* non-retimed!
-
-c1_t=0 : c1 []
-c2_t=0 : c2 []
-
-c1_t=1 : c1 [in0]
-c2_t=0 : c2 []
-
-
- *)
-
-(*
-(* The retiming relation is similar to cequiv, except that the relation now
-   takes a natural-number argument signifying how many steps remain before the
-   output of c1 will match the stored output from c2 *)
-Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists (R : nat -> o -> circuit_state c1 -> circuit_state c2 -> Prop),
-    (* when c1 gets an input, R holds with n steps remaining *)
-    (forall st1 st2 input,
-        R n (snd (step c2 st2 input)) (fst (step c1 st1 input))
-          (fst (step c2 st2 input)))
-    (* if R holds for a 0 counter, then output of next step must match stored
-       output *)
-    /\ (forall st1 st2 input output,
-        R 0 output st1 st2 -> snd (step c1 st1 input) = output)
-    (* if R holds for a nonzero counter, continue stepping c1 *)
-    /\ (forall m st1 st2 input output,
-          R (S m) output st1 st2 ->
-          m < n ->
-          R m output (fst (step c1 st1 input)) st2).
-
-*)
-(*
-(* The retiming relation is similar to cequiv, except that the relation now
-   takes a natural-number argument signifying how many steps remain before the
-   outputs will match *)
-Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists (R : nat -> circuit_state c1 -> circuit_state c2 -> Prop),
-    R n (reset_state c1) (reset_state c2)
-    /\ (forall m st1 st2 input1 input2,
-          R m st1 st2 ->
-          m <= n ->
-          (* if the inputs match, R holds on the new states with a fresh counter *)
-          (input1 = input2 ->
-           R n (fst (step c1 st1 input1)) (fst (step c2 st2 input2)))
-          (* if the counter is 0, then the outputs match; otherwise R holds on
-             the decremented counter *)
-          /\ match m with
-            | 0 => snd (step c1 st1 input1) = snd (step c2 st2 input2)
-            | S m' => R m' (fst (step c1 st1 input1))
-                       (fst (step c2 st2 input2))
-            end).
-*)
-(*
-(* The retiming relation is similar to cequiv, except that the relation now
-   takes a natural-number argument signifying how many steps remain before the
-   outputs will match *)
-Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists (R : nat -> circuit_state c1 -> circuit_state c2 -> Prop),
-    (*R n (reset_state c1) (reset_state c2)
-    /\ *) (forall l st1 st2 input1 input2,
-          (* R holds for each counter in the list *)
-          Forall (fun m => R m st1 st2) l ->
-          (* list of counters has no duplicates *)
-          NoDup l ->
-          (* if one of the counters is now 0, outputs must match *)
-          (In 0 l -> snd (step c1 st1 input1) = snd (step c2 st2 input2))
-          (* R continues to hold on remaining counters *)
-          /\ Forall
-              (fun m =>
-                 R m (fst (step c1 st1 input1)) (fst (step c2 st2 input2)))
-              (map Nat.pred (remove Nat.eq_dec 0 l))
-          (* if inputs match, then R also holds for a new counter *)
-          /\ (input1 = input2 ->
-             R n (fst (step c1 st1 input1)) (fst (step c2 st2 input2)))).
-
-
-(* The retiming relation is similar to cequiv, except that the relation now
-   takes a natural-number argument signifying how many steps remain before the
-   outputs will match *)
-Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists (R : list nat -> circuit_state c1 -> circuit_state c2 -> Prop),
-    R [] (reset_state c1) (reset_state c2)
-    /\ (forall l st1 st2 input1 input2,
-          (* R holds *)
-          R l st1 st2 ->
-          (* no counter is > n *)
-          Forall (fun m => m <= n) l ->
-          (* list is strongly sorted, no duplicates *)
-          (forall i j 0, i < j < length l -> nth i l 0 < nth i j 0) ->
-          (* if one of the counters is now 0, outputs must match *)
-          (In 0 l -> snd (step c1 st1 input) = snd (step c2 st2 input))
-          (* if inputs match, enqueue another counter *)
-          (input1 = input2 ->
-           R (n :: map Nat.pred (remove 0 l))
-             (fst (step c1 st1 input)) (fst (step c2 st2 input)))
-          (* if inputs do not match, just *)
-          /\ (input1 <> input2 ->
-             R
-          match m with
-          | S m' =>
-            (* if there are steps remaining, the outputs might not match;
-               decrement steps remaining *)
-            R m' (fst (step c1 st1 input))
-              (fst (step c2 st2 input))
-          | 0 =>
-            (* if there are no steps remaining, the output must match and the
-               counter resets *)
-            snd (step c1 st1 input) = snd (step c2 st2 input)
-            /\ R n (fst (step c1 st1 input))
-                (fst (step c2 st2 input))
-          end).
-
-(* The retiming relation is similar to cequiv, except that the relation now
-   takes a natural-number argument signifying how many steps remain before the
-   outputs will match *)
-Definition retimed {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
-  exists (R : nat -> circuit_state c1 -> circuit_state c2 -> Prop),
-    R n (reset_state c1) (reset_state c2)
-    /\ (forall m st1 st2 input1 input2,
-          m <= n ->
-          R m st1 st2 ->
-          match m with
-          | S m' =>
-            (* if there are steps remaining, the outputs might not match;
-               decrement steps remaining *)
-            R m' (fst (step c1 st1 input))
-              (fst (step c2 st2 input))
-          | 0 =>
-            (* if there are no steps remaining, the output must match and the
-               counter resets *)
-            snd (step c1 st1 input) = snd (step c2 st2 input)
-            /\ R n (fst (step c1 st1 input))
-                (fst (step c2 st2 input))
-          end).
- *)
+Import ListNotations Circuit.Notations.
 
 (* Define a restricted type format for the delay circuits to work with *)
 Section WithCava.
@@ -200,11 +54,30 @@ Section WithCava.
         Par (delays a (fst resetvals)) (delays b (snd resetvals))
     end.
 
+  (* get the value stored in the 1-delay circuit *)
+  Fixpoint delays_get {t : itype}
+    : forall {resetvals}, circuit_state (delays t resetvals) -> ivalue t :=
+    match t with
+    | ione _ => fun _ => snd
+    | ipair _ _ => fun _ st => (delays_get (fst st), delays_get (snd st))
+    end.
+
   (* make a circuit with repeated delays for each signal, given the delays'
      reset values for each layer *)
-  Definition ndelays (t : itype) (resetvals : list (ivalue (signal:=combType) t))
+  Fixpoint ndelays (t : itype) (resetvals : list (ivalue (signal:=combType) t))
     : Circuit (ivalue t) (ivalue t) :=
-    fold_left (fun c resetvals => c >==> delays t resetvals) resetvals Id.
+    match resetvals with
+    | [] => Id
+    | r0 :: resetvals => ndelays t resetvals >==> delays t r0
+    end.
+
+  (* get all the values stored in the n-delay circuit *)
+  Fixpoint ndelays_get {t : itype} {resetvals}
+    : circuit_state (ndelays t resetvals) -> list (ivalue t) :=
+    match resetvals with
+    | [] => fun _ => []
+    | _ :: _ => fun st => delays_get (snd st) :: ndelays_get (fst st)
+    end.
 End WithCava.
 
 Definition retimed {i o} (n : nat) (c1 c2 : Circuit i (ivalue o)) : Prop :=

--- a/cava/Cava/Lib/Retiming.v
+++ b/cava/Cava/Lib/Retiming.v
@@ -33,7 +33,7 @@ Section WithCava.
   (* make a circuit with one delay for each signal, given reset values *)
   Fixpoint delays {t : type} : Circuit t t :=
     match t with
-    | tzero => Id
+    | tzero => Delay
     | tone t => Delay
     | tpair t1 t2 => Par delays delays
     end.
@@ -51,5 +51,8 @@ Definition phase_retimed {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
   exists (proj21 : value (loops_state c2) -> value (loops_state c1))
     (proj12 : value (loops_state c1) -> value (loops_state c2)),
     (forall x, proj12 (proj21 x) = x)
-    /\ wequiv (Second (Comb proj21) >==> loopless c1 >==> Second (Comb proj12))
-             (Par (ndelays m) (ndelays n)  >==> loopless c2).
+    /\ wequiv (loopless c1)
+             (Second (Comb proj12)
+                   >==> Par (ndelays m) (ndelays n)
+                   >==> loopless c2
+                   >==> Second (Comb proj21)).

--- a/cava/Cava/Lib/RetimingProperties.v
+++ b/cava/Cava/Lib/RetimingProperties.v
@@ -47,64 +47,58 @@ All should be based on phase_retimed!
 
  *)
 
-Lemma split_delay {t1 t2} (r1 : value t1) (r2 : value t2) :
+Lemma split_delay_init {t1 t2} (r1 : value t1) (r2 : value t2) :
   cequiv (DelayInit (t:=t1*t2) (r1, r2)) (Par (DelayInit r1) (DelayInit r2)).
 Proof.
-  exists eq. ssplit; [ solve_is_total | reflexivity | ].
+  exists eq. ssplit; [ reflexivity | ].
   cbn [value circuit_state Par].
   intros; subst; destruct_products. ssplit; reflexivity.
 Qed.
+Lemma split_delay {t1 t2} : cequiv (Delay (t:=t1*t2)) (Par Delay Delay).
+Proof. apply split_delay_init. Qed.
 
-(* This admit is not provable! *)
-Lemma Comb_invertible {i o} (f : value i -> cava (value o)) x :
-  exists y, f y = x.
+Lemma LoopInitCE_Compose_l {i o s t}
+      (c : Circuit t i) (body : Circuit (i * s) (o * s)) r :
+  cequiv (First c >==> LoopInitCE r body)
+         (LoopInitCE r (First c >==> body)).
 Admitted.
 
-Lemma move_delay {i o} (c : Circuit i o) r :
-  is_loop_free c = true ->
+Lemma LoopInit_Compose_l {i o s t}
+      (c : Circuit t i) (body : Circuit (i * s) (o * s)) r :
+  cequiv (c >==> LoopInit r body) (LoopInit r (First c >==> body)).
+Admitted.
+
+Lemma move_delay_init {i o} (c : Circuit i o) r :
   cequiv (DelayInit r >==> c)
          (chreset c (fst (step c (reset_state c) r))
                   >==> DelayInit (snd (step c (reset_state c) r))).
 Proof.
-  revert r; induction c; intros.
-  { (* Comb case *)
-    eexists.
-    Unshelve. 2:cbn.
-    exists (fun s1 s2 => snd s2 = c (fst s1)).
-    cbn [value circuit_state reset_state chreset step fst snd]. simpl_ident.
-    ssplit.
-    { split; [ solve_is_total | ].
-      intros; destruct_products; cbn[fst snd] in *; logical_simplify.
-      lazymatch goal with |- context [?x = c _] => pose proof (Comb_invertible c x) end.
-      logical_simplify; subst; eexists_destruct; cbn [fst snd]; eauto. }
-    { reflexivity. }
-    { intros; logical_simplify. destruct_products; cbn [fst snd] in *; subst.
-      ssplit; reflexivity. } }
-  { (* Compose case *)
-    cbn [is_loop_free] in *.
-    lazymatch goal with H : (_ && _)%bool = true |- _ => apply Bool.andb_true_iff in H end.
-    logical_simplify. autorewrite with circuitsimpl.
-    rewrite IHc1 by auto. rewrite <-(Compose_assoc _ _ c2).
-    rewrite IHc2 by auto. autorewrite with circuitsimpl.
-    cbn [step reset_state fst snd]. reflexivity. }
-  { (* First case *)
-    cbn [is_loop_free value] in *. destruct_products.
-    cbn [reset_state fst snd step]. rewrite !split_delay.
-    cbv [Par]. rewrite First_Second_comm.
-    rewrite <-(Compose_assoc _ _ (First c)), <-First_Compose.
-    rewrite IHc by auto.
-    autorewrite with circuitsimpl; reflexivity. }
-  { (* Second case *)
-    cbn [is_loop_free value] in *. destruct_products.
-    cbn [reset_state fst snd step]. rewrite !split_delay.
-    cbv [Par]. autorewrite with circuitsimpl.
-    rewrite <-(Compose_assoc _ _ (Second c)). rewrite <-Second_Compose.
-    rewrite IHc by auto. cbn [chreset].
-    autorewrite with circuitsimpl; reflexivity. }
-  { (* LoopInitCE case *)
-    cbn [is_loop_free] in *. discriminate. }
-  { (* DelayInit case *)
-    reflexivity. }
+  exists (fun (s1 : value i * value (circuit_state c))
+       (s2 : value (circuit_state (chreset c _)) * value o) =>
+       step c (snd s1) (fst s1) = (from_chreset_state (fst s2), snd s2)).
+  cbn [fst snd reset_state from_chreset_state reset_state chreset
+           circuit_state value].
+  rewrite chreset_reset, from_to_chreset_state.
+  rewrite <-surjective_pairing.
+  ssplit; [ reflexivity | ].
+  intros; destruct_products. cbn [step fst snd] in *.
+  lazymatch goal with H : step _ _ _ = _ |- _ => rewrite H end.
+  ssplit; [ reflexivity | ]. cbn [fst snd].
+  rewrite step_chreset; cbn [fst snd].
+  rewrite from_to_chreset_state.
+  rewrite <-surjective_pairing.
+  reflexivity.
+Qed.
+
+Lemma split_ndelays {t1 t2} n :
+  cequiv (ndelays (t1*t2) n) (Par (ndelays t1 n) (ndelays t2 n)).
+Proof.
+  induction n; cbn [ndelays]; autorewrite with circuitsimpl; [ reflexivity | ].
+  rewrite split_delay, IHn. cbv [Par]. autorewrite with circuitsimpl.
+  eapply Proper_Compose; [ | reflexivity ].
+  rewrite <-(Compose_assoc (First _) (Second _) (First _)).
+  rewrite <-!First_Second_comm. autorewrite with circuitsimpl.
+  reflexivity.
 Qed.
 
 (*
@@ -174,28 +168,27 @@ Lemma Par_Id_r {i o t} (f : Circuit i o) : cequiv (Par (Id (t:=t)) f) (Second f)
 Proof. cbv [Par]. autorewrite with circuitsimpl. reflexivity. Qed.
 Hint Rewrite @Par_Id_r using solve [eauto] : circuitsimpl.
 
-Print Cava.
 Lemma Second_Comb {i o t} f :
   cequiv (Second (Comb f)) (Comb (i:=t*i) (o:=t*o) (fun x => (fst x, f (snd x)))).
 Proof.
-  cbv [cequiv]. cbn. ssplit; intros; [ solve_is_total | reflexivity | ].
-  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; try tauto; lia.
+  exists (fun _ _ => True). cbn [value circuit_state]. ssplit; [ tauto | ].
+  intros; logical_simplify. cbn [step fst snd]. ssplit; tauto.
 Qed.
 Hint Rewrite @Second_Comb using solve [eauto] : pull_comb.
 
 Lemma First_Comb {i o t} f :
   cequiv (First (Comb f)) (Comb (i:=i*t) (o:=o*t) (fun x => (f (fst x), snd x))).
 Proof.
-  cbv [cequiv]. cbn. ssplit; intros; [ reflexivity | ].
-  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; try tauto; lia.
+  exists (fun _ _ => True). cbn [value circuit_state]. ssplit; [ tauto | ].
+  intros; logical_simplify. cbn [step fst snd]. ssplit; tauto.
 Qed.
 Hint Rewrite @First_Comb using solve [eauto] : pull_comb.
 
 Lemma Compose_Comb {i t o} f g :
   cequiv (@Compose _ _ i t o (Comb f) (Comb g)) (Comb (f >=> g)).
 Proof.
-  cbv [cequiv]. cbn. ssplit; intros; [ reflexivity | ].
-  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; try tauto; lia.
+  exists (fun _ _ => True). cbn [value circuit_state]. ssplit; [ tauto | ].
+  intros; logical_simplify. cbn [step fst snd]. ssplit; tauto.
 Qed.
 Hint Rewrite @Compose_Comb using solve [eauto] : pull_comb.
 
@@ -207,30 +200,233 @@ Proof.
 Qed.
 Hint Rewrite @Compose_Comb_r using solve [eauto] : pull_comb.
 
-
-Lemma delays_Comb_comm {i o} (f : value i -> cava (value o)) :
-  wequiv (delays >==> Comb f) (Comb f >==> delays).
+Lemma loopless_loop_free {i o} (c : Circuit i o) :
+  is_loop_free c = true -> cequiv (loopless c) (First c).
 Proof.
-  Print wequiv.
-  Search cequivn.
-  induction i.
-  induction n; cbn [ndelays]; autorewrite with circuitsimplw; [ reflexivity | ].
-  rewrite <-(Compose_assoc_w _ _ _ _ (ndelays _) delays).
+  induction c; cbn [loopless is_loop_free];
+    rewrite ?Bool.andb_true_iff; intros; logical_simplify.
+  { (* Comb *)
+    reflexivity. }
+  { (* Compose *)
+    rewrite IHc1, IHc2 by auto.
+    exists (fun (s1 : unit * value (circuit_state c1) * unit * value (circuit_state c2) * unit)
+         (s2 : value (circuit_state c1) * value (circuit_state c2)) =>
+         s1 = (tt, fst s2, tt, snd s2, tt)).
+    cbn [value circuit_state reset_state loops_state fst snd].
+    ssplit; [ reflexivity | ].
+    intros; subst; destruct_products; cbn [fst snd step].
+    ssplit; reflexivity. }
+  { (* First *)
+    rewrite IHc by auto.
+    exists (fun (s1 : unit * value (circuit_state c) * unit) (s2: value (circuit_state c)) =>
+         s1 = (tt, s2, tt)).
+    cbn [value circuit_state reset_state loops_state fst snd].
+    ssplit; [ reflexivity | ].
+    intros; subst; destruct_products; cbn [fst snd step].
+    ssplit; reflexivity. }
+  { (* Second *)
+    rewrite IHc by auto.
+    exists (fun (s1 : unit * value (circuit_state c) * unit) (s2: value (circuit_state c)) =>
+         s1 = (tt, s2, tt)).
+    cbn [value circuit_state reset_state loops_state fst snd].
+    ssplit; [ reflexivity | ].
+    intros; subst; destruct_products; cbn [fst snd step].
+    ssplit; reflexivity. }
+  { (* Loop *)
+    discriminate. }
+  { (* Delay *)
+    reflexivity. }
 Qed.
 
-Lemma ndelays_Comb_comm {i o} (f : value i -> cava (value o)) n :
-  wequiv (ndelays n >==> Comb f) (Comb f >==> ndelays n).
+About to_chreset_state.
+
+Axiom reassemble_state :
+  forall {i o} (c : Circuit i o), value (circuit_state (loopless c)) -> value (loops_state c) -> value (circuit_state c).
+
+Axiom loops_state_from_circuit_state :
+  forall {i o} (c : Circuit i o), value (circuit_state c) -> value (loops_state c).
+Axiom loopless_state_from_circuit_state :
+  forall {i o} (c : Circuit i o), value (circuit_state c) -> value (circuit_state (loopless c)).
+
+Axiom to_chreset_loops_state :
+  forall {i o} {c : Circuit i o} {r : value (circuit_state c)}, value (loops_state c) -> value (loops_state (chreset c r)).
+Axiom from_chreset_loops_state :
+  forall {i o} {c : Circuit i o} {r : value (circuit_state c)}, value (loops_state (chreset c r)) -> value (loops_state c).
+
+Eval simpl in (fun r c => loops_state (DelayInit r >==> c)).
+Locate swap.
+Eval simpl in
+    (fun i o r c =>
+       Circuit (i * loops_state (DelayInit r >==> c)) (o * loops_state (DelayInit r >==> c))).
+Eval simpl in (fun i o r c =>
+ Circuit (i * loops_state (chreset c (fst (step c (reset_state c) r)) >==> DelayInit (snd (step c (reset_state c) r))))
+         (o * loops_state (chreset c (fst (step c (reset_state c) r)) >==> DelayInit (snd (step c (reset_state c) r))))).
+
+Lemma move_delay_loopless {i o} (c : Circuit i o) r :
+  cequiv (loopless (DelayInit r >==> c))
+         (Second (Comb (i:=(tzero*loops_state c))
+                       (o:=(loops_state (chreset c _)*tzero))
+                       (fun x => (to_chreset_loops_state (snd x), tt)))
+            >==> (loopless
+                    (chreset c (fst (step c (reset_state c) r))
+                             >==> DelayInit (snd (step c (reset_state c) r))))
+            >==> Second (Comb (i:=(loops_state (chreset c _)*tzero))
+                              (o:=(tzero * loops_state c))
+                              (fun x => (tt, from_chreset_loops_state (fst x))))).
+Admitted.
+(*
+(* i, (s1, s2)
+
+   == First c1 >==> Second (Comb (fun s => snd s)) >==> loopless c2
+*)
+Lemma loopless_Compose_loop_free_l {i o t} (c1 : Circuit i t) (c2 : Circuit t o) :
+  is_loop_free c1 = true ->
+  cequiv (loopless (c1 >==> c2))
+         ((First c1)
+            >==> (Comb (i:=t*(loops_state c1*loops_state c2)) (o:=_*_*_) (fun '(t,s1,s2) => (t,s2,s1)
+            (fun 
+         ) >==> loopless c2).
+ (Second c1 >==> loopless c2).
+  
+  loopless (Delay >==> c2)
+*)
+Lemma loopless_chreset {i o} (c : Circuit i o) r :
+  cequiv (loopless (chreset c r))
+         (Second (Comb from_chreset_loops_state)
+                 >==> chreset (loopless c) (loopless_state_from_circuit_state c r)
+                 >==> Second (Comb to_chreset_loops_state)).
+Admitted.
+
+Lemma ndelays_succ_l {t} n : cequiv (ndelays t (S n)) (Delay >==> ndelays t n).
 Proof.
-  induction n; cbn [ndelays]; autorewrite with circuitsimplw; [ reflexivity | ].
-  rewrite <-(Compose_assoc_w _ _ _ _ (ndelays _) delays).
+  induction n; cbn [ndelays]; autorewrite with circuitsimpl; [ reflexivity | ].
+  rewrite <-IHn. reflexivity.
 Qed.
 
-Lemma Comb_ext {i o} (f g : value i -> cava (value o)) :
-  (forall x, f x = g x) -> wequiv (Comb f) (Comb g).
+Fixpoint Forall_ndelays {t1 t2 n} (R : value t1 -> value t2 -> Prop)
+  : value (circuit_state (ndelays t1 n))
+    -> value (circuit_state (ndelays t2 n)) -> Prop :=
+  match n with
+  | 0 => fun _ _ => True
+  | S _ =>
+    fun d1 d2 =>
+      Forall_ndelays R (fst d1) (fst d2) /\ R (snd d1) (snd d2)
+  end.
+
+Lemma reassemble_reset_state {i o} (c : Circuit i o) :
+  reassemble_state c (reset_state (loopless c)) (loops_reset_state c) = reset_state c.
+Admitted.
+
+(* TODO: this should be cequiv ==> cequiv ==> iff *)
+Instance Proper_retimed {i o} n m :
+  Proper (cequiv ==> eq ==> iff) (@retimed i o n m).
 Proof.
-  intro Hext. cbv [wequiv]. cbn. ssplit; intros; [ reflexivity | ].
-  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; auto; lia.
+  intros a b Hab c d Hcd. subst. cbv [retimed].
+  split.
+  { intros [r Hac]; logical_simplify.
+    exists r. rewrite <-Hab, Hac. reflexivity. }
+  { intros [r Hbd]; logical_simplify.
+    exists r. rewrite Hab, Hbd. reflexivity. }
 Qed.
+
+Lemma retimed_trans {i o} n m n' m' (c1 c2 c3 : Circuit i o) :
+  retimed n m c1 c2 -> retimed n' m' c2 c3 ->
+  retimed (n + n') (m + m') c1 c3.
+Admitted.
+
+Lemma delay1_output {i o} n m (c1 c2 : Circuit i o) :
+  retimed n m c1 (c2 >==> Delay) ->
+  retimed (S n) m c1 c2.
+Proof.
+  intros.
+  replace (S n) with (n + 1) by lia. replace m with (m + 0) by lia.
+  eapply retimed_trans; [ eassumption | ].
+  cbv [retimed]. cbn [Par circuit_state chreset value ndelays Id].
+  exists (tt, defaultValue, tt). cbn [fst snd].
+  autorewrite with circuitsimpl.
+  change defaultValue with (reset_state (Delay (t:=o))).
+  rewrite chreset_noop, LoopInit_First_r.
+  rewrite <-extract_loops. reflexivity.
+Qed.
+
+Lemma delay1_input {i o} n m (c1 c2 : Circuit i o) :
+  retimed n m c1 (Delay >==> c2) ->
+  retimed (S n) m c1 (chreset c2 (fst (step c2 (reset_state c2) defaultValue))).
+Proof.
+  intros.
+  replace (S n) with (n + 1) by lia.
+  replace m with (m + 0) by lia.
+  eapply retimed_trans; [ eassumption | ].
+  cbv [Delay]. rewrite move_delay_init.
+  cbv [retimed]. cbn [Par circuit_state chreset value ndelays Id Delay].
+  exists (tt, snd (step c2 (reset_state c2) defaultValue), tt). cbn [fst snd].
+  autorewrite with circuitsimpl.
+  rewrite LoopInit_First_r. rewrite <-extract_loops.
+  reflexivity.
+Qed.
+
+Require Import Coq.derive.Derive.
+
+Local Ltac simpl_resets :=
+  cbn [step fst snd defaultValue default_value
+            CombinationalSemantics defaultSignal defaultCombValue].
+
+Derive pipelined_nand
+       SuchThat (retimed
+                   2 0 pipelined_nand
+                   (Comb (i:=Bit*Bit) (o:=Bit) and2
+                         >==> Comb (o:=Bit) inv))
+       As pipelined_nand_correct.
+Proof.
+  (* insert a delay *)
+  apply delay1_input.
+  (* move the delay to the end of the circuit *)
+  rewrite move_delays by reflexivity.
+  (* insert another delay *)
+  apply delay1_input.
+  (* move the delay in between the and2 and inv *)
+  rewrite !Compose_assoc_w.
+  rewrite move_delays by reflexivity.
+  (* reflexivity *)
+  subst pipelined_nand. reflexivity.
+Qed.
+Print pipelined_nand.
+Check pipelined_nand_correct.
+
+Definition cipher_middle_round
+           {state key : type}
+           (sbytes : Circuit state state)
+           (shrows : Circuit state state)
+           (mxcols : Circuit state state)
+           (add_rk : Circuit (state * key) state)
+  : Circuit (state * key) state :=
+  First (sbytes >==> shrows >==> mxcols) >==> add_rk.
+
+Derive retimed_cipher_middle_round
+       SuchThat
+       (forall {state key} n
+          (sbytes retimed_sbytes shrows mxcols : Circuit state state)
+          (add_rk : Circuit (state * key) state),
+           phase_retimed 0 n retimed_sbytes sbytes ->
+           phase_retimed
+             0 n
+             (retimed_cipher_middle_round
+                state key retimed_sbytes shrows mxcols add_rk)
+             (cipher_middle_round sbytes shrows mxcols add_rk))
+       As retimed_cipher_middle_round_correct.
+Proof.
+  intros. cbv [cipher_middle_round].
+  autorewrite with circuitsimplw.
+  eapply delayn_input.
+  cbv [phase_retimed] in * |- . logical_simplify.
+  destruct_lists_by_length. cbn [ndelays] in *.
+  cbv [Par] in *; autorewrite with circuitsimplw in *.
+  rewrite ndelays_First.
+  Print phase_retimed.
+
+  (* TODO: not quite working right now, how to properly incorporate retimed
+     subcomponents? *)
+Abort.
 
 Lemma loopless_LoopInit {i o s} (body : Circuit (i * s) (o * s)) r :
   wequiv (loopless (LoopInit r body))
@@ -295,12 +491,6 @@ Proof.
     with (Id (t:=loops_state c)).
   autorewrite with circuitsimplw. reflexivity.
 Qed.
-
-Axiom reassemble_state :
-  forall {i o} (c : Circuit i o), value (circuit_state (loopless c)) -> value (loops_state c) -> value (circuit_state c).
-
-Axiom loops_state_from_circuit_state :
-  forall {i o} (c : Circuit i o), value (circuit_state c) -> value (loops_state c).
 
 Global Instance Proper_phase_retimed {i o} :
   Proper (eq ==> eq ==> wequiv ==> wequiv ==> iff) (@phase_retimed i o).

--- a/cava/Cava/Lib/RetimingProperties.v
+++ b/cava/Cava/Lib/RetimingProperties.v
@@ -1,0 +1,159 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import coqutil.Tactics.Tactics.
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Semantics.Equivalence.
+Require Import Cava.Semantics.Simulation.
+Require Import Cava.Lib.CircuitTransforms.
+Require Import Cava.Lib.CircuitTransformsProperties.
+Require Import Cava.Lib.Retiming.
+Require Import Cava.Util.Tactics.
+Import ListNotations Circuit.Notations.
+
+Lemma retimed_cequiv_iff {i o} (c1 c2 : Circuit i o) :
+  retimed 0 c1 c2 <-> cequiv c1 c2.
+Proof.
+  split.
+  { intros [R ?]. logical_simplify.
+    exists (R 0).
+    ssplit; [ assumption | ]. intros.
+    specialize
+      (HR 0 _ _ (ltac:(eassumption)) (ltac:(eassumption))
+          (ltac:(eassumption)) (ltac:(lia))).
+    cbn iota in *. rewrite (proj2 HR).
+    logical_simplify. ssplit; eauto. }
+  { intros [R [? HR]]. exists (fun _ => R).
+    ssplit; [ assumption | ]. intros.
+    destruct m; [ | lia ].
+    ssplit; intros; subst.
+    2:{
+    specialize
+      (HR _ _ (ltac:(eassumption)) (ltac:(eassumption))).
+    logical_simplify. ssplit; eauto.
+    rewrite (proj2 HR). logical_simplify. ssplit; eauto. }
+Qed.
+
+(*
+Lemma retimed_sum {i o} (n m: nat) (c1 c2 c3 : Circuit i o) :
+  retimed (n+m) c1 c2 -> retimed n c1 c3 -> retimed m c2 c3.
+Proof.
+  intros [R12 [? H12]]. intros [R13 [? H13]].
+  exists (fun i (st2 : circuit_state c2) (st3 : circuit_state c3) =>
+       exists st1, R12 i st1 st2
+              /\ R13 (Nat.modulo (i*m) n) st1 st3).
+  ssplit.
+  { exists (reset_state c1). ssplit; eauto.
+Qed.
+*)
+
+(*
+Lemma retimed_delays1_l_iff {i o} (n : nat) (c1 c2 : Circuit (ivalue i) o) :
+  retimed 1 c1 c2
+  <-> (exists resetvals : ivalue i,
+        cequiv c1 (delays i resetvals >==> c2)).
+Admitted.
+ *)
+
+(*
+the second part matches every m cycles
+the first part matches every n cycles
+
+assume m=2, n=3
+
+0:reset
+2:second part matches
+3:first part matches
+4:second part matches
+6:first part matches
+??????
+ahhhh, the second part matches only m cycles *after its input matches*
+
+
+
+if we are i steps away from matching...
+
+if i <= m,
+ the second part is i steps away from matching
+else
+ second part unclear but does have an R
+
+
+ *)
+
+Lemma retimed_compose A B C n m (c1 c2 : Circuit A B) (c3 c4 : Circuit B C) :
+  retimed n c1 c2 -> retimed m c3 c4 -> retimed (n+m) (c1 >==> c3) (c2 >==> c4).
+Proof.
+  intros [R12 [? H12]] [R34 [? H34]].
+  exists (fun i st1 st2 =>
+       R12 (i - m) (fst st1) (fst st2)
+       /\ R34 i (snd st1) (snd st2)).
+  cbn [reset_state fst snd].
+  ssplit;
+    [ autorewrite with natsimpl;
+      solve [eauto] | | ].
+  { 
+  cbn [circuit_state]. intros.
+  destruct_products; cbn [fst snd] in *.
+  logical_simplify. destruct_one_match.
+  { autorewrite with natsimpl in *.
+    cbn [step]. repeat (destruct_pair_let; cbn [fst snd]).
+    specialize (H34 0 _ _ (ltac:(eassumption)) (ltac:(lia))
+                    (ltac:(eassumption))).
+    cbn iota in H34. destruct H34 as [H34 ?].
+    rewrite H34 in *.
+  { 
+Qed.
+
+Lemma retimed_succ {i o} n (c1 c2 : Circuit (ivalue i) o) :
+  retimed (S n) c1 c2 ->
+  exists resetvals, retimed n c1 (delays i resetvals >==> c2).
+Proof.
+Qed.
+
+Lemma retimed_ndelays_l_iff {i o} (n : nat) (c1 c2 : Circuit (ivalue i) o) :
+  retimed n c1 c2 <-> (exists resetvals : list (ivalue i),
+                        length resetvals = n
+                        /\ cequiv c1 (ndelays i resetvals >==> c2)).
+Proof.
+  split.
+  { revert i o c1 c2; induction n; intros *.
+    { rewrite retimed_cequiv_iff.
+      intros. exists nil. cbn [ndelays fold_left].
+      autorewrite with circuitsimpl.
+      ssplit; eauto. }
+    {
+      (* retimed (S n) c1 c2 -> exists c3, retimed n c1 c3 /\ cequiv c3 (delays >==> c2) *)
+      
+      intros [R [? HR]]. logical_simplify.
+    
+
+    (*
+      equivalence state relation should say that R 0 holds on the last?
+    *)
+
+    evar (r: list (ivalue (signal:=combType) i)).
+    exists r. ssplit.
+    2:{
+      exists (fun (st1 : circuit_state c1)
+           (st2 : circuit_state (ndelays i r) * circuit_state c2) =>
+           R 0 st1 (snd st2)).
+      
+Qed.
+

--- a/cava/Cava/Lib/RetimingProperties.v
+++ b/cava/Cava/Lib/RetimingProperties.v
@@ -47,9 +47,17 @@ All should be based on phase_retimed!
 
  *)
 
+Lemma cpath_delays {t} : cpath (@delays _ _ t) = 1.
+Proof.
+  induction t; cbn [delays cpath Delay Par]; [ reflexivity .. | ].
+Qed.
+
 Lemma move_delays {i o} (c : Circuit i o) :
   is_loop_free c = true -> wequiv (delays >==> c) (c >==> delays).
-Admitted.
+Proof.
+  intros. cbv [wequiv]. ssplit; [ cbn [cpath]; try lia | ].
+  { Set Printing All.
+Qed.
 
 Lemma split_ndelays {t1 t2} n :
   wequiv (ndelays (t:=t1 * t2) n) (Par (ndelays n) (ndelays n)).
@@ -69,6 +77,130 @@ Lemma delayn_input {i o} n m (c1 c2 : Circuit i o) :
   phase_retimed n 0 c1 (ndelays m >==> c2) ->
   phase_retimed n m c1 c2.
 Admitted.
+
+Lemma Par_Id_l_w {i o t} (f : Circuit i o) : wequiv (Par f (Id (t:=t))) (First f).
+Proof. cbv [Par]. autorewrite with circuitsimplw. reflexivity. Qed.
+Hint Rewrite @Par_Id_l_w using solve [eauto] : circuitsimplw.
+
+Lemma Par_Id_r_w {i o t} (f : Circuit i o) : wequiv (Par (Id (t:=t)) f) (Second f).
+Proof. cbv [Par]. autorewrite with circuitsimplw. reflexivity. Qed.
+Hint Rewrite @Par_Id_r_w using solve [eauto] : circuitsimplw.
+
+Lemma Second_Comb_w {i o t} f :
+  wequiv (Second (Comb f)) (Comb (i:=t*i) (o:=t*o) (fun x => (fst x, f (snd x)))).
+Proof.
+  cbv [wequiv]. cbn. ssplit; intros; [ reflexivity | ].
+  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; try tauto; lia.
+Qed.
+Hint Rewrite @Second_Comb_w using solve [eauto] : pull_comb.
+
+Lemma First_Comb_w {i o t} f :
+  wequiv (First (Comb f)) (Comb (i:=i*t) (o:=o*t) (fun x => (f (fst x), snd x))).
+Proof.
+  cbv [wequiv]. cbn. ssplit; intros; [ reflexivity | ].
+  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; try tauto; lia.
+Qed.
+Hint Rewrite @First_Comb_w using solve [eauto] : pull_comb.
+
+Lemma Compose_Comb_w {i t o} f g :
+  wequiv (@Compose _ _ i t o (Comb f) (Comb g)) (Comb (f >=> g)).
+Proof.
+  cbv [wequiv]. cbn. ssplit; intros; [ reflexivity | ].
+  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; try tauto; lia.
+Qed.
+Hint Rewrite @Compose_Comb_w using solve [eauto] : pull_comb.
+
+Lemma Compose_Comb_r_w {i t1 t2 o} c f g :
+  wequiv (@Compose _ _ i t2 o (@Compose _ _ i t1 t2 c (Comb f)) (Comb g))
+         (c >==> Comb (f >=> g)).
+Proof.
+  rewrite <-Compose_Comb_w. autorewrite with circuitsimplw. reflexivity.
+Qed.
+Hint Rewrite @Compose_Comb_r_w using solve [eauto] : pull_comb.
+
+Lemma First_Second_comm {i1 i2 o1 o2} (c1 : Circuit i1 o1) (c2 : Circuit i2 o2) :
+  wequiv (First c1 >==> Second c2) (Second c2 >==> First c1).
+Admitted.
+
+Lemma delays_Comb_comm {i o} (f : value i -> cava (value o)) :
+  wequiv (delays >==> Comb f) (Comb f >==> delays).
+Proof.
+  Print wequiv.
+  Search cequivn.
+  induction i.
+  induction n; cbn [ndelays]; autorewrite with circuitsimplw; [ reflexivity | ].
+  rewrite <-(Compose_assoc_w _ _ _ _ (ndelays _) delays).
+Qed.
+
+Lemma ndelays_Comb_comm {i o} (f : value i -> cava (value o)) n :
+  wequiv (ndelays n >==> Comb f) (Comb f >==> ndelays n).
+Proof.
+  induction n; cbn [ndelays]; autorewrite with circuitsimplw; [ reflexivity | ].
+  rewrite <-(Compose_assoc_w _ _ _ _ (ndelays _) delays).
+Qed.
+
+Lemma Comb_ext {i o} (f g : value i -> cava (value o)) :
+  (forall x, f x = g x) -> wequiv (Comb f) (Comb g).
+Proof.
+  intro Hext. cbv [wequiv]. cbn. ssplit; intros; [ reflexivity | ].
+  exists (fun i _ _ => i = 0); ssplit; intros; cbn [step fst snd]; auto; lia.
+Qed.
+
+Lemma loopless_LoopInit {i o s} (body : Circuit (i * s) (o * s)) r :
+  wequiv (loopless (LoopInit r body))
+         (Comb (i:=(_*(_*(_*_)))) (o:=_*_*_)
+               (fun '(x, (_, (body_st, loop_st))) => (x, loop_st, body_st))
+               >==> loopless body
+               >==> (Comb (i:=_*_*_) (o:=(_*(tzero*(_*_))))
+                          (fun '(x, loop_st, body_st) => (x, (tt, (body_st, loop_st)))))).
+Proof.
+  cbv [wequiv]. ssplit; intros; [ cbn; lia | ].
+  cbn [cpath loopless LoopInit]. autorewrite with natsimpl. simpl_ident.
+  cbv [cequivn]. cbn [value loops_state LoopInit circuit_state].
+  destruct (cequivn_reflexive (loopless body) ltac:(apply is_loop_free_loopless))
+    as [Rb ?]. logical_simplify.
+  exists (fun i s1 s2 => Rb i (snd (fst (snd (fst s1)))) (snd (fst s2))).
+  ssplit.
+  { intros; destruct_products. cbn. auto. }
+  { intros; destruct_products. cbn.
+    repeat lazymatch goal with x : unit |- _ => destruct x end.
+    repeat destruct_pair_let. cbn [fst snd].
+    lazymatch goal with H : cpath _ = 0 -> _ |- _ => erewrite H by auto end.
+    reflexivity. }
+  { intros; destruct_products; cbn.
+    repeat lazymatch goal with x : unit |- _ => destruct x end.
+    repeat destruct_pair_let. cbn [fst snd] in *.
+    lazymatch goal with H : forall _ _ _ _, Rb 1 _ _ -> _ |- _ =>
+                        erewrite H by eauto end.
+    reflexivity. }
+  { intros; destruct_products; cbn.
+    repeat lazymatch goal with x : unit |- _ => destruct x end.
+    repeat destruct_pair_let. cbn [fst snd] in *. eauto. }
+Qed.
+
+Lemma retime_loop {i o s} (f g : Circuit (i * s) (o * s)) n r :
+  phase_retimed n n f g ->
+  phase_retimed n n (LoopInit r f) (LoopInit r g).
+Proof.
+  cbv [phase_retimed]. intros [proj_gf [proj_fg [Hproj Hequiv]]].
+  cbn [loops_state value LoopInit].
+  exists (fun x => (fst x, (proj_gf (fst (snd x)), snd (snd x)))).
+  exists (fun x => (fst x, (proj_fg (fst (snd x)), snd (snd x)))).
+  rewrite !loopless_LoopInit. rewrite Hequiv.
+  split; [ intros; destruct_products; cbn [fst snd]; rewrite Hproj;
+           reflexivity | ].
+  autorewrite with circuitsimplw pull_comb.
+  cbv [mcompose]; simpl_ident.
+  (* RHS has delays and Comb flipped around *)
+  repeat eapply Proper_Compose.
+  (* need Proper_comb with funext *)
+  (* each subcircuit should now be equiivalent *)
+  eapply Proper_Comb.
+  Print phase_retimed.
+  (* objective: get to Second (Par (ndelays n) (ndelays n)) >==> loopless g) and rewrite *)
+  
+  Search LoopInitCE.
+Qed.
 
 Instance phase_retimed_0_refl {i o} : Reflexive (@phase_retimed i o 0 0) | 10.
 Proof.
@@ -148,6 +280,7 @@ Proof.
   destruct_lists_by_length. cbn [ndelays] in *.
   cbv [Par] in *; autorewrite with circuitsimplw in *.
   rewrite ndelays_First.
+  Print phase_retimed.
 
   (* TODO: not quite working right now, how to properly incorporate retimed
      subcomponents? *)

--- a/cava/Cava/Lib/RetimingProperties.v
+++ b/cava/Cava/Lib/RetimingProperties.v
@@ -14,6 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Classes.Morphisms.
 Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.
 Require Import coqutil.Tactics.Tactics.
@@ -24,31 +26,389 @@ Require Import Cava.Semantics.Simulation.
 Require Import Cava.Lib.CircuitTransforms.
 Require Import Cava.Lib.CircuitTransformsProperties.
 Require Import Cava.Lib.Retiming.
+Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 Import ListNotations Circuit.Notations.
 
-Lemma retimed_cequiv_iff {i o} (c1 c2 : Circuit i o) :
+Lemma retimed0_cequiv_iff {i o} (c1 c2 : Circuit i (ivalue o)) :
   retimed 0 c1 c2 <-> cequiv c1 c2.
 Proof.
   split.
-  { intros [R ?]. logical_simplify.
-    exists (R 0).
-    ssplit; [ assumption | ]. intros.
-    specialize
-      (HR 0 _ _ (ltac:(eassumption)) (ltac:(eassumption))
-          (ltac:(eassumption)) (ltac:(lia))).
-    cbn iota in *. rewrite (proj2 HR).
-    logical_simplify. ssplit; eauto. }
-  { intros [R [? HR]]. exists (fun _ => R).
-    ssplit; [ assumption | ]. intros.
-    destruct m; [ | lia ].
-    ssplit; intros; subst.
-    2:{
-    specialize
-      (HR _ _ (ltac:(eassumption)) (ltac:(eassumption))).
-    logical_simplify. ssplit; eauto.
-    rewrite (proj2 HR). logical_simplify. ssplit; eauto. }
+  { intros [resetvals ?]. logical_simplify.
+    destruct resetvals; [ | cbn [length] in *; lia ].
+    cbn [ndelays fold_left] in *.
+    autorewrite with circuitsimpl in *. auto. }
+  { intros. exists nil. ssplit; [ reflexivity | ].
+    cbn [ndelays fold_left].
+    autorewrite with circuitsimpl. auto. }
 Qed.
+
+(* rephrasing of the definition of retimed that can be helpful when proving a
+   retimed goal *)
+Lemma retimed_cequiv {i o} n (c1 c2 : Circuit i (ivalue o)) resetvals :
+  cequiv c1 (c2 >==> ndelays o resetvals) ->
+  length resetvals = n ->
+  retimed n c1 c2.
+Proof. cbv [retimed]; intros; eauto. Qed.
+
+Lemma simulate_delays t resetvals input :
+  simulate (delays t resetvals) input
+  = firstn (length input) (resetvals :: input).
+Proof.
+  revert input; induction t; intros; cbn [delays ivalue];
+    autorewrite with push_simulate; [ reflexivity | ].
+  rewrite !IHt1, IHt2. autorewrite with push_length.
+  rewrite <-combine_firstn. cbn [combine].
+  rewrite <-surjective_pairing.
+  rewrite combine_map_r, combine_map_l, combine_same.
+  rewrite !map_map. cbn [fst snd].
+  rewrite List.map_id_ext by (intros; symmetry; apply surjective_pairing).
+  reflexivity.
+Qed.
+Hint Rewrite @simulate_delays using solve [eauto] : push_simulate.
+
+Lemma delays_get_reset t resetvals :
+  delays_get (reset_state (delays t resetvals)) = resetvals.
+Proof.
+  induction t; [ reflexivity | ].
+  cbn [delays delays_get Par reset_state fst snd].
+  rewrite IHt1, IHt2, <-surjective_pairing.
+  reflexivity.
+Qed.
+
+Lemma delays_get_step t resetvals st input :
+  delays_get (fst (step (delays t resetvals) st input)) = input.
+Proof.
+  induction t; [ reflexivity | ].
+  cbn [delays delays_get Par step fst snd].
+  repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite IHt1, IHt2, <-surjective_pairing.
+  reflexivity.
+Qed.
+
+Lemma step_delays t resetvals st input :
+  snd (step (delays t resetvals) st input) = delays_get st.
+Proof.
+  induction t; [ reflexivity | ].
+  cbn [delays delays_get Par step fst snd].
+  repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite IHt1, IHt2. reflexivity.
+Qed.
+
+Lemma move_delays i o (c : Circuit (ivalue i) (ivalue o)) resetvalsi resetvalso :
+  (* step c applied to resetvals from resetstate needs to result in reset
+     state; otherwise first results don't match *)
+  step c (reset_state c) resetvalsi = (reset_state c, resetvalso) ->
+  cequiv (delays i resetvalsi >==> c)
+         (c >==> delays o resetvalso).
+Proof.
+  intro Hreset.
+  exists (fun (st1 : circuit_state (delays i resetvalsi) * circuit_state c)
+       (st2 : circuit_state c * circuit_state (delays o resetvalso)) =>
+       step c (snd st1) (delays_get (fst st1)) = (fst st2, delays_get (snd st2))).
+  ssplit.
+  { cbn. rewrite !delays_get_reset.
+    destruct (step c (reset_state c) resetvalsi); cbn [fst snd] in *.
+    logical_simplify; subst. reflexivity. }
+  { cbn [circuit_state step]; intros *. intro Hstep.
+    destruct_products; cbn [fst snd] in *.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    logical_simplify. rewrite !delays_get_step, !step_delays.
+    rewrite Hstep. cbn [fst snd]. rewrite <-surjective_pairing.
+    ssplit; reflexivity. }
+Qed.
+
+Lemma ndelays_cons t resetvals r0 :
+  cequiv (ndelays t (r0 :: resetvals)) (ndelays t resetvals >==> delays t r0).
+Proof. reflexivity. Qed.
+
+Lemma ndelays_snoc t resetvals r0 :
+  cequiv (ndelays t (resetvals ++ [r0])) (delays t r0 >==> ndelays t resetvals).
+Proof.
+  revert r0. induction resetvals; intros.
+  { cbn [app ndelays]. autorewrite with circuitsimpl. reflexivity. }
+  { cbn [app ndelays]. rewrite IHresetvals, Compose_assoc.
+    reflexivity. }
+Qed.
+
+Lemma simulate_ndelays t resetvals input :
+  simulate (ndelays t resetvals) input
+  = firstn (length input) (resetvals ++ input).
+Proof.
+  revert input; induction resetvals; intros.
+  { autorewrite with push_simulate listsimpl push_firstn.
+    reflexivity. }
+  { rewrite ndelays_cons.
+    autorewrite with push_simulate push_length.
+    rewrite IHresetvals, <-app_comm_cons.
+    destruct input; [ reflexivity | ].
+    autorewrite with push_length push_firstn natsimpl.
+    apply Min.min_case_strong; intros; [ | reflexivity ].
+    autorewrite with natsimpl push_firstn listsimpl.
+    reflexivity. }
+Qed.
+Hint Rewrite @simulate_ndelays using solve [eauto] : push_simulate.
+
+Global Instance Proper_retimed i o :
+  Proper (eq ==> cequiv ==> cequiv ==> iff) (@retimed i o).
+Proof.
+  repeat intro. cbv [retimed].
+  split; intros; logical_simplify; subst;
+    eexists; (ssplit; [ reflexivity | ]).
+  all:repeat match goal with H : cequiv _ _ |- _ => rewrite H in * end.
+  all:reflexivity.
+Qed.
+
+Global Instance Reflexive_retimed0 i o : Reflexive (@retimed i o 0) | 10.
+Proof.
+  repeat intro; subst.
+  exists []; ssplit; [ reflexivity | ].
+  cbn [ndelays]. autorewrite with circuitsimpl.
+  reflexivity.
+Qed.
+
+Lemma retimed_step_r {i o} n (c1 c2 : Circuit i (ivalue o)) resetvals :
+  retimed n c1 (c2 >==> delays o resetvals) ->
+  retimed (S n) c1 c2.
+Proof.
+  intros. cbv [retimed] in *. logical_simplify; subst.
+  eexists (_++ [_]). autorewrite with push_length.
+  rewrite Nat.add_1_r. ssplit; [ reflexivity | ].
+  rewrite ndelays_snoc, Compose_assoc. eauto.
+Qed.
+
+Lemma retimed_transitivity {i o} n m (c1 c2 c3 : Circuit i (ivalue o)) :
+  retimed n c1 c2 ->
+  retimed m c2 c3 ->
+  retimed (n+m) c1 c3.
+Proof.
+  revert c1 c2 c3 n; induction m; intros *.
+  { rewrite retimed0_cequiv_iff.
+    autorewrite with natsimpl.
+    intros ? Heq. rewrite <-Heq; eauto. }
+  { intros ? [vals [? Heq]]. rewrite Nat.add_succ_r.
+    destruct vals using rev_ind; [ cbn [length] in *; lia | ].
+    eapply retimed_step_r. eapply IHm; eauto; [ ].
+    rewrite ndelays_snoc, !Compose_assoc in *.
+Abort.
+
+
+(*
+
+Can we prove that for every circuit, there exists n, c2 such that retimed n c1 (Comb c2)?
+
+If so, maybe we can prove move_ndelays for Comb only, and use that to prove retimed_step_l...
+ *)
+
+Print retimed.
+(* need to be equivalent to c2 >==> delays
+
+   (delays >==> c2) will be equivalent to starting c2 at the state that results
+   from the reset value of the delays
+
+   (c2 >==> delays) will be just starting c2 as usual and then adding some
+   different outputs to the beginning, which is why it's different
+
+   R : circuit_state c1 -> ivalue i -> circuit_state c2 -> Prop
+
+   R (reset_state c1) resetvalsi (reset_state c2)
+
+   preserved_over_step c1 (delays >==> c2) R
+
+   need to prove exists R' : circuit_state c1 -> ivalue o -> circuit_state c2 ->
+   Prop such that R' (reset_state c1) resetvalso (reset_state c2) and
+   preserved_over_step c1 (c2 >==> delays) R'
+
+
+   IDEA: Can this be proven the *other* way around? i.e. if retimed means the
+   delay is tacked on the front, then can we prove the delay can be tacked on
+   the end?
+
+   we can get the values from running the circuit; right now we have to prove
+   the inputs exist
+
+   potential problem still: the state of the circuit for input 0 for delays >==>
+   c2 would still be the state after getting all the reset values, while the
+   state for c2 >==> delays would be the reset state first
+ *)
+Lemma retimed_step_l {i o} n (c1 c2 : Circuit (ivalue i) (ivalue o)) resetvals :
+  retimed n c1 (delays i resetvals >==> c2) ->
+  retimed (S n) c1 c2.
+Proof.
+  intro Hretimed. pose proof Hretimed.
+  destruct Hretimed as [? [? [R ?]]].
+  logical_simplify; subst.
+  eapply retimed_step_r.
+  cbn [ndelays]. rewrite Compose_assoc.
+  ssplit.
+  2:{
+    cbn [circuit_state reset_state] in *.
+    exists (fun (st1 : circuit_state c1)
+         (st2 : circuit_state c2 * circuit_state (ndelays _ _)
+                * circuit_state (delays _ _)) =>
+         exists (vali : circuit_state (delays i resetvals)),
+           R st1 (vali, fst (fst st2), snd (fst st2))).
+    ssplit; [ eauto | ]. cbn [circuit_state].
+    intros; logical_simplify.
+    destruct_products; cbn [fst snd] in *.
+    ssplit.
+    { cbn.
+      repeat destruct_pair_let; cbn [fst snd].
+
+
+    
+  rewrite move_delays in H0.
+  ssplit; [ reflexivity | ].
+  rewrite ndelays_snoc, Compose_assoc. eauto.
+Qed.
+
+Lemma move_delays_retimed {i o} n (c1 c2 : Circuit (ivalue i) (ivalue o))
+      resetvalsi resetvalso :
+  retimed (S n) c1 (delays i resetvalsi >==> c2) ->
+  retimed (S n) c1 (c2 >==> delays o resetvalso).
+Proof.
+  intros [vals [? Hequiv]]. (* destruct Hequiv as [R [? ?]]]]. *)
+  destruct vals as [|v0 vals]; [ cbn [length] in *; lia | ].
+  cbn [ndelays circuit_state reset_state] in *.
+  
+Qed.
+
+
+Require Import Coq.derive.Derive.
+
+Derive pipelined_nand
+       SuchThat (retimed (o:=ione Bit) 2 pipelined_nand
+                         (Comb and2 >==> Comb inv))
+       As pipelined_nand_correct.
+Proof.
+  eapply retimed_step; [ reflexivity | ].
+  eapply retimed_step; [ reflexivity | ].
+  apply retimed0_cequiv_iff.
+  rewrite <-move_delays with (i:=ipair (ione Bit) (ione Bit))
+    by (cbn; repeat destruct_pair_let; reflexivity).
+  rewrite <-Compose_assoc.
+  rewrite <-move_delays with (i:=ione Bit)
+    by (cbn; repeat destruct_pair_let; reflexivity).
+  instantiate (1:=((false,false) : ivalue (signal:=combType) (ipair (ione Bit) (ione Bit)))).
+  cbn [fst snd andb delays]. autorewrite with circuitsimpl.
+  rewrite !Compose_assoc. subst pipelined_nand.
+  reflexivity.
+Qed.
+Print pipelined_nand.
+
+Lemma ndelays_get_reset t resetvals :
+  ndelays_get (reset_state (ndelays t resetvals)) = resetvals.
+Proof.
+  induction resetvals; [ reflexivity | ].
+  cbn [ndelays ndelays_get delays_get reset_state fst snd].
+  rewrite delays_get_reset, IHresetvals.
+  reflexivity.
+Qed.
+
+Lemma step_ndelays t resetvals st input :
+  snd (step (ndelays t resetvals) st input) = hd input (ndelays_get st).
+Proof.
+  induction resetvals; [ reflexivity | ].
+  cbn [ndelays ndelays_get step].
+  repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite IHresetvals, step_delays. reflexivity.
+Qed.
+
+Lemma hd_snoc {A} d (l : list A) : hd d (l ++ [d]) = hd d l.
+Proof. destruct l; reflexivity. Qed.
+
+Lemma ndelays_get_step t resetvals st input :
+  ndelays_get (fst (step (ndelays t resetvals) st input))
+  = tl (ndelays_get st ++ [input]).
+Proof.
+  induction resetvals; [ reflexivity | ].
+  cbn [ndelays ndelays_get step fst snd].
+  repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite delays_get_step, IHresetvals, step_ndelays.
+  rewrite <-app_comm_cons. cbn [hd tl].
+  etransitivity; [ | symmetry; apply eta_list; length_hammer ].
+  rewrite hd_snoc. reflexivity.
+Qed.
+
+Lemma move_ndelays i o (c : Circuit (ivalue i) (ivalue o)) resetvalsi resetvalso :
+  (*
+  (* step c applied to resetvals from resetstate needs to result in reset
+     state; otherwise first results don't match *)
+  step c (reset_state c) resetvalsi = (reset_state c, resetvalso) ->*)
+  cequiv (ndelays i resetvalsi >==> c)
+         (c >==> ndelays o resetvalso).
+Proof.
+  assert (length resetvalsi = length resetvalso) by admit.
+  revert c; revert dependent resetvalso;
+    induction resetvalsi; destruct resetvalso; intros;
+    cbn [length] in *; try lia; [ | ].
+  { cbn [ndelays]. autorewrite with circuitsimpl. reflexivity. }
+  { cbn [ndelays]. rewrite Compose_assoc.
+    erewrite <-(move_delays _ o).
+    2:{
+      cbn. repeat destruct_pair_let.
+      rewrite !step_ndelays.
+      rewrite ndel
+      f_equal. 1:f_equal.
+      
+      rewrite <-surjective_pairing.
+    rewrite <-(Compose_assoc _ _ _ _ (ndelays _ _)).
+    rewrite IHresetvalsi.
+    
+    Check move_delays.
+  intro Hreset.
+  exists (fun (st1 : circuit_state (delays i resetvalsi) * circuit_state c)
+       (st2 : circuit_state c * circuit_state (delays o resetvalso)) =>
+       step c (snd st1) (delays_get (fst st1)) = (fst st2, delays_get (snd st2))).
+  ssplit.
+  { cbn. rewrite !delays_get_reset.
+    destruct (step c (reset_state c) resetvalsi); cbn [fst snd] in *.
+    logical_simplify; subst. reflexivity. }
+  { cbn [circuit_state step]; intros *. intro Hstep.
+    destruct_products; cbn [fst snd] in *.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    logical_simplify. rewrite !delays_get_step, !step_delays.
+    rewrite Hstep. cbn [fst snd]. rewrite <-surjective_pairing.
+    ssplit; reflexivity. }
+Qed.
+
+Lemma simulate_retimed
+      {i o} (n : nat) (c1 c2 : Circuit i (ivalue (signal:=combType) o)) input :
+  retimed n c1 c2 ->
+  skipn n (simulate c1 input) = firstn (length input - n) (simulate c2 input).
+Proof.
+  intros [? [? Heq]]. rewrite Heq.
+  autorewrite with push_simulate push_length.
+  rewrite skipn_firstn_comm. subst.
+  autorewrite with push_skipn natsimpl.
+  reflexivity.
+Qed.
+
+Lemma retimed_compose A B C n m
+      (c1 c2 : Circuit A (ivalue B)) (c3 c4 : Circuit (ivalue B) (ivalue C)) :
+  retimed n c1 c2 -> retimed m c3 c4 -> retimed (n+m) (c1 >==> c3) (c2 >==> c4).
+Proof.
+  intros [? [? Heq12]] [? [? Heq34]]. rewrite Heq12, Heq34.
+Qed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 (*
 Lemma retimed_sum {i o} (n m: nat) (c1 c2 c3 : Circuit i o) :

--- a/cava/Cava/Lib/RetimingProperties.v
+++ b/cava/Cava/Lib/RetimingProperties.v
@@ -191,6 +191,22 @@ Proof.
   rewrite <-IHn. reflexivity.
 Qed.
 
+Lemma simulate_retimed {i o} (c1 c2 : Circuit i o) n :
+  retimed n c1 c2 ->
+  forall input1 input2 : list (value i),
+    (forall i, nth i input2 defaultValue = nth (i*(n+1)) input1 defaultValue) ->
+    forall i,
+      0 < i ->
+      nth i (simulate c2 input2) defaultValue
+      = nth (i*n) (simulate c1 input1) defaultValue.
+Proof.
+  intros [r Hr]. intros.
+  erewrite (simulate_cequiv c1) by eauto.
+  cbv [simulate].
+  (* separate input1 into (length input2) lists of multiple inputs, prove that
+     executing each list is equivalent to one execution of c2 *)
+Admitted.
+
 Fixpoint Forall_ndelays {t1 t2 n} (R : value t1 -> value t2 -> Prop)
   : value (circuit_state (ndelays t1 n))
     -> value (circuit_state (ndelays t2 n)) -> Prop :=
@@ -480,10 +496,8 @@ Proof.
   (* cancel out combinational components *)
   apply retimed_cancel_r.
   apply retimed_cancel_l.
-  (* use retimed middle round *)
-  pose proof (retimed_cipher_middle_round_correct state) as Hmiddle.
-  cbv [retimed_cipher_middle_round] in Hmiddle.
-  apply Hmiddle.
+  (*  use the retimed middle round lemma *)
+  apply (retimed_cipher_middle_round_correct state).
   (* done! *)
   eassumption.
 Qed.

--- a/cava/Cava/Lib/RetimingProperties.v
+++ b/cava/Cava/Lib/RetimingProperties.v
@@ -28,909 +28,319 @@ Require Import Cava.Semantics.WeakEquivalence.
 Require Import Cava.Lib.CircuitTransforms.
 Require Import Cava.Lib.CircuitTransformsProperties.
 Require Import Cava.Lib.Retiming.
+Require Import Cava.Lib.Multiplexers.
+Require Import Cava.Lib.MultiplexersProperties.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
-Import ListNotations Circuit.Notations.
+Import ListNotations Circuit.Notations MonadNotation.
 
-(* starting from scratch with retiming lemmas! Might not even need cequivn now. *)
+(* Start from scratch again. What do we really need? *)
 
-Fixpoint multi_loop {i o s}
-  : Circuit (i * ivalue s) (o * ivalue s) -> ivalue s -> Circuit i o :=
-  match s with
-  | ione t => fun c resetval => LoopInit resetval c
-  | ipair t1 t2 =>
-    fun (c : Circuit (i * (ivalue t1 * ivalue t2))
-                   (o * (ivalue t1 * ivalue t2)))
-      (resetvals : ivalue t1 * ivalue t2) =>
-      multi_loop
-        (multi_loop
-           (Comb (fun '(i,s1,s2) => ret (i,(s1,s2)))
-                 >==> c
-                 >==> Comb (fun '(o,(s1,s2)) => ret (o,s1,s2)))
-           (snd resetvals))
-        (fst resetvals)
-  end.
+(*
+All should be based on phase_retimed!
+- Move input delays over compose
+- Move state delays over feedback
+- Add delays to one end or the other, increment retiming number
+- retimed 0 0 <-> cequiv
+- Move delays over compose for loop-free circuits in general?
+- Move delays in/out of loops?
 
-Fixpoint loops_reset_state {i o} (c : Circuit i o)
-  : ivalue (signal:=combType) (loops_state c) :=
-  match c as c in Circuit i o return ivalue (loops_state c) with
-  | Comb _ => tt
-  | First f => loops_reset_state f
-  | Second f => loops_reset_state f
-  | Compose f g => (loops_reset_state f, loops_reset_state g)
-  | DelayInitCE r => tt
-  | LoopInitCE r body => (loops_reset_state body, r)
-  end.
+ *)
 
-(* counts # delays on the critical path *)
-Fixpoint cpath_delay {i o} (c : Circuit i o) : nat :=
+Lemma LoopInit_ignore_state {i o s} resetval (c : Circuit i o) :
+  cequiv (LoopInit (s:=s) resetval (First c)) c.
+Proof.
+  exists (fun s1 s2 => fst (snd s1) = s2). cbn [circuit_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  cbn [step LoopInit]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  split; reflexivity.
+Qed.
+
+Lemma LoopInit_merge {i1 o1 o2 s1 s2} r1 r2
+      (c1 : Circuit (i1 * s1) (o1 * s1))
+      (c2 : Circuit (o1 * s2) (o2 * s2)) :
+  cequiv (LoopInit r1 c1 >==> LoopInit r2 c2)
+         (LoopInit (s:=s1*s2)
+                   (r1, r2)
+                   ((Comb (i:=_*(_*_))
+                          (fun '(i,(s1,s2)) =>
+                             ret (i, s1, s2)))
+                      >==> First c1
+                      >==> (Comb (i:=_*_*_)
+                                 (fun '(o1,s1',s2) =>
+                                    ret (o1, s2, s1')))
+                      >==> First c2
+                      >==> (Comb (i:=_*_*_)
+                                 (fun '(o2,s2',s1') =>
+                                    ret (o2, (s1', s2')))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd (fst s1)), tt, fst (snd (snd s1)),
+                  tt, (snd (snd (fst s1)), snd (snd (snd s1)))))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma First_LoopInit {i o s t} r
+      (c : Circuit (i * s) (o * s)) :
+  cequiv (First (t:=t) (LoopInit r c))
+         (LoopInit r
+                   ((Comb (i:=_*_*_)
+                          (fun '(i,t,s) => ret (i,s,t)))
+                      >==> First c
+                      >==> (Comb (i:=_*_*_)
+                                 (fun '(o,s,t) => ret (o,t,s))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma Second_LoopInit {i o s t} r
+      (c : Circuit (i * s) (o * s)) :
+  cequiv (Second (t:=t) (LoopInit r c))
+         (LoopInit r
+                   ((Comb (i:=_*_*_)
+                          (fun '(t,i,s) => ret (t,(i,s))))
+                      >==> Second c
+                      >==> (Comb (i:=_*(_*_))
+                                 (fun '(t,(o,s)) => ret (t,o,s))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma LoopInit_LoopInit {i o s1 s2} r1 r2
+      (c : Circuit (i * s1 * s2) (o * s1 * s2)) :
+  cequiv (LoopInit r1 (LoopInit r2 c))
+         (LoopInit (s:=s1*s2)
+                   (r1, r2)
+                   ((Comb (i:=_*(_*_))
+                          (fun '(i,(s1,s2)) =>
+                             ret (i, s1, s2)))
+                      >==> c
+                      >==> (Comb (i:=_*_*_)
+                                 (fun '(o,s1,s2) =>
+                                    ret (o, (s1, s2)))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd (fst (snd s1))), tt,
+                  (snd (snd s1), snd (snd (fst (snd s1))))))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma LoopInitCE_LoopInit {i o s1 s2} r1 r2 (c : Circuit (i * s1 * s2) (o * s1 * s2)) :
+  cequiv (LoopInitCE r1 (LoopInit r2 c))
+         (LoopInit (s:=s2*s1)
+                   (r2, r1)
+                   ((Comb (i:=_*_*(_*_))
+                          (fun '(x, en, (s2, s1)) =>
+                             ret (en, s1, (x, s1, s2)))
+                          >==> Second c
+                          >==> (Comb (i:=Bit*s1*(o*s1*s2))
+                                     (o:=o*(s2*s1))
+                                     (fun '(en, s1, (y, s1', s2')) =>
+                                        s <- mux2 en (s1, s1') ;;
+                                        ret (y, (s2', s))))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd (fst s1)), tt,
+                  (snd (snd (fst s1)), snd s1)))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  simpl_ident. ssplit; reflexivity.
+Qed.
+
+Lemma extract_loops {i o} (c : Circuit i o) :
+  cequiv c (LoopInit (loops_reset_state c) (loopless c)).
+Proof.
+  induction c; cbn [loopless].
+  { rewrite LoopInit_ignore_state. reflexivity. }
+  { rewrite IHc1 at 1. rewrite IHc2 at 1.
+    apply LoopInit_merge. }
+  { rewrite IHc at 1. apply First_LoopInit. }
+  { rewrite IHc at 1. apply Second_LoopInit. }
+  { simpl_ident. rewrite IHc at 1.
+    apply LoopInitCE_LoopInit. }
+  { rewrite LoopInit_ignore_state. reflexivity. }
+Qed.
+
+Fixpoint is_loop_free {i o} (c : Circuit i o) : bool :=
   match c with
-  | Comb _ => 0
-  | First f => cpath_delay f
-  | Second f => cpath_delay f
-  | Compose f g => cpath_delay f + cpath_delay g
-  | DelayInitCE r => 1
-  | LoopInitCE r body => cpath_delay body
+  | Comb _ => true
+  | Compose f g => (is_loop_free f && is_loop_free g)%bool
+  | First f => is_loop_free f
+  | Second f => is_loop_free f
+  | DelayInitCE _ => true
+  | LoopInitCE _ _ => false
   end.
 
-Inductive is_loop_free : forall {i o}, Circuit i o -> Prop :=
-| is_loop_free_comb : forall {i o} (f : i -> cava o), is_loop_free (Comb f)
-| is_loop_free_first :
-    forall {i t o} f, is_loop_free f -> is_loop_free (@First _ _ i t o f)
-| is_loop_free_second :
-    forall {i t o} f, is_loop_free f -> is_loop_free (@Second _ _ i t o f)
-| is_loop_free_compose :
-    forall {i t o} f g, is_loop_free f -> is_loop_free g ->
-                   is_loop_free (@Compose _ _ i t o f g)
-| is_loop_free_delay : forall {t} r, is_loop_free (@DelayInitCE _ _ t r)
-.
-
-Definition extract_loops {i o} (c : Circuit i o) : Circuit i o :=
-  multi_loop (loopless c) (loops_reset_state c).
-
-Lemma is_loop_free_loopless {i o} (c : Circuit i o) : is_loop_free (loopless c).
-Proof. induction c; cbn [loopless]; repeat constructor; eauto. Qed.
-
-Lemma extract_loops_equiv {i o} (c : Circuit i o) : cequiv (extract_loops c) c.
-Proof.
+Lemma move_delays {i o} (iresets : value i) (oresets : value o) (c : Circuit i o) :
+  is_loop_free c = true ->
+  oresets = snd (step c (reset_state c) iresets) ->
+  cequiv (delays iresets >==> c) (c >==> delays oresets).
 Admitted.
 
-Lemma cequivn_reflexive_loop_free i o (c : Circuit i o) :
-  is_loop_free c -> cequivn (cpath_delay c) c c.
+Lemma delay_input {i o} n m (c1 c2 : Circuit i o) resets :
+  phase_retimed n m c1 (delays resets >==> c2) ->
+  phase_retimed n (S m) c1 c2.
+Admitted.
+
+Lemma ndelay_state {i o} n m (c1 c2 : Circuit i o) resets :
+  phase_retimed n m c1 (delays resets >==> c2) ->
+  phase_retimed n m c1 c2.
+Admitted.
+
+Lemma phase_retimed_cequiv_iff {i o} (c1 c2 : Circuit i o) :
+  phase_retimed 0 0 c1 c2 <-> cequiv c1 c2.
 Proof.
-  induction 1; cbn [cpath_delay].
-  { exists eq. cbn [circuit_state]. ssplit; intros.
-    all:destruct_lists_by_length; subst.
-    all:repeat lazymatch goal with x : unit |- _ => destruct x end.
-    all:ssplit; reflexivity. }
+  cbv [phase_retimed]. split; intros; logical_simplify.
+  { destruct_lists_by_length. cbn [ndelays] in *.
+    cbv [Par] in *. autorewrite with circuitsimpl in *.
+    rewrite <-(extract_loops c2) in *. assumption. }
+  { exists [], []. ssplit; [ reflexivity .. | ].
+    cbn [ndelays]. cbv [Par]. autorewrite with circuitsimpl.
+    rewrite <-extract_loops. assumption. }
+Qed.
+
+Axiom reassemble_state :
+  forall {i o} (c : Circuit i o), value (circuit_state (loopless c)) -> value (loops_state c) -> value (circuit_state c).
+
+Axiom loops_state_from_circuit_state :
+  forall {i o} (c : Circuit i o), value (circuit_state c) -> value (loops_state c).
+
+Global Instance Proper_phase_retimed {i o} :
+  Proper (eq ==> eq ==> cequiv ==> cequiv ==> iff) (@phase_retimed i o).
+Proof.
+  repeat intro. subst.
+  split; cbv [phase_retimed]; intros; logical_simplify.
   { lazymatch goal with
-    | H : cequivn _ _ _ |- _ => destruct H as [R [Hstart HR]]
+    | Heq : cequiv ?c1 ?c2, H : context [loopless ?c1] |- context [loopless ?c2] =>
+      destruct Heq as [R [Hstart Hpres]]
     end.
-    exists R; cbn [circuit_state]; ssplit; intros;
-      [ autorewrite with push_repeat_step; apply Hstart; length_hammer | ].
-    cbn [step]. repeat (destruct_pair_let; cbn [fst snd]).
-    destruct_products; cbn [fst snd].
-    specialize (HR _ _ ltac:(eassumption) ltac:(eassumption)).
-    logical_simplify. ssplit; congruence. }
-  { lazymatch goal with
-    | H : cequivn _ _ _ |- _ => destruct H as [R [Hstart HR]]
-    end.
-    exists R; cbn [circuit_state]; ssplit; intros;
-      [ autorewrite with push_repeat_step; apply Hstart; length_hammer | ].
-    cbn [step]. repeat (destruct_pair_let; cbn [fst snd]).
-    destruct_products; cbn [fst snd].
-    specialize (HR _ _ ltac:(eassumption) ltac:(eassumption)).
-    logical_simplify. ssplit; congruence. }
-  { lazymatch goal with
-    | H : cequivn _ _ f |- _ => destruct H as [R1 [Hstart1 HR1]]
-    end.
-    lazymatch goal with
-    | H : cequivn _ _ g |- _ => destruct H as [R2 [Hstart2 HR2]]
-    end.
-    exists (fun st1 st2 => R1 (fst st1) (fst st2) /\ R2 (snd st1) (snd st2)).
-    cbn [circuit_state]; ssplit; intros.
-    { ssplit.
-      { autorewrite with push_repeat_step. cbn [fst snd].
-        eapply state_relation_repeat_step_longer; eauto;
-        length_hammer. }
-      { erewrite <-(firstn_skipn (cpath_delay f) input).
-        rewrite !repeat_step_app.
-        autorewrite with push_repeat_step. cbn [fst snd].
-        erewrite state_relation_fold_left_accumulate_step
-          by (eauto; eapply Hstart1; length_hammer).
-        eapply Hstart2. length_hammer. } }
-    { cbn [step]. repeat (destruct_pair_let; cbn [fst snd]).
-      destruct_products; cbn [fst snd] in *.
-      specialize (HR1 _ _ ltac:(eassumption) ltac:(eassumption)).
-      lazymatch goal with
-      | |- context [step g _ ?i] =>
-        specialize (HR2 _ _ i ltac:(eassumption))
-      end.
-      logical_simplify. ssplit; congruence. } }
-  { exists eq. cbn [circuit_state].
-    ssplit; intros; [ | subst; ssplit; reflexivity ].
-    destruct_lists_by_length; subst.
-    autorewrite with push_repeat_step.
-    cbn [step]. repeat (destruct_pair_let; cbn [fst snd]).
-    (* damn it, doesn't work because delay might be disabled *)
-Abort.
-
-Lemma ndelays0_is_id {t} (c : Circuit t t) : is_ndelays 0 c -> c = Id.
-Proof. inversion 1; subst; reflexivity. Qed.
-
-Lemma phase_retimed_retimed_iff {i o} m (c1 c2 : Circuit i o) :
-  phase_retimed 0 m c1 c2 <-> retimed m c1 c2.
+    do 2 eexists; ssplit.
+    3:{
+      rewrite <-H1. rewrite H3.
+      exists (fun (s1 : unit * (value (circuit_state (ndelays _))
+                         * value (circuit_state (ndelays _))
+                         * value (circuit_state (loopless _))
+                         * value (loops_state _)))
+           (s2 : unit * (value (circuit_state (ndelays _))
+                         * value (circuit_state (ndelays _))
+                         * value (circuit_state (loopless _))
+                         * value (loops_state _))) =>
+           R (reassemble_state _ (snd (fst (snd s1))) (snd (snd s1)))
+             (reassemble_state _ (snd (fst (snd s2))) (snd (snd s2)))
+           /\ ndelays_get (fst (fst (fst (snd s1)))) = ndelays_get (fst (fst (fst (snd s2))))
+           /\ (Forall2
+                (fun v1 v2 =>
+                   exists u1 u2, R (reassemble_state _ u1 v1) (reassemble_state _ u2 v2))
+                (ndelays_get (snd (fst (fst (snd s1)))))
+                (ndelays_get (snd (fst (fst (snd s2))))))).
 Admitted.
-
-(*
-Lemma invert_delays'_par {t1 t2} (c : Circuit (ivalue (ipair t1 t2)) (ivalue (ipair t1 t2))) :
-  is_delays' _ c ->
-  exists d1 d2, is_delays' t1 d1 /\ is_delays' t2 d2 /\ c = Par d1 d2.
-Proof.
-  inversion 1. inversion_sigma; subst.
-  do 2 eexists; ssplit; eauto.
-  rewrite <-Eqdep_dec.eq_rect_eq_dec by apply itype_eq_dec.
-  reflexivity.
-Qed.
-
-Lemma invert_delays'_delay {t} (c : Circuit (ivalue (ione t)) (ivalue (ione t))) :
-  is_delays' _ c -> exists r, c = DelayInit r.
-Proof.
-  inversion 1. inversion_sigma; subst.
-  rewrite <-Eqdep_dec.eq_rect_eq_dec by apply itype_eq_dec.
-  eexists; reflexivity.
-Qed.
-
-Lemma split_delays {t1 t2} (c : Circuit (t1 * t2) (t1 * t2)) :
-  is_delays c ->
-  exists (d1 : Circuit t1 t1) (d2 : Circuit t2 t2),
-    is_delays d1 /\ is_delays d2 /\ c = Par d1 d2.
-Proof.
-  inversion 1. inversion_sigma; subst.
-  destruct t.
-  { eapply invert_delays'_delay in H2.
-    logical_simplify; subst.
-    Search unit.
-    inversion H. inversion_sigma.
-    cbn [ivalue] in *. subst.
-    rewrite H4 in *.
-    do 2 eexists.
-    rewrite f_equal_dep.
-  eapply split_delays' in H2.
-  rewrite H4 in *.
-  do 2 eexists.
-  rewrite <-Eqdep_dec.eq_rect_eq_dec by apply itype_eq_dec.
-Qed.
-
-
-Lemma split_ndelays {t1 t2} n (c : Circuit (t1 * t2) (t1 * t2)) :
-  is_ndelays n c ->
-  exists (d1 : Circuit t1 t1) (d2 : Circuit t2 t2),
-    is_ndelays n d1 /\ is_ndelays n d2 /\ cequiv c (Par d1 d2).
-Proof.
-  inversion 1.
-  induction 1.
-Qed.
-*)
-
-Lemma phase_retimed_LoopInit
-      {i o s} n m (c1 c2 : Circuit (i * combType s) (o * combType s)) r :
-  phase_retimed n m c1 c2 ->
-  phase_retimed (S n) m (LoopInit r (Second Delay >==> c1)) (LoopInit r c2).
-Proof.
-  intros [state_delays [input_delays [proj ?]]].
-  logical_simplify.
-  exists (Par Delay (Par state_delays Delay)).
-  exists (Comb (fun i => ret (i, defaultCombValue s))
-          >==> input_delays
-          >==> Comb (fun '(i,s) => ret i)).
-  cbn [loops_state LoopInit ivalue].
-Qed.
-
-(* phase_retimed n m c1 c2 -> is_ndelays m d ->
-   phase_retimed n m (Loop (Second d >==> c1)) (Loop c2) *)
-Print retimed.
-Print phase_retimed.
-(* retimed is NOT related to cequivn as stated, because cequivn says everything
-   will always stabilize after a certain number of inputs and that's just not
-   true within loops. equiv is actually weaker because it says they must be in
-   the same start state.
-
-   What about phase_retimed? That one *is* related, because we have the
-   guarantee that the circuit is loopless.
-
-   Actually, no it's not, because we could have *disabled* delays inside the
-   circuit and that would mean state could linger longer.
-
-
-   What we really need for loops is not quite cequivn; we need a guarantee that
-   after an equal input, N cycles later the circuits will produce an equal output.
-
- *)
-
-(* forall c, cequivn (ncycles c) c c *)
-(* forall c1 c2, cequiv c1 c2 -> ncycles c1 = ncycles c2 /\ cequivn (ncycles c1) c1 c2*)
-(* cequiv c1 c2 -> cequivn c1 c3 -> cequivn n c2 c3? *)
-
-
-(* is_delays c1 -> is_delays c2 -> cequivn 1 c1 c2 *)
-(* cequivn n c2 -> is_delays d1 -> is_delays d2 -> cequivn (S n) (c1 >==> d) (c2 >==> d) *)
-(* is_ndelays n c1 -> is_ndelays n c2 -> cequivn n c1 c2 *)
-
-(* retimed n c1 c2 -> is_delays d -> retimed (S n) (c1 >==> d) c2 *)
-(* retimed 0 c1 c2 <-> cequiv c1 c2 *)
-(* cequiv c1 c2 -> retimed n c1 c3 -> retimed n c2 c3 *)
-(* cequiv c1 c2 -> retimed n c3 c1 -> retimed n c3 c2 *)
-(* is_delays d -> exists d', is_delays d' /\ cequiv (d >==> c) (c >==> d') *)
-(* is_delays d1 -> is_delays d2  -> cequivn (c >==> d1) (c >==> d2) *)
-(* is_delays d -> is_delays d' -> cequivn 1 (d >==> c) (c >==> d') *)
-(* is_ndelays n d -> is_ndelays n d' -> cequivn n (d >==> c) (c >==> d') *)
-
-(* cequiv n c1 c2 -> retimed n c1 c3 -> retimed n c2 c3 *)
-
-(* is_delays d -> retimed n (c >==> d) *)
-(* is_delays d -> exists d', is_delays d' /\ cequiv (d >==> c) (c >==> d') *)
-
-(* retimed n c1 c2 <-> phase_retimed n 0 c1 c2 *)
-(* phase_retimed n m c1 c2 -> is_ndelays m d ->
-   phase_retimed n m (Loop (Second d >==> c1)) (Loop c2) *)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Lemma retimed_cequiv_iff {i o} n (c1 c2 : Circuit i (ivalue o)) :
-  retimed n c1 c2 <-> (exists d, cequivn n d (ndelays n o)
-                          /\ cequiv c1 (c2 >==> d)).
-Proof.
-  (* do we need this lemma? *)
-Admitted.
-
-(*
-Lemma retimed0_cequiv_iff {i o} (c1 c2 : Circuit i (ivalue o)) :
-  retimed 0 c1 c2 -> cequiv c1 c2.
-Proof.
-  cbv [retimed ndelays]. autorewrite with circuitsimpl.
-  intros.
-  apply cequivn_cequiv.
-  split.
-  { intros [resetvals ?]. logical_simplify.
-    destruct resetvals; [ | cbn [length] in *; lia ].
-    cbn [ndelays fold_left] in *.
-    autorewrite with circuitsimpl in *. auto. }
-  { intros. exists nil. ssplit; [ reflexivity | ].
-    cbn [ndelays fold_left].
-    autorewrite with circuitsimpl. auto. }
-Qed.
-
-(* rephrasing of the definition of retimed that can be helpful when proving a
-   retimed goal *)
-Lemma retimed_cequiv {i o} n (c1 c2 : Circuit i (ivalue o)) resetvals :
-  cequiv c1 (c2 >==> ndelays o resetvals) ->
-  length resetvals = n ->
-  retimed n c1 c2.
-Proof. cbv [retimed]; intros; eauto. Qed.
- *)
-
-Lemma simulate_delays t input :
-  simulate (delays t) input = firstn (length input) (idefault t :: input).
-Proof.
-  revert input; induction t; intros; cbn [delays ivalue idefault];
-    autorewrite with push_simulate; [ reflexivity | ].
-  rewrite !IHt1, IHt2. autorewrite with push_length.
-  rewrite <-combine_firstn. cbn [combine].
-  rewrite combine_map_r, combine_map_l, combine_same.
-  rewrite !map_map. cbn [fst snd].
-  rewrite List.map_id_ext by (intros; symmetry; apply surjective_pairing).
-  reflexivity.
-Qed.
-Hint Rewrite @simulate_delays using solve [eauto] : push_simulate.
-
-Lemma delays_get_reset t  :
-  delays_get (reset_state (delays t)) = idefault t.
-Proof.
-  induction t; [ reflexivity | ].
-  cbn [delays delays_get Par reset_state fst snd].
-  rewrite IHt1, IHt2. reflexivity.
-Qed.
-
-Lemma delays_get_step t st input :
-  delays_get (fst (step (delays t) st input)) = input.
-Proof.
-  induction t; [ reflexivity | ].
-  cbn [delays delays_get Par step fst snd].
-  repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite IHt1, IHt2, <-surjective_pairing.
-  reflexivity.
-Qed.
-
-Lemma step_delays t st input :
-  snd (step (delays t) st input) = delays_get st.
-Proof.
-  induction t; [ reflexivity | ].
-  cbn [delays delays_get Par step fst snd].
-  repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite IHt1, IHt2. reflexivity.
-Qed.
-
-Lemma is_delays_cequivn t (c1 c2 : Circuit t t) :
-  is_delays c1 -> is_delays c2 -> cequivn 1 c1 c2.
-Admitted.
-
-Lemma is_ndelays_cequivn t n (c1 c2 : Circuit t t) :
-  is_ndelays n c1 -> is_ndelays n c2 -> cequivn n c1 c2.
-Admitted.
-
-Lemma fold_left_accumulate_step_DelayInit t (resetval : combType t) input st :
-  fold_left_accumulate (step (DelayInit resetval)) input st
-  = firstn (length input) (snd st :: input).
-Proof.
-  revert st. cbv [DelayInit]. simpl_ident. cbn [circuit_state step].
-  induction input; intros; [ reflexivity | ].
-  autorewrite with push_length push_firstn push_fold_acc.
-  destruct_products; cbn [fst snd]. erewrite IHinput.
-  reflexivity.
-Qed.
-
-Lemma move_DelayInit i o n (c1 c2 : Circuit (combType i) (combType o))
-      resetvali resetvalo :
-  cequivn n c1 c2 ->
-  cequivn (S n) (c1 >==> DelayInit resetvalo) (DelayInit resetvali >==> c2).
-Proof.
-  intros [R [? HR]].
-  exists (fun (st1 : circuit_state c1 * (unit * combType o))
-       (st2 : unit * combType i * circuit_state c2) =>
-       R (fst st1) (fst (step c2 (snd st2) (snd (fst st2))))
-       /\ snd (step c2 (snd st2) (snd (fst st2))) = snd (snd st1)).
-  ssplit.
-  { cbn [circuit_state]; intro input; intros.
-    destruct input using rev_ind; [ cbn [length] in *; lia | ].
-    clear IHinput.
-    autorewrite with push_repeat_step push_fold_acc; cbn [fst snd].
-    rewrite fold_left_accumulate_step_DelayInit.
-    autorewrite with push_length. rewrite ?Nat.add_1_r.
-    autorewrite with push_firstn natsimpl listsimpl.
-    cbn [step DelayInit]. simpl_ident.
-    autorewrite with push_repeat_step.
-    ssplit.
-    { lazymatch goal with
-      | |- R (fst (step c1 ?s1 ?x)) (fst (step c2 ?s2 ?x)) =>
-        assert (R s1 s2)
-      end.
-      { Search repeat_step.
-        apply state_relation_repeat_step.
-      eapply HR.
-      rewrite fold_left_accumulate_step_DelayInit.
-      autorewrite with push_length. rewrite Nat.add_1_r.
-      autorewrite with push_firstn natsimpl listsimpl.
-      Search fold_left_accumulate.
-      Search repeat_step.
-      eapply H.
-    cbv [DelayInit]. cbn [step circuit_state]. simpl_ident.
-    ssplit.
-    { Search repeat_step.
-      eapply state_relation_repeat_step.
-    rewrite <-surjective_pairing.
-Qed.
-
-
-Lemma move_delays i o (c1 : Circuit i o) c2 c3 :
-  is_delays c2 -> is_delays c3 ->
-  cequivn 1 (c1 >==> c2) (c3 >==> c1).
-Proof.
-  revert c3; induction 1.
-  { destruct 1.
-    { 
-Qed.
-
-Lemma is_delays_cequivn_compose t n (c1 c2 c3 : Circuit t t) :
-  is_delays n c1 -> is_delays n c2 ->
-  cequivn d (c3 >==> c1) (c3 >==> c2) = cequivn (m - n).
-Admitted.
-
-Search cequivn.
-Lemma is_ndelays_cequivn_compose t n (c1 c2 c3 : Circuit t t) :
-  is_ndelays n c1 -> is_ndelays n c2 ->
-  cequivn n (c3 >==> c1) (c3 >==> c2) = cequivn (m - n).
-Admitted.
-
-Lemma retimed_cequivn i o n (c1 c2 c3 : Circuit i o) :
-  retimed n c1 c2 -> retimed n c1 c3 -> cequivn n c2 c3.
-Proof.
-  cbv [retimed]; intros. logical_simplify.
-  rewrite H2 in H1.
-  etransitivity.
-  { symmetry.
-  Search cequivn.
-Qed.
-
-Lemma move_delays i o n (c1 c2 : Circuit (ivalue i) (ivalue o)) :
-  cequivn n c1 c2 ->
-  cequivn (S n) (delays i >==> c1) (c2 >==> delays o).
-Proof.
-  intros.
-  etransitivity.
-  (* transitivity, replace delays with some delays that have the reset values for c1 (defaults) *)
-  (* OR transitivity, then use cequivn compose-delay lemmas *)
-  eapply cequivn_compose with (n0:=1) (m:=n).
-  
-  intros [R [? ?]].
-  exists (fun (st1 : circuit_state (delays i) * circuit_state c1)
-       (st2 : circuit_state c2 * circuit_state (delays o)) =>
-       exists st1',
-         step c1 (snd st1) (delays_get (fst st1)) = (st1', delays_get (snd st2))).
-  ssplit.
-  { cbn [circuit_state]. intro input; intros.
-    destruct input using rev_ind; [ cbn [length] in *; lia | ].
-    clear IHinput. autorewrite with push_repeat_step.
-    rewrite !fold_left_accumulate_snoc. cbn [fst snd].
-    autorewrite with push_repeat_step push_fold_acc.
-    destruct_products; cbn [fst snd] in *.
-    rewrite !step_delays, !delays_get_step.
-    rewrite H0.
-    eexists.
-    
-    repeat (destruct_pair_let; cbn [fst snd]).
-    rewrite !delays_get_step, !step_delays.
-  { cbn. rewrite !delays_get_reset.
-    destruct (step c (reset_state c) resetvalsi); cbn [fst snd] in *.
-    logical_simplify; subst. reflexivity. }
-  { cbn [circuit_state step]; intros *. intro Hstep.
-    destruct_products; cbn [fst snd] in *.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    logical_simplify. rewrite !delays_get_step, !step_delays.
-    rewrite Hstep. cbn [fst snd]. rewrite <-surjective_pairing.
-    ssplit; reflexivity. }
-Qed.
-
-Lemma move_delays i o (c : Circuit (ivalue i) (ivalue o)) resetvalsi resetvalso :
-  (* step c applied to resetvals from resetstate needs to result in reset
-     state; otherwise first results don't match *)
-  step c (reset_state c) resetvalsi = (reset_state c, resetvalso) ->
-  cequiv (delays i resetvalsi >==> c)
-         (c >==> delays o resetvalso).
-Proof.
-  intro Hreset.
-  exists (fun (st1 : circuit_state (delays i resetvalsi) * circuit_state c)
-       (st2 : circuit_state c * circuit_state (delays o resetvalso)) =>
-       step c (snd st1) (delays_get (fst st1)) = (fst st2, delays_get (snd st2))).
-  ssplit.
-  { cbn. rewrite !delays_get_reset.
-    destruct (step c (reset_state c) resetvalsi); cbn [fst snd] in *.
-    logical_simplify; subst. reflexivity. }
-  { cbn [circuit_state step]; intros *. intro Hstep.
-    destruct_products; cbn [fst snd] in *.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    logical_simplify. rewrite !delays_get_step, !step_delays.
-    rewrite Hstep. cbn [fst snd]. rewrite <-surjective_pairing.
-    ssplit; reflexivity. }
-Qed.
-
-Lemma ndelays_cons t resetvals r0 :
-  cequiv (ndelays t (r0 :: resetvals)) (ndelays t resetvals >==> delays t r0).
-Proof. reflexivity. Qed.
-
-Lemma ndelays_snoc t resetvals r0 :
-  cequiv (ndelays t (resetvals ++ [r0])) (delays t r0 >==> ndelays t resetvals).
-Proof.
-  revert r0. induction resetvals; intros.
-  { cbn [app ndelays]. autorewrite with circuitsimpl. reflexivity. }
-  { cbn [app ndelays]. rewrite IHresetvals, Compose_assoc.
-    reflexivity. }
-Qed.
-
-Lemma simulate_ndelays t resetvals input :
-  simulate (ndelays t resetvals) input
-  = firstn (length input) (resetvals ++ input).
-Proof.
-  revert input; induction resetvals; intros.
-  { autorewrite with push_simulate listsimpl push_firstn.
-    reflexivity. }
-  { rewrite ndelays_cons.
-    autorewrite with push_simulate push_length.
-    rewrite IHresetvals, <-app_comm_cons.
-    destruct input; [ reflexivity | ].
-    autorewrite with push_length push_firstn natsimpl.
-    apply Min.min_case_strong; intros; [ | reflexivity ].
-    autorewrite with natsimpl push_firstn listsimpl.
-    reflexivity. }
-Qed.
-Hint Rewrite @simulate_ndelays using solve [eauto] : push_simulate.
-
-Global Instance Proper_retimed i o :
-  Proper (eq ==> cequiv ==> cequiv ==> iff) (@retimed i o).
-Proof.
-  repeat intro. cbv [retimed].
-  split; intros; logical_simplify; subst;
-    eexists; (ssplit; [ reflexivity | ]).
-  all:repeat match goal with H : cequiv _ _ |- _ => rewrite H in * end.
-  all:reflexivity.
-Qed.
-
-Global Instance Reflexive_retimed0 i o : Reflexive (@retimed i o 0) | 10.
-Proof.
-  repeat intro; subst.
-  exists []; ssplit; [ reflexivity | ].
-  cbn [ndelays]. autorewrite with circuitsimpl.
-  reflexivity.
-Qed.
-
-Lemma retimed_step_r {i o} n (c1 c2 : Circuit i (ivalue o)) resetvals :
-  retimed n c1 (c2 >==> delays o resetvals) ->
-  retimed (S n) c1 c2.
-Proof.
-  intros. cbv [retimed] in *. logical_simplify; subst.
-  eexists (_++ [_]). autorewrite with push_length.
-  rewrite Nat.add_1_r. ssplit; [ reflexivity | ].
-  rewrite ndelays_snoc, Compose_assoc. eauto.
-Qed.
-
-Lemma retimed_transitivity {i o} n m (c1 c2 c3 : Circuit i (ivalue o)) :
-  retimed n c1 c2 ->
-  retimed m c2 c3 ->
-  retimed (n+m) c1 c3.
-Proof.
-  revert c1 c2 c3 n; induction m; intros *.
-  { rewrite retimed0_cequiv_iff.
-    autorewrite with natsimpl.
-    intros ? Heq. rewrite <-Heq; eauto. }
-  { intros ? [vals [? Heq]]. rewrite Nat.add_succ_r.
-    destruct vals using rev_ind; [ cbn [length] in *; lia | ].
-    eapply retimed_step_r. eapply IHm; eauto; [ ].
-    rewrite ndelays_snoc, !Compose_assoc in *.
-Abort.
-
-
-(*
-
-Can we prove that for every circuit, there exists n, c2 such that retimed n c1 (Comb c2)?
-
-If so, maybe we can prove move_ndelays for Comb only, and use that to prove retimed_step_l...
- *)
-
-Print retimed.
-(* need to be equivalent to c2 >==> delays
-
-   (delays >==> c2) will be equivalent to starting c2 at the state that results
-   from the reset value of the delays
-
-   (c2 >==> delays) will be just starting c2 as usual and then adding some
-   different outputs to the beginning, which is why it's different
-
-   R : circuit_state c1 -> ivalue i -> circuit_state c2 -> Prop
-
-   R (reset_state c1) resetvalsi (reset_state c2)
-
-   preserved_over_step c1 (delays >==> c2) R
-
-   need to prove exists R' : circuit_state c1 -> ivalue o -> circuit_state c2 ->
-   Prop such that R' (reset_state c1) resetvalso (reset_state c2) and
-   preserved_over_step c1 (c2 >==> delays) R'
-
-
-   IDEA: Can this be proven the *other* way around? i.e. if retimed means the
-   delay is tacked on the front, then can we prove the delay can be tacked on
-   the end?
-
-   we can get the values from running the circuit; right now we have to prove
-   the inputs exist
-
-   potential problem still: the state of the circuit for input 0 for delays >==>
-   c2 would still be the state after getting all the reset values, while the
-   state for c2 >==> delays would be the reset state first
- *)
-Lemma retimed_step_l {i o} n (c1 c2 : Circuit (ivalue i) (ivalue o)) resetvals :
-  retimed n c1 (delays i resetvals >==> c2) ->
-  retimed (S n) c1 c2.
-Proof.
-  intro Hretimed. pose proof Hretimed.
-  destruct Hretimed as [? [? [R ?]]].
-  logical_simplify; subst.
-  eapply retimed_step_r.
-  cbn [ndelays]. rewrite Compose_assoc.
-  ssplit.
-  2:{
-    cbn [circuit_state reset_state] in *.
-    exists (fun (st1 : circuit_state c1)
-         (st2 : circuit_state c2 * circuit_state (ndelays _ _)
-                * circuit_state (delays _ _)) =>
-         exists (vali : circuit_state (delays i resetvals)),
-           R st1 (vali, fst (fst st2), snd (fst st2))).
-    ssplit; [ eauto | ]. cbn [circuit_state].
-    intros; logical_simplify.
-    destruct_products; cbn [fst snd] in *.
-    ssplit.
-    { cbn.
-      repeat destruct_pair_let; cbn [fst snd].
-
-
-    
-  rewrite move_delays in H0.
-  ssplit; [ reflexivity | ].
-  rewrite ndelays_snoc, Compose_assoc. eauto.
-Qed.
-
-Lemma move_delays_retimed {i o} n (c1 c2 : Circuit (ivalue i) (ivalue o))
-      resetvalsi resetvalso :
-  retimed (S n) c1 (delays i resetvalsi >==> c2) ->
-  retimed (S n) c1 (c2 >==> delays o resetvalso).
-Proof.
-  intros [vals [? Hequiv]]. (* destruct Hequiv as [R [? ?]]]]. *)
-  destruct vals as [|v0 vals]; [ cbn [length] in *; lia | ].
-  cbn [ndelays circuit_state reset_state] in *.
-  
-Qed.
-
 
 Require Import Coq.derive.Derive.
 
+Local Ltac simpl_resets :=
+  cbn [step fst snd defaultValue default_value
+            CombinationalSemantics defaultSignal defaultCombValue].
+
 Derive pipelined_nand
-       SuchThat (retimed (o:=ione Bit) 2 pipelined_nand
-                         (Comb and2 >==> Comb inv))
+       SuchThat (phase_retimed
+                   0 2 pipelined_nand
+                   (Comb (i:=Bit*Bit) (o:=Bit) and2
+                         >==> Comb (o:=Bit) inv))
        As pipelined_nand_correct.
 Proof.
-  eapply retimed_step; [ reflexivity | ].
-  eapply retimed_step; [ reflexivity | ].
-  apply retimed0_cequiv_iff.
-  rewrite <-move_delays with (i:=ipair (ione Bit) (ione Bit))
-    by (cbn; repeat destruct_pair_let; reflexivity).
-  rewrite <-Compose_assoc.
-  rewrite <-move_delays with (i:=ione Bit)
-    by (cbn; repeat destruct_pair_let; reflexivity).
-  instantiate (1:=((false,false) : ivalue (signal:=combType) (ipair (ione Bit) (ione Bit)))).
-  cbn [fst snd andb delays]. autorewrite with circuitsimpl.
-  rewrite !Compose_assoc. subst pipelined_nand.
-  reflexivity.
+  (* insert a delay *)
+  eapply delay_input with (resets:=defaultValue).
+  (* move the delay to the end of the circuit *)
+  erewrite move_delays with (oresets:=true : value Bit) by reflexivity.
+  (* insert another delay *)
+  eapply delay_input with (resets:=defaultValue).
+  (* move the delay in between the and2 and inv *)
+  rewrite !Compose_assoc.
+  erewrite move_delays with (oresets:=false : value Bit) by reflexivity.
+  (* reflexivity *)
+  apply phase_retimed_cequiv_iff.
+  subst pipelined_nand; reflexivity.
 Qed.
 Print pipelined_nand.
+Check pipelined_nand_correct.
 
-Lemma ndelays_get_reset t resetvals :
-  ndelays_get (reset_state (ndelays t resetvals)) = resetvals.
+Definition cipher_middle_round
+           {state key : type}
+           (sbytes : Circuit state state)
+           (shrows : Circuit state state)
+           (mxcols : Circuit state state)
+           (add_rk : Circuit (state * key) state)
+  : Circuit (state * key) state :=
+  First (sbytes >==> shrows >==> mxcols) >==> add_rk.
+
+Derive retimed_cipher_middle_round
+       SuchThat
+       (forall {state key} n
+          (sbytes retimed_sbytes shrows mxcols : Circuit state state)
+          (add_rk : Circuit (state * key) state),
+           phase_retimed 0 n retimed_sbytes sbytes ->
+           phase_retimed
+             n 0
+             (retimed_cipher_middle_round
+                state key retimed_sbytes shrows mxcols add_rk)
+             (cipher_middle_round sbytes shrows mxcols add_rk))
+       As retimed_cipher_middle_round_correct.
 Proof.
-  induction resetvals; [ reflexivity | ].
-  cbn [ndelays ndelays_get delays_get reset_state fst snd].
-  rewrite delays_get_reset, IHresetvals.
-  reflexivity.
+  intros. cbv [cipher_middle_round].
+  autorewrite with circuitsimpl.
+  cbv [phase_retimed] in * |- . logical_simplify.
+  destruct_lists_by_length. cbn [ndelays] in *.
+  cbv [Par] in *; autorewrite with circuitsimpl in *.
+  
+
+
+  
+  (* insert a delay *)
+  eapply delay_input with (resets:=defaultValue).
+  (* move the delay to the end of the circuit *)
+  erewrite move_delays with (oresets:=true : value Bit) by reflexivity.
+  (* insert another delay *)
+  eapply delay_input with (resets:=defaultValue).
+  (* move the delay in between the and2 and inv *)
+  rewrite !Compose_assoc.
+  erewrite move_delays with (oresets:=false : value Bit) by reflexivity.
+  (* reflexivity *)
+  apply phase_retimed_cequiv_iff.
+  subst pipelined_nand; reflexivity.
 Qed.
-
-Lemma step_ndelays t resetvals st input :
-  snd (step (ndelays t resetvals) st input) = hd input (ndelays_get st).
-Proof.
-  induction resetvals; [ reflexivity | ].
-  cbn [ndelays ndelays_get step].
-  repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite IHresetvals, step_delays. reflexivity.
-Qed.
-
-Lemma hd_snoc {A} d (l : list A) : hd d (l ++ [d]) = hd d l.
-Proof. destruct l; reflexivity. Qed.
-
-Lemma ndelays_get_step t resetvals st input :
-  ndelays_get (fst (step (ndelays t resetvals) st input))
-  = tl (ndelays_get st ++ [input]).
-Proof.
-  induction resetvals; [ reflexivity | ].
-  cbn [ndelays ndelays_get step fst snd].
-  repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite delays_get_step, IHresetvals, step_ndelays.
-  rewrite <-app_comm_cons. cbn [hd tl].
-  etransitivity; [ | symmetry; apply eta_list; length_hammer ].
-  rewrite hd_snoc. reflexivity.
-Qed.
-
-Lemma move_ndelays i o (c : Circuit (ivalue i) (ivalue o)) resetvalsi resetvalso :
-  (*
-  (* step c applied to resetvals from resetstate needs to result in reset
-     state; otherwise first results don't match *)
-  step c (reset_state c) resetvalsi = (reset_state c, resetvalso) ->*)
-  cequiv (ndelays i resetvalsi >==> c)
-         (c >==> ndelays o resetvalso).
-Proof.
-  assert (length resetvalsi = length resetvalso) by admit.
-  revert c; revert dependent resetvalso;
-    induction resetvalsi; destruct resetvalso; intros;
-    cbn [length] in *; try lia; [ | ].
-  { cbn [ndelays]. autorewrite with circuitsimpl. reflexivity. }
-  { cbn [ndelays]. rewrite Compose_assoc.
-    erewrite <-(move_delays _ o).
-    2:{
-      cbn. repeat destruct_pair_let.
-      rewrite !step_ndelays.
-      rewrite ndel
-      f_equal. 1:f_equal.
-      
-      rewrite <-surjective_pairing.
-    rewrite <-(Compose_assoc _ _ _ _ (ndelays _ _)).
-    rewrite IHresetvalsi.
-    
-    Check move_delays.
-  intro Hreset.
-  exists (fun (st1 : circuit_state (delays i resetvalsi) * circuit_state c)
-       (st2 : circuit_state c * circuit_state (delays o resetvalso)) =>
-       step c (snd st1) (delays_get (fst st1)) = (fst st2, delays_get (snd st2))).
-  ssplit.
-  { cbn. rewrite !delays_get_reset.
-    destruct (step c (reset_state c) resetvalsi); cbn [fst snd] in *.
-    logical_simplify; subst. reflexivity. }
-  { cbn [circuit_state step]; intros *. intro Hstep.
-    destruct_products; cbn [fst snd] in *.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    logical_simplify. rewrite !delays_get_step, !step_delays.
-    rewrite Hstep. cbn [fst snd]. rewrite <-surjective_pairing.
-    ssplit; reflexivity. }
-Qed.
-
-Lemma simulate_retimed
-      {i o} (n : nat) (c1 c2 : Circuit i (ivalue (signal:=combType) o)) input :
-  retimed n c1 c2 ->
-  skipn n (simulate c1 input) = firstn (length input - n) (simulate c2 input).
-Proof.
-  intros [? [? Heq]]. rewrite Heq.
-  autorewrite with push_simulate push_length.
-  rewrite skipn_firstn_comm. subst.
-  autorewrite with push_skipn natsimpl.
-  reflexivity.
-Qed.
-
-Lemma retimed_compose A B C n m
-      (c1 c2 : Circuit A (ivalue B)) (c3 c4 : Circuit (ivalue B) (ivalue C)) :
-  retimed n c1 c2 -> retimed m c3 c4 -> retimed (n+m) (c1 >==> c3) (c2 >==> c4).
-Proof.
-  intros [? [? Heq12]] [? [? Heq34]]. rewrite Heq12, Heq34.
-Qed.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-(*
-Lemma retimed_sum {i o} (n m: nat) (c1 c2 c3 : Circuit i o) :
-  retimed (n+m) c1 c2 -> retimed n c1 c3 -> retimed m c2 c3.
-Proof.
-  intros [R12 [? H12]]. intros [R13 [? H13]].
-  exists (fun i (st2 : circuit_state c2) (st3 : circuit_state c3) =>
-       exists st1, R12 i st1 st2
-              /\ R13 (Nat.modulo (i*m) n) st1 st3).
-  ssplit.
-  { exists (reset_state c1). ssplit; eauto.
-Qed.
-*)
-
-(*
-Lemma retimed_delays1_l_iff {i o} (n : nat) (c1 c2 : Circuit (ivalue i) o) :
-  retimed 1 c1 c2
-  <-> (exists resetvals : ivalue i,
-        cequiv c1 (delays i resetvals >==> c2)).
-Admitted.
- *)
-
-(*
-the second part matches every m cycles
-the first part matches every n cycles
-
-assume m=2, n=3
-
-0:reset
-2:second part matches
-3:first part matches
-4:second part matches
-6:first part matches
-??????
-ahhhh, the second part matches only m cycles *after its input matches*
-
-
-
-if we are i steps away from matching...
-
-if i <= m,
- the second part is i steps away from matching
-else
- second part unclear but does have an R
-
-
- *)
-
-Lemma retimed_compose A B C n m (c1 c2 : Circuit A B) (c3 c4 : Circuit B C) :
-  retimed n c1 c2 -> retimed m c3 c4 -> retimed (n+m) (c1 >==> c3) (c2 >==> c4).
-Proof.
-  intros [R12 [? H12]] [R34 [? H34]].
-  exists (fun i st1 st2 =>
-       R12 (i - m) (fst st1) (fst st2)
-       /\ R34 i (snd st1) (snd st2)).
-  cbn [reset_state fst snd].
-  ssplit;
-    [ autorewrite with natsimpl;
-      solve [eauto] | | ].
-  { 
-  cbn [circuit_state]. intros.
-  destruct_products; cbn [fst snd] in *.
-  logical_simplify. destruct_one_match.
-  { autorewrite with natsimpl in *.
-    cbn [step]. repeat (destruct_pair_let; cbn [fst snd]).
-    specialize (H34 0 _ _ (ltac:(eassumption)) (ltac:(lia))
-                    (ltac:(eassumption))).
-    cbn iota in H34. destruct H34 as [H34 ?].
-    rewrite H34 in *.
-  { 
-Qed.
-
-Lemma retimed_succ {i o} n (c1 c2 : Circuit (ivalue i) o) :
-  retimed (S n) c1 c2 ->
-  exists resetvals, retimed n c1 (delays i resetvals >==> c2).
-Proof.
-Qed.
-
-Lemma retimed_ndelays_l_iff {i o} (n : nat) (c1 c2 : Circuit (ivalue i) o) :
-  retimed n c1 c2 <-> (exists resetvals : list (ivalue i),
-                        length resetvals = n
-                        /\ cequiv c1 (ndelays i resetvals >==> c2)).
-Proof.
-  split.
-  { revert i o c1 c2; induction n; intros *.
-    { rewrite retimed_cequiv_iff.
-      intros. exists nil. cbn [ndelays fold_left].
-      autorewrite with circuitsimpl.
-      ssplit; eauto. }
-    {
-      (* retimed (S n) c1 c2 -> exists c3, retimed n c1 c3 /\ cequiv c3 (delays >==> c2) *)
-      
-      intros [R [? HR]]. logical_simplify.
-    
-
-    (*
-      equivalence state relation should say that R 0 holds on the last?
-    *)
-
-    evar (r: list (ivalue (signal:=combType) i)).
-    exists r. ssplit.
-    2:{
-      exists (fun (st1 : circuit_state c1)
-           (st2 : circuit_state (ndelays i r) * circuit_state c2) =>
-           R 0 st1 (snd st2)).
-      
-Qed.
-
+Print pipelined_nand.
+Check pipelined_nand_correct.

--- a/cava/Cava/Lib/VecProperties.v
+++ b/cava/Cava/Lib/VecProperties.v
@@ -131,17 +131,17 @@ Hint Rewrite @shiftout_correct using solve [eauto] : simpl_ident.
 
 Lemma transpose_correct A n m (v : combType (Vec (Vec A n) m)) :
   Vec.transpose v = transpose (A:=combType A) v.
-Proof. crush. rewrite packV2_correct, unpackV2_correct. reflexivity. Qed.
+Proof. crush. Qed.
 Hint Rewrite @transpose_correct using solve [eauto] : simpl_ident.
 
 Lemma reshape_correct A n m (v : combType (Vec A (n * m))) :
   Vec.reshape v = reshape v.
-Proof. crush. rewrite packV2_correct; reflexivity. Qed.
+Proof. crush. Qed.
 Hint Rewrite @reshape_correct using solve [eauto] : simpl_ident.
 
 Lemma flatten_correct A n m (v : combType (Vec (Vec A m) n)) :
   Vec.flatten v = flatten v.
-Proof. crush. rewrite unpackV2_correct; reflexivity. Qed.
+Proof. crush. Qed.
 Hint Rewrite @flatten_correct using solve [eauto] : simpl_ident.
 
 Lemma resize_default_correct A n m (v : combType (Vec A n)) :
@@ -199,35 +199,35 @@ Hint Rewrite @inv_correct using solve [eauto] : simpl_ident.
 
 Lemma and_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.and i = Vector.map2 andb (fst i) (snd i).
-Proof. crush. apply map2_correct. Qed.
+Proof. crush. Qed.
 Hint Rewrite @and_correct using solve [eauto] : simpl_ident.
 
 Lemma nand_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.nand i = Vector.map2 nandb (fst i) (snd i).
-Proof. crush. apply map2_correct. Qed.
+Proof. crush. Qed.
 Hint Rewrite @nand_correct using solve [eauto] : simpl_ident.
 
 Lemma or_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.or i = Vector.map2 orb (fst i) (snd i).
-Proof. crush. apply map2_correct. Qed.
+Proof. crush. Qed.
 Hint Rewrite @or_correct using solve [eauto] : simpl_ident.
 
 Lemma nor_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.nor i = Vector.map2 norb (fst i) (snd i).
-Proof. crush. apply map2_correct. Qed.
+Proof. crush. Qed.
 Hint Rewrite @nor_correct using solve [eauto] : simpl_ident.
 
 Lemma xor_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.xor i = Vector.map2 xorb (fst i) (snd i).
-Proof. crush. apply map2_correct. Qed.
+Proof. crush. Qed.
 Hint Rewrite @xor_correct using solve [eauto] : simpl_ident.
 
 Lemma xnor_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.xnor i = Vector.map2 xnorb (fst i) (snd i).
-Proof. crush. apply map2_correct. Qed.
+Proof. crush. Qed.
 Hint Rewrite @xnor_correct using solve [eauto] : simpl_ident.
 
 Lemma xorcy_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.xorcy i = Vector.map2 xorb (fst i) (snd i).
-Proof. crush. apply map2_correct. Qed.
+Proof. crush. Qed.
 Hint Rewrite @xorcy_correct using solve [eauto] : simpl_ident.

--- a/cava/Cava/Lib/VecProperties.v
+++ b/cava/Cava/Lib/VecProperties.v
@@ -25,8 +25,9 @@ Require Cava.Lib.Vec.
 Import Vector.VectorNotations.
 Local Open Scope vector_scope.
 
-Existing Instance CombinationalSemantics.
+Existing Instances combType CombinationalSemantics.
 
+Set Printing All.
 Local Ltac crush :=
   (* inline Vec definition *)
   lazymatch goal with
@@ -47,9 +48,12 @@ Lemma of_N_correct n (x : N) : Vec.of_N x = N2Bv_sized n x.
 Proof. crush. Qed.
 Hint Rewrite @of_N_correct using solve [eauto] : simpl_ident.
 
-Hint Rewrite @bitvec_literal_correct using solve [eauto] : simpl_ident.
+About Vec.map_literal.
+Hint Transparent CombinationalSemantics.
 Lemma map_literal_correct {A B} n (f : A -> cava (combType B)) (v : Vector.t A n) :
+  Vector.map f v = Vec.map_literal f v.
   Vec.map_literal f v = Vector.map f v.
+  @eq (Vector.t (combType B) n) (Vec.map_literal f v) (Vector.map f v).
 Proof. crush. Qed.
 Hint Rewrite @map_literal_correct using solve [eauto] : simpl_ident.
 
@@ -70,18 +74,18 @@ Proof. crush. Qed.
 Hint Rewrite @unpackV4_correct using solve [eauto] : simpl_ident.
 
 Lemma packV2_correct {A n0 n1} (v : combType (Vec (Vec A n0) n1)) :
-  Vec.packV2 v = v.
+  Vec.packV2 (signal:=combType) v = v.
 Proof. crush. Qed.
 Hint Rewrite @packV2_correct using solve [eauto] : simpl_ident.
 
 Lemma packV3_correct {A n0 n1 n2} (v : combType (Vec (Vec (Vec A n0) n1) n2)) :
-  Vec.packV3 v = v.
+  Vec.packV3 (signal:=combType)  v = v.
 Proof. crush. Qed.
 Hint Rewrite @packV3_correct using solve [eauto] : simpl_ident.
 
 Lemma packV4_correct {A n0 n1 n2 n3}
       (v : combType (Vec (Vec (Vec (Vec A n0) n1) n2) n3)) :
-  Vec.packV4 v = v.
+  Vec.packV4 (signal:=combType)  v = v.
 Proof. crush. Qed.
 Hint Rewrite @packV4_correct using solve [eauto] : simpl_ident.
 
@@ -131,18 +135,18 @@ Proof. crush. Qed.
 Hint Rewrite @shiftout_correct using solve [eauto] : simpl_ident.
 
 Lemma transpose_correct A n m (v : combType (Vec (Vec A n) m)) :
-  Vec.transpose v = transpose v.
-Proof. crush. Qed.
+  Vec.transpose v = transpose (A:=combType A) v.
+Proof. crush. rewrite packV2_correct, unpackV2_correct. reflexivity. Qed.
 Hint Rewrite @transpose_correct using solve [eauto] : simpl_ident.
 
 Lemma reshape_correct A n m (v : combType (Vec A (n * m))) :
   Vec.reshape v = reshape v.
-Proof. crush. Qed.
+Proof. crush. rewrite packV2_correct; reflexivity. Qed.
 Hint Rewrite @reshape_correct using solve [eauto] : simpl_ident.
 
 Lemma flatten_correct A n m (v : combType (Vec (Vec A m) n)) :
   Vec.flatten v = flatten v.
-Proof. crush. Qed.
+Proof. crush. rewrite unpackV2_correct; reflexivity. Qed.
 Hint Rewrite @flatten_correct using solve [eauto] : simpl_ident.
 
 Lemma resize_default_correct A n m (v : combType (Vec A n)) :
@@ -200,35 +204,35 @@ Hint Rewrite @inv_correct using solve [eauto] : simpl_ident.
 
 Lemma and_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.and i = Vector.map2 andb (fst i) (snd i).
-Proof. crush. Qed.
+Proof. crush. apply map2_correct. Qed.
 Hint Rewrite @and_correct using solve [eauto] : simpl_ident.
 
 Lemma nand_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.nand i = Vector.map2 nandb (fst i) (snd i).
-Proof. crush. Qed.
+Proof. crush. apply map2_correct. Qed.
 Hint Rewrite @nand_correct using solve [eauto] : simpl_ident.
 
 Lemma or_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.or i = Vector.map2 orb (fst i) (snd i).
-Proof. crush. Qed.
+Proof. crush. apply map2_correct. Qed.
 Hint Rewrite @or_correct using solve [eauto] : simpl_ident.
 
 Lemma nor_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.nor i = Vector.map2 norb (fst i) (snd i).
-Proof. crush. Qed.
+Proof. crush. apply map2_correct. Qed.
 Hint Rewrite @nor_correct using solve [eauto] : simpl_ident.
 
 Lemma xor_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.xor i = Vector.map2 xorb (fst i) (snd i).
-Proof. crush. Qed.
+Proof. crush. apply map2_correct. Qed.
 Hint Rewrite @xor_correct using solve [eauto] : simpl_ident.
 
 Lemma xnor_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.xnor i = Vector.map2 xnorb (fst i) (snd i).
-Proof. crush. Qed.
+Proof. crush. apply map2_correct. Qed.
 Hint Rewrite @xnor_correct using solve [eauto] : simpl_ident.
 
 Lemma xorcy_correct n (i : Vector.t bool n * Vector.t bool n) :
   Vec.xorcy i = Vector.map2 xorb (fst i) (snd i).
-Proof. crush. Qed.
+Proof. crush. apply map2_correct. Qed.
 Hint Rewrite @xorcy_correct using solve [eauto] : simpl_ident.

--- a/cava/Cava/Lib/VecProperties.v
+++ b/cava/Cava/Lib/VecProperties.v
@@ -27,7 +27,6 @@ Local Open Scope vector_scope.
 
 Existing Instances combType CombinationalSemantics.
 
-Set Printing All.
 Local Ltac crush :=
   (* inline Vec definition *)
   lazymatch goal with
@@ -48,12 +47,8 @@ Lemma of_N_correct n (x : N) : Vec.of_N x = N2Bv_sized n x.
 Proof. crush. Qed.
 Hint Rewrite @of_N_correct using solve [eauto] : simpl_ident.
 
-About Vec.map_literal.
-Hint Transparent CombinationalSemantics.
 Lemma map_literal_correct {A B} n (f : A -> cava (combType B)) (v : Vector.t A n) :
-  Vector.map f v = Vec.map_literal f v.
   Vec.map_literal f v = Vector.map f v.
-  @eq (Vector.t (combType B) n) (Vec.map_literal f v) (Vector.map f v).
 Proof. crush. Qed.
 Hint Rewrite @map_literal_correct using solve [eauto] : simpl_ident.
 

--- a/cava/Cava/NetlistGeneration/NetlistGeneration.v
+++ b/cava/Cava/NetlistGeneration/NetlistGeneration.v
@@ -289,10 +289,10 @@ Fixpoint interpCircuit {i o} (c : Circuit i o)
       (* place a delay on each of the feedback wires *)
       addDelays resetval en feedback_out feedback_in ;;
       ret out
-  | @DelayInitCE _ _ t resetval =>
-    fun '(input, en) =>
+  | @DelayInit _ _ t resetval =>
+    fun input =>
       out <- newSignals t ;;
-      addDelays resetval en input out ;;
+      addDelays resetval Vcc input out ;;
       ret out
   end.
 

--- a/cava/Cava/NetlistGeneration/NetlistGeneration.v
+++ b/cava/Cava/NetlistGeneration/NetlistGeneration.v
@@ -258,7 +258,7 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
       localSignalNet (@GreaterThanOrEqual m n (fst ab) (snd ab));
     localSignal := @localSignalNet;
     instantiate intf circuit a :=
-      let cs := makeNetlist' intf circuit in
+      let cs := makeNetlist intf circuit in
       addModule intf (module cs) ;;
       blackBoxNet intf a;
     blackBox := blackBoxNet;
@@ -266,8 +266,8 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
 
 (* Run circuit for a single step *)
 Fixpoint interpCircuit {i o} (c : Circuit i o)
-    : i -> state CavaState o :=
-  match c in Circuit i o return i -> state CavaState o with
+    : value i -> state CavaState (value o) :=
+  match c in Circuit i o return value i -> state CavaState (value o) with
   | Comb f => f
   | Compose f g =>
     fun input =>
@@ -296,8 +296,8 @@ Fixpoint interpCircuit {i o} (c : Circuit i o)
       ret out
   end.
 
+
 Definition makeCircuitNetlist (intf : CircuitInterface)
-           (c : Circuit (tupled' (port_signal Signal <$> circuitInputs intf))
-                        (tupled' (port_signal Signal <$> circuitOutputs intf))) : CavaState :=
-                        makeNetlist intf (interpCircuit c).
+           (c : Circuit (circuitInputs intf) (circuitOutputs intf)) : CavaState :=
+  makeNetlist intf (interpCircuit c).
 

--- a/cava/Cava/NetlistGeneration/NetlistGeneration.v
+++ b/cava/Cava/NetlistGeneration/NetlistGeneration.v
@@ -284,15 +284,15 @@ Fixpoint interpCircuit {i o} (c : Circuit i o)
       ret (fst input, x)
   | @LoopInitCE _ _ i o s resetval f =>
     fun '(input, en) =>
-      feedback_in <- newSignal s ;;
+      feedback_in <- newSignals s ;;
       '(out, feedback_out) <- interpCircuit f (input, feedback_in) ;;
-      (* place a delay on the feedback wire *)
-      addInstance (DelayEnable s resetval en feedback_out feedback_in) ;;
+      (* place a delay on each of the feedback wires *)
+      addDelays resetval en feedback_out feedback_in ;;
       ret out
   | @DelayInitCE _ _ t resetval =>
     fun '(input, en) =>
-      out <- newSignal t ;;
-      addInstance (DelayEnable t resetval en input out) ;;
+      out <- newSignals t ;;
+      addDelays resetval en input out ;;
       ret out
   end.
 

--- a/cava/Cava/NetlistGeneration/NetlistGeneration.v
+++ b/cava/Cava/NetlistGeneration/NetlistGeneration.v
@@ -274,14 +274,11 @@ Fixpoint interpCircuit {i o} (c : Circuit i o)
       x <- interpCircuit f input ;;
       y <- interpCircuit g x ;;
       ret y
-  | First f =>
+  | Par f g =>
     fun input =>
       x <- interpCircuit f (fst input) ;;
-      ret (x, snd input)
-  | Second f =>
-    fun input =>
-      x <- interpCircuit f (snd input) ;;
-      ret (fst input, x)
+      y <- interpCircuit g (snd input) ;;
+      ret (x, y)
   | @LoopInitCE _ _ i o s resetval f =>
     fun '(input, en) =>
       feedback_in <- newSignals s ;;

--- a/cava/Cava/NetlistGeneration/NetlistGeneration.v
+++ b/cava/Cava/NetlistGeneration/NetlistGeneration.v
@@ -274,11 +274,14 @@ Fixpoint interpCircuit {i o} (c : Circuit i o)
       x <- interpCircuit f input ;;
       y <- interpCircuit g x ;;
       ret y
-  | Par f g =>
+  | First f =>
     fun input =>
       x <- interpCircuit f (fst input) ;;
-      y <- interpCircuit g (snd input) ;;
-      ret (x, y)
+      ret (x, snd input)
+  | Second f =>
+    fun input =>
+      x <- interpCircuit f (snd input) ;;
+      ret (fst input, x)
   | @LoopInitCE _ _ i o s resetval f =>
     fun '(input, en) =>
       feedback_in <- newSignals s ;;

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -85,11 +85,14 @@ Fixpoint step {i o} (c : Circuit i o)
       let cs1_x := step f (fst cs) input in
       let cs2_y := step g (snd cs) (snd cs1_x) in
       (fst cs1_x, fst cs2_y, snd cs2_y)
-  | Par f g =>
+  | First f =>
     fun cs input =>
-      let cs1_x := step f (fst cs) (fst input) in
-      let cs2_y := step g (snd cs) (snd input) in
-      (fst cs1_x, fst cs2_y, (snd cs1_x, snd cs2_y))
+      let cs_x := step f cs (fst input) in
+      (fst cs_x, (snd cs_x, snd input))
+  | Second f =>
+    fun cs input =>
+      let cs_x := step f cs (snd input) in
+      (fst cs_x, (fst input, snd cs_x))
   | LoopInitCE _ f =>
     fun cs_st input_en =>
       let cs_out_st := step f (fst cs_st) (fst input_en, snd cs_st) in

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -41,7 +41,7 @@ Definition xnorb b1 b2 : bool := negb (xorb b1 b2).
 (* interpretation.                                                            *)
 (******************************************************************************)
 
-Instance CombinationalSemantics : Cava combType | 10 :=
+Instance CombinationalSemantics : Cava combType :=
   { cava := ident;
     monad := Monad_ident;
     constant := fun x => x;

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -82,25 +82,26 @@ Fixpoint step {i o} (c : Circuit i o)
   | Comb f => fun _ i => (tt, f i)
   | Compose f g =>
     fun cs input =>
-      let '(cs1, x) := step f (fst cs) input in
-      let '(cs2, y) := step g (snd cs) x in
-      (cs1, cs2, y)
+      let cs1_x := step f (fst cs) input in
+      let cs2_y := step g (snd cs) (snd cs1_x) in
+      (fst cs1_x, fst cs2_y, snd cs2_y)
   | First f =>
     fun cs input =>
-      let '(cs', x) := step f cs (fst input) in
-      (cs', (x, snd input))
+      let cs_x := step f cs (fst input) in
+      (fst cs_x, (snd cs_x, snd input))
   | Second f =>
     fun cs input =>
-      let '(cs', x) := step f cs (snd input) in
-      (cs', (fst input, x))
+      let cs_x := step f cs (snd input) in
+      (fst cs_x, (fst input, snd cs_x))
   | LoopInitCE _ f =>
-    fun '(cs,st) '(input, en) =>
-      let '(cs', (out, st')) := step f cs (input, st) in
-      let new_state := if en then st' else st in
-      (cs', new_state, out)
+    fun cs_st input_en =>
+      let cs_out_st := step f (fst cs_st) (fst input_en, snd cs_st) in
+      let new_state := if snd input_en
+                       then snd (snd cs_out_st) else snd cs_st in
+      (fst cs_out_st, new_state, fst (snd cs_out_st))
   | DelayInitCE _ =>
-    fun st '(input, en) =>
-      let new_state := if en then input else st in
+    fun st input_en =>
+      let new_state := if snd input_en then fst input_en else st in
       (new_state, st)
   end.
 

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -85,14 +85,11 @@ Fixpoint step {i o} (c : Circuit i o)
       let cs1_x := step f (fst cs) input in
       let cs2_y := step g (snd cs) (snd cs1_x) in
       (fst cs1_x, fst cs2_y, snd cs2_y)
-  | First f =>
+  | Par f g =>
     fun cs input =>
-      let cs_x := step f cs (fst input) in
-      (fst cs_x, (snd cs_x, snd input))
-  | Second f =>
-    fun cs input =>
-      let cs_x := step f cs (snd input) in
-      (fst cs_x, (fst input, snd cs_x))
+      let cs1_x := step f (fst cs) (fst input) in
+      let cs2_y := step g (snd cs) (snd input) in
+      (fst cs1_x, fst cs2_y, (snd cs1_x, snd cs2_y))
   | LoopInitCE _ f =>
     fun cs_st input_en =>
       let cs_out_st := step f (fst cs_st) (fst input_en, snd cs_st) in

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -65,13 +65,13 @@ Instance CombinationalSemantics : Cava combType :=
     muxcy := fun sel x y => ret (if sel then x else y);
     unpackV _ _ v := ret v;
     packV _ _ v := ret v;
-    indexAt t sz isz := fun v sel => ret (nth_default (defaultCombSignal _) (N.to_nat (Bv2N sel)) v);
+    indexAt t sz isz := fun v sel => ret (nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v);
     unsignedAdd m n a := ret (unsignedAddBool a);
     unsignedMult m n a := ret (unsignedMultBool a);
     greaterThanOrEqual m n a := ret (greaterThanOrEqualBool a);
     localSignal _ v := ret v;
     instantiate intf circuit args := circuit args;
-    blackBox intf _ := defaultCombValue _
+    blackBox intf _ := default_value defaultCombValue _
   }.
 
 (* Run circuit for a single step *)

--- a/cava/Cava/Semantics/Combinational.v
+++ b/cava/Cava/Semantics/Combinational.v
@@ -99,10 +99,7 @@ Fixpoint step {i o} (c : Circuit i o)
       let new_state := if snd input_en
                        then snd (snd cs_out_st) else snd cs_st in
       (fst cs_out_st, new_state, fst (snd cs_out_st))
-  | DelayInitCE _ =>
-    fun st input_en =>
-      let new_state := if snd input_en then fst input_en else st in
-      (new_state, st)
+  | DelayInit _ => fun st input => (input, st)
   end.
 
 (* Automation to help simplify expressions using the identity monad *)

--- a/cava/Cava/Semantics/Equivalence.v
+++ b/cava/Cava/Semantics/Equivalence.v
@@ -134,7 +134,8 @@ Proof.
   pose proof (fun i => proj2 (Hcd _ _ i ltac:(eassumption))) as Hcd2.
   clear Hab Hcd. logical_simplify.
   repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite ?Hab1, ?Hcd1. ssplit; eauto.
+  rewrite ?Hab1, ?Hcd1.
+  ssplit; eauto; [ apply Hab2 | apply Hcd2 ].
 Qed.
 
 (* cequiv c1 c2 -> cequiv (First c1) (First c2) *)

--- a/cava/Cava/Semantics/Equivalence.v
+++ b/cava/Cava/Semantics/Equivalence.v
@@ -138,37 +138,30 @@ Proof.
   ssplit; eauto; [ apply Hab2 | apply Hcd2 ].
 Qed.
 
-(* cequiv c1 c3 -> cequiv c2 c4 -> cequiv (Par c1 c2) (Par c3 c4) *)
-Global Instance Proper_Par {i1 i2 o1 o2} :
-  Proper (cequiv ==> cequiv ==> cequiv) (@Par _ _ i1 i2 o1 o2).
-Proof.
-  intros a b [Rab [? Hab]].
-  intros c d [Rcd [? Hcd]].
-  exists (fun st1 st2 => Rab (fst st1) (fst st2) /\ Rcd (snd st1) (snd st2)).
-  ssplit; [ assumption .. | ].
-  cbn [circuit_state step]. intros; logical_simplify.
-  pose proof (fun i => proj1 (Hab _ _ i ltac:(eassumption))) as Hab1.
-  pose proof (fun i => proj2 (Hab _ _ i ltac:(eassumption))) as Hab2.
-  pose proof (fun i => proj1 (Hcd _ _ i ltac:(eassumption))) as Hcd1.
-  pose proof (fun i => proj2 (Hcd _ _ i ltac:(eassumption))) as Hcd2.
-  clear Hab Hcd. logical_simplify.
-  repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite ?Hab1, ?Hcd1.
-  ssplit; eauto; [ apply Hab2 | apply Hcd2 ].
-Qed.
-
 (* cequiv c1 c2 -> cequiv (First c1) (First c2) *)
 Global Instance Proper_First {i o t} :
   Proper (cequiv ==> cequiv) (@First _ _ i o t).
 Proof.
-  repeat intro. eapply Proper_Par; [ assumption | reflexivity ].
+  intros x y [Rxy [? Hxy]].
+  exists Rxy; ssplit; [ assumption | ].
+  cbn [circuit_state step]. intros; logical_simplify.
+  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
+  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
+  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite Hxy1. ssplit; eauto.
 Qed.
 
 (* cequiv c1 c2 -> cequiv (Second c1) (Second c2) *)
 Global Instance Proper_Second {i o t} :
   Proper (cequiv ==> cequiv) (@Second _ _ i o t).
 Proof.
-  repeat intro. eapply Proper_Par; [ reflexivity | assumption ].
+  intros x y [Rxy [? Hxy]].
+  exists Rxy; ssplit; [ assumption | ].
+  cbn [circuit_state step]. intros; logical_simplify.
+  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
+  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
+  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite Hxy1. ssplit; eauto.
 Qed.
 
 (* r1 = r2 -> cequiv c1 c2 -> cequiv (LoopInit r1 c1) (LoopInit r2 c2) *)

--- a/cava/Cava/Semantics/Equivalence.v
+++ b/cava/Cava/Semantics/Equivalence.v
@@ -14,6 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Classes.Morphisms.
 Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Core.Core.

--- a/cava/Cava/Semantics/Equivalence.v
+++ b/cava/Cava/Semantics/Equivalence.v
@@ -23,52 +23,108 @@ Require Import Cava.Semantics.Simulation.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 
+(* states that a relation is total *)
+Definition is_total {A B} (R : A -> B -> Prop) : Prop :=
+  (forall a, exists b, R a b) /\ (forall b, exists a, R a b).
+
 (* Circuit equivalence relation *)
 Definition cequiv {i o} (c1 c2 : Circuit i o) : Prop :=
   (* there exists some relation between the circuit states... *)
   exists (R : value (circuit_state c1) -> value (circuit_state c2) -> Prop),
-    (* ...and the relation holds on the reset states *)
-    R (reset_state c1) (reset_state c2)
-    (* ...and if the relation holds, stepping each circuit on the same input
-         results in the same output as well as new states on which the relation
-         continues to hold *)
+    (* ...and the relation is total *)
+    is_total R
+    (* ...and the reset states are related *)
+    /\ R (reset_state c1) (reset_state c2)
+    (* ...and if the states are related, stepping each circuit on the same input
+         results in the same output as well as new related states *)
     /\ (forall s1 s2 input,
           R s1 s2 ->
           snd (step c1 s1 input) = snd (step c2 s2 input)
           /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))).
 
+(* TODO: move? *)
+Lemma ex_split_pair {A B} (P : A * B -> Prop) :
+  (exists a b, P (a,b)) -> (exists ab, P ab).
+Proof. intros. logical_simplify. eexists; eauto. Qed.
+
+(* TODO: move? *)
+Ltac eexists_destruct :=
+  repeat lazymatch goal with
+         | |- exists _ : (_ * _)%type, _ => apply ex_split_pair
+         | |- exists _ : unit, _ => exists tt
+         | |- exists _, _ => eexists
+         end.
+
+(* solve is_total side conditions *)
+Ltac solve_is_total :=
+  cbv [is_total] in *; intros; logical_simplify;
+  ssplit; intros;
+  destruct_products; cbn [fst snd] in *;
+  logical_simplify;
+  repeat lazymatch goal with
+         | H : (forall x : ?T, exists _, _), x :?T |- _ =>
+           specialize (H x); logical_simplify
+         end;
+  (* the eexists/eauto might produce shelved existential variables if some
+     pieces of state appear in one circuit's state but not the other's; try to plug
+     in default values for the unused variables, and fail if we can't *)
+  unshelve (eexists_destruct; cbn[fst snd]; (solve [ eauto ]));
+  lazymatch goal with
+  | |- unit => exact tt
+  | |- value _ => exact defaultValue
+  | |- ?x => fail "could not infer default value for unused state value with type" x
+  end.
+
+(* find the hypothesis saying circuit state equivalence is preserved over
+   [step], and specialize it to the current arguments *)
+Local Ltac use_preserved :=
+  lazymatch goal with
+  | H : (forall _ _ _, ?R _ _ -> _ /\ _), HR : ?R ?s1 ?s2
+    |- context [step _ ?s1 ?i] =>
+    let H1 := fresh in
+    let H2 := fresh in
+    specialize (H s1 s2 i HR); destruct H as [H1 H2];
+    rewrite ?H1, ?H2
+end.
+
 (* cequiv is transitive *)
 Global Instance Transitive_cequiv {i o} : Transitive (@cequiv i o) | 10.
 Proof.
-  intros x y z [Rxy [? Hxy]] [Ryz [? Hyz]]. logical_simplify.
-  exists (fun (st1 : value (circuit_state x)) (st2 : value (circuit_state z)) =>
-       exists st3 : value (circuit_state y), Rxy st1 st3 /\ Ryz st3 st2).
-  ssplit; [ exists (reset_state y); tauto | ].
-  intros; logical_simplify.
-  specialize (Hxy _ _ ltac:(eassumption) ltac:(eassumption)).
-  specialize (Hyz _ _ ltac:(eassumption) ltac:(eassumption)).
-  logical_simplify. ssplit; [ congruence | ]. eauto.
+  intros x y z [Rxy [? [? Hxy]]] [Ryz [? [? Hyz]]].
+  logical_simplify. exists (fun x z => exists y, Rxy x y /\ Ryz y z).
+  ssplit; [ solve_is_total | solve [eauto] | ].
+  intros; logical_simplify; subst.
+  repeat use_preserved. ssplit; eauto.
 Qed.
 
 (* cequiv is reflexive *)
 Global Instance Reflexive_cequiv {i o} : Reflexive (@cequiv i o) | 10.
 Proof.
-  repeat intro. exists eq. ssplit; [ reflexivity | ].
+  repeat intro. exists eq. ssplit; [ solve_is_total | reflexivity | ].
   intros; subst. ssplit; reflexivity.
 Qed.
 
 (* cequiv is symmetric *)
 Global Instance Symmetric_cequiv {i o} : Symmetric (@cequiv i o) | 10.
 Proof.
-  intros x y [R [? HR]]. logical_simplify.
-  exists (fun st1 st2 => R st2 st1). ssplit; [ assumption | ].
-  intros. specialize (HR _ _ ltac:(eassumption) ltac:(eassumption)).
-  logical_simplify. eauto.
+  intros x y [Rxy [? [? Hxy]]]. logical_simplify. exists (fun y x => Rxy x y).
+  ssplit; [ solve_is_total | solve [eauto] | ].
+  intros; logical_simplify; subst.
+  repeat use_preserved. ssplit; eauto.
 Qed.
 
 (* cequiv is an equivalence relation *)
 Global Instance Equivalence_cequiv {i o} : Equivalence (@cequiv i o) | 10.
 Proof. constructor; typeclasses eauto. Qed.
+
+(* Try to solve [Proper] goals with cequiv *)
+Local Ltac proper_hammer :=
+  cbn [reset_state circuit_state fst snd value] in *; fold @value combType in *;
+  ssplit; intros; destruct_products; cbn [fst snd] in *;
+    [ solve_is_total | solve [eauto] .. | ];
+  cbn [circuit_state step fst snd]; intros; logical_simplify; subst;
+  cbn [value]; fold @value combType in *;
+  repeat use_preserved; ssplit; try congruence.
 
 (* equivalent circuits produce the same output on the same input *)
 Lemma simulate_cequiv {i o} (c1 c2 : Circuit i o) :
@@ -79,15 +135,8 @@ Proof.
     with (I:=fun st1 st2 acc1 acc2 =>
                R st1 st2 /\ acc1 = acc2).
   { ssplit; eauto. }
-  { intros; logical_simplify; subst.
-    lazymatch goal with
-    | H : forall _ _ _, R _ _ -> _ /\ _, HR : R _ _ |- context [step _ _ ?i] =>
-    let H1 := fresh in
-    let H2 := fresh in
-    specialize (H _ _ i HR); destruct H as [H1 H2];
-      rewrite ?H1, ?H2
-    end.
-    ssplit; eauto. }
+  { intros; logical_simplify; subst. use_preserved.
+    ssplit; congruence. }
   { intros; logical_simplify; subst. reflexivity. }
 Qed.
 
@@ -102,67 +151,28 @@ Global Instance Proper_LoopInitCE {i s o} :
 Proof.
   repeat intro; subst.
   lazymatch goal with H : cequiv _ _ |- _ => destruct H as [R ?] end.
-  logical_simplify.
-  exists (fun st1 st2 => R (fst st1) (fst st2) /\ snd st1 = snd st2).
-  cbn [reset_state circuit_state fst snd] in *.
-  ssplit; [ solve [auto] .. | ]. intros; logical_simplify.
-  cbn [value] in *. destruct_products; cbn [fst snd] in *; subst.
-  cbn [step]. simpl_ident.
-  repeat destruct_pair_let; cbn [fst snd]. cbn [value]. fold @value combType.
-  lazymatch goal with
-  | H : forall _ _ _, R _ _ -> _ /\ _, HR : R _ _ |- context [step _ _ ?i] =>
-  let H1 := fresh in
-  let H2 := fresh in
-  specialize (H _ _ i HR); destruct H as [H1 H2];
-    rewrite ?H1, ?H2
-  end.
-  ssplit; eauto.
+  exists (fun s1 s2 => R (fst s1) (fst s2) /\ snd s1 = snd s2).
+  proper_hammer.
 Qed.
 
 (* cequiv c1 c3 -> cequiv c2 c4 -> cequiv (c1 >==> c2) (c3 >==> c4) *)
 Global Instance Proper_Compose {i t o} :
   Proper (cequiv ==> cequiv ==> cequiv) (@Compose _ _ i t o).
 Proof.
-  intros a b [Rab [? Hab]].
-  intros c d [Rcd [? Hcd]].
-  exists (fun st1 st2 => Rab (fst st1) (fst st2) /\ Rcd (snd st1) (snd st2)).
-  ssplit; [ assumption .. | ].
-  cbn [circuit_state step]. intros; logical_simplify.
-  pose proof (fun i => proj1 (Hab _ _ i ltac:(eassumption))) as Hab1.
-  pose proof (fun i => proj2 (Hab _ _ i ltac:(eassumption))) as Hab2.
-  pose proof (fun i => proj1 (Hcd _ _ i ltac:(eassumption))) as Hcd1.
-  pose proof (fun i => proj2 (Hcd _ _ i ltac:(eassumption))) as Hcd2.
-  clear Hab Hcd. logical_simplify.
-  repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite ?Hab1, ?Hcd1.
-  ssplit; eauto; [ apply Hab2 | apply Hcd2 ].
+  intros a b [Rab ?] c d [Rcd ?].
+  exists (fun ac bd => Rab (fst ac) (fst bd) /\ Rcd (snd ac) (snd bd)).
+  proper_hammer.
 Qed.
 
 (* cequiv c1 c2 -> cequiv (First c1) (First c2) *)
 Global Instance Proper_First {i o t} :
   Proper (cequiv ==> cequiv) (@First _ _ i o t).
-Proof.
-  intros x y [Rxy [? Hxy]].
-  exists Rxy; ssplit; [ assumption | ].
-  cbn [circuit_state step]. intros; logical_simplify.
-  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
-  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
-  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite Hxy1. ssplit; eauto.
-Qed.
+Proof. intros x y [R ?]. exists R. proper_hammer. Qed.
 
 (* cequiv c1 c2 -> cequiv (Second c1) (Second c2) *)
 Global Instance Proper_Second {i o t} :
   Proper (cequiv ==> cequiv) (@Second _ _ i o t).
-Proof.
-  intros x y [Rxy [? Hxy]].
-  exists Rxy; ssplit; [ assumption | ].
-  cbn [circuit_state step]. intros; logical_simplify.
-  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
-  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
-  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite Hxy1. ssplit; eauto.
-Qed.
+Proof. intros x y [R ?]. exists R. proper_hammer. Qed.
 
 (* r1 = r2 -> cequiv c1 c2 -> cequiv (LoopInit r1 c1) (LoopInit r2 c2) *)
 Global Instance Proper_LoopInit {i s o} :

--- a/cava/Cava/Semantics/Equivalence.v
+++ b/cava/Cava/Semantics/Equivalence.v
@@ -138,30 +138,37 @@ Proof.
   ssplit; eauto; [ apply Hab2 | apply Hcd2 ].
 Qed.
 
+(* cequiv c1 c3 -> cequiv c2 c4 -> cequiv (Par c1 c2) (Par c3 c4) *)
+Global Instance Proper_Par {i1 i2 o1 o2} :
+  Proper (cequiv ==> cequiv ==> cequiv) (@Par _ _ i1 i2 o1 o2).
+Proof.
+  intros a b [Rab [? Hab]].
+  intros c d [Rcd [? Hcd]].
+  exists (fun st1 st2 => Rab (fst st1) (fst st2) /\ Rcd (snd st1) (snd st2)).
+  ssplit; [ assumption .. | ].
+  cbn [circuit_state step]. intros; logical_simplify.
+  pose proof (fun i => proj1 (Hab _ _ i ltac:(eassumption))) as Hab1.
+  pose proof (fun i => proj2 (Hab _ _ i ltac:(eassumption))) as Hab2.
+  pose proof (fun i => proj1 (Hcd _ _ i ltac:(eassumption))) as Hcd1.
+  pose proof (fun i => proj2 (Hcd _ _ i ltac:(eassumption))) as Hcd2.
+  clear Hab Hcd. logical_simplify.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite ?Hab1, ?Hcd1.
+  ssplit; eauto; [ apply Hab2 | apply Hcd2 ].
+Qed.
+
 (* cequiv c1 c2 -> cequiv (First c1) (First c2) *)
 Global Instance Proper_First {i o t} :
   Proper (cequiv ==> cequiv) (@First _ _ i o t).
 Proof.
-  intros x y [Rxy [? Hxy]].
-  exists Rxy; ssplit; [ assumption | ].
-  cbn [circuit_state step]. intros; logical_simplify.
-  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
-  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
-  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite Hxy1. ssplit; eauto.
+  repeat intro. eapply Proper_Par; [ assumption | reflexivity ].
 Qed.
 
 (* cequiv c1 c2 -> cequiv (Second c1) (Second c2) *)
 Global Instance Proper_Second {i o t} :
   Proper (cequiv ==> cequiv) (@Second _ _ i o t).
 Proof.
-  intros x y [Rxy [? Hxy]].
-  exists Rxy; ssplit; [ assumption | ].
-  cbn [circuit_state step]. intros; logical_simplify.
-  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
-  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
-  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
-  rewrite Hxy1. ssplit; eauto.
+  repeat intro. eapply Proper_Par; [ reflexivity | assumption ].
 Qed.
 
 (* r1 = r2 -> cequiv c1 c2 -> cequiv (LoopInit r1 c1) (LoopInit r2 c2) *)

--- a/cava/Cava/Semantics/Equivalence.v
+++ b/cava/Cava/Semantics/Equivalence.v
@@ -25,7 +25,7 @@ Require Import Cava.Util.Tactics.
 (* Circuit equivalence relation *)
 Definition cequiv {i o} (c1 c2 : Circuit i o) : Prop :=
   (* there exists some relation between the circuit states... *)
-  exists (R : circuit_state c1 -> circuit_state c2 -> Prop),
+  exists (R : value (circuit_state c1) -> value (circuit_state c2) -> Prop),
     (* ...and the relation holds on the reset states *)
     R (reset_state c1) (reset_state c2)
     (* ...and if the relation holds, stepping each circuit on the same input
@@ -40,8 +40,8 @@ Definition cequiv {i o} (c1 c2 : Circuit i o) : Prop :=
 Global Instance Transitive_cequiv {i o} : Transitive (@cequiv i o) | 10.
 Proof.
   intros x y z [Rxy [? Hxy]] [Ryz [? Hyz]]. logical_simplify.
-  exists (fun (st1 : circuit_state x) (st2 : circuit_state z) =>
-       exists st3 : circuit_state y, Rxy st1 st3 /\ Ryz st3 st2).
+  exists (fun (st1 : value (circuit_state x)) (st2 : value (circuit_state z)) =>
+       exists st3 : value (circuit_state y), Rxy st1 st3 /\ Ryz st3 st2).
   ssplit; [ exists (reset_state y); tauto | ].
   intros; logical_simplify.
   specialize (Hxy _ _ ltac:(eassumption) ltac:(eassumption)).
@@ -105,9 +105,9 @@ Proof.
   exists (fun st1 st2 => R (fst st1) (fst st2) /\ snd st1 = snd st2).
   cbn [reset_state circuit_state fst snd] in *.
   ssplit; [ solve [auto] .. | ]. intros; logical_simplify.
-  destruct_products; cbn [fst snd] in *; subst.
+  cbn [value] in *. destruct_products; cbn [fst snd] in *; subst.
   cbn [step]. simpl_ident.
-  repeat destruct_pair_let; cbn [fst snd].
+  repeat destruct_pair_let; cbn [fst snd]. cbn [value]. fold @value combType.
   lazymatch goal with
   | H : forall _ _ _, R _ _ -> _ /\ _, HR : R _ _ |- context [step _ _ ?i] =>
   let H1 := fresh in

--- a/cava/Cava/Semantics/Loopless.v
+++ b/cava/Cava/Semantics/Loopless.v
@@ -1,0 +1,80 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import ExtLib.Structures.Monad.
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
+Import Circuit.Notations MonadNotation.
+
+Fixpoint loops_state {i o} (c : Circuit i o) : type :=
+  match c with
+  | Comb _ => tzero
+  | First f => loops_state f
+  | Second f => loops_state f
+  | Compose f g => loops_state f * loops_state g
+  | @DelayInit _ _ t _ => tzero
+  | @LoopInitCE _ _ _ _ t _ body => loops_state body * t
+  end.
+
+Fixpoint loops_reset_state {i o} (c : Circuit i o)
+  : value (signal:=combType) (loops_state c) :=
+  match c with
+  | Comb _ => tt
+  | First f => loops_reset_state f
+  | Second f => loops_reset_state f
+  | Compose f g => (loops_reset_state f, loops_reset_state g)
+  | DelayInit _=> tt
+  | LoopInitCE resetval body => (loops_reset_state body, resetval)
+  end.
+
+(* Pull the loops out of the circuit completely *)
+Fixpoint loopless {i o} (c : Circuit i o)
+  : Circuit (i * loops_state c) (o * loops_state c) :=
+  match c as c in Circuit i o
+        return Circuit (i * loops_state c) (o * loops_state c) with
+  | Comb f => First (Comb f)
+  | Compose f g =>
+    Comb (i:=_*(_*_)) (o:=_*_*_)
+         (fun '(x,(st1,st2)) => (x,st1,st2)) (* rearrange *)
+         >==> First (loopless f) (* recursive call *)
+         >==> (Comb (i:=(_*_*_)) (o:=_*_*_)
+                    (fun '(y,st1,st2) => (y,st2,st1))) (* rearrange *)
+         >==> First (loopless g) (* recursive call *)
+         >==> (Comb (i:=(_*_*_)) (o:=_*(_*_))
+                    (fun '(z,st2,st1) => (z,(st1,st2)))) (* rearrange *)
+  | First f =>
+    Comb (i:=(_*_*_)) (o:=_*_*_)
+         (fun '(x1,x2,st) => (x1,st,x2)) (* rearrange *)
+         >==> First (loopless f) (* recursive call *)
+         >==> (Comb (i:=(_*_*_)) (o:=_*_*_)
+                    (fun '(y1,st,y2) => (y1,y2,st))) (* rearrange *)
+  | Second f =>
+    Comb (i:=(_*_*_)) (o:=_*(_*_))
+         (fun '(x1,x2,st) => (x1,(x2,st))) (* rearrange *)
+         >==> Second (loopless f) (* recursive call *)
+         >==> (Comb (i:=(_*(_*_))) (o:=_*_*_)
+                    (fun '(y1,(y2,st)) => (y1,y2,st))) (* rearrange *)
+  | DelayInit resetval => First (DelayInit resetval)
+  | @LoopInitCE _ _ _ _ s resetval body =>
+    (Comb (i:=(_*_*(_*_))) (o:=_*_*(_*_*_))
+          (fun '(x,en,(body_st, loop_st)) =>
+             (en,loop_st,(x,loop_st,body_st)))) (* rearrange *)
+         >==> Second (loopless body) (* recursive call *)
+         >==> (Comb (i:=(Bit * _ * (_ * _ * _))) (o:=(_*(_* _)))
+                    (fun '(en, loop_st, (y, loop_st', body_st')) =>
+                       let loop_st' := if (en : bool) then loop_st' else loop_st in
+                       (y,(body_st',loop_st'))))
+  end.

--- a/cava/Cava/Semantics/Loopless.v
+++ b/cava/Cava/Semantics/Loopless.v
@@ -22,8 +22,7 @@ Import Circuit.Notations MonadNotation.
 Fixpoint loops_state {i o} (c : Circuit i o) : type :=
   match c with
   | Comb _ => tzero
-  | First f => loops_state f
-  | Second f => loops_state f
+  | Par f g => loops_state f * loops_state g
   | Compose f g => loops_state f * loops_state g
   | @DelayInit _ _ t _ => tzero
   | @LoopInitCE _ _ _ _ t _ body => loops_state body * t
@@ -33,8 +32,7 @@ Fixpoint loops_reset_state {i o} (c : Circuit i o)
   : value (signal:=combType) (loops_state c) :=
   match c with
   | Comb _ => tt
-  | First f => loops_reset_state f
-  | Second f => loops_reset_state f
+  | Par f g => (loops_reset_state f, loops_reset_state g)
   | Compose f g => (loops_reset_state f, loops_reset_state g)
   | DelayInit _=> tt
   | LoopInitCE resetval body => (loops_reset_state body, resetval)
@@ -55,18 +53,12 @@ Fixpoint loopless {i o} (c : Circuit i o)
          >==> First (loopless g) (* recursive call *)
          >==> (Comb (i:=(_*_*_)) (o:=_*(_*_))
                     (fun '(z,st2,st1) => (z,(st1,st2)))) (* rearrange *)
-  | First f =>
-    Comb (i:=(_*_*_)) (o:=_*_*_)
-         (fun '(x1,x2,st) => (x1,st,x2)) (* rearrange *)
-         >==> First (loopless f) (* recursive call *)
-         >==> (Comb (i:=(_*_*_)) (o:=_*_*_)
-                    (fun '(y1,st,y2) => (y1,y2,st))) (* rearrange *)
-  | Second f =>
-    Comb (i:=(_*_*_)) (o:=_*(_*_))
-         (fun '(x1,x2,st) => (x1,(x2,st))) (* rearrange *)
-         >==> Second (loopless f) (* recursive call *)
-         >==> (Comb (i:=(_*(_*_))) (o:=_*_*_)
-                    (fun '(y1,(y2,st)) => (y1,y2,st))) (* rearrange *)
+  | Par f g =>
+    Comb (i:=(_*_*(_*_))) (o:=_*_*(_*_))
+         (fun '(x1,x2,(st1,st2)) => (x1,st1,(x2,st2))) (* rearrange *)
+         >==> Par (loopless f) (loopless g) (* recursive call *)
+         >==> (Comb (i:=(_*_*(_*_))) (o:=_*_*(_*_))
+                    (fun '(y1,st1,(y2,st2)) => (y1,y2,(st1,st2)))) (* rearrange *)
   | DelayInit resetval => First (DelayInit resetval)
   | @LoopInitCE _ _ _ _ s resetval body =>
     (Comb (i:=(_*_*(_*_))) (o:=_*_*(_*_*_))

--- a/cava/Cava/Semantics/LooplessProperties.v
+++ b/cava/Cava/Semantics/LooplessProperties.v
@@ -47,7 +47,7 @@ Proof.
   exists (fun (s1 : unit * (value (circuit_state c) * value s)) s2 =>
        fst (snd s1) = s2).
   cbn [circuit_state LoopInit value].
-  ssplit; [ solve_is_total | reflexivity | ].
+  ssplit; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   cbn [step LoopInit]. simpl_ident.
   repeat (destruct_pair_let; cbn [fst snd]).
@@ -74,7 +74,7 @@ Proof.
        s2 = (tt, (tt, fst (snd (fst s1)), tt, fst (snd (snd s1)),
                   tt, (snd (snd (fst s1)), snd (snd (snd s1)))))).
   cbn [circuit_state reset_state LoopInit value].
-  ssplit; [ solve_is_total | reflexivity | ].
+  ssplit; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -95,7 +95,7 @@ Proof.
   exists (fun s1 s2 =>
        s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
   cbn [circuit_state reset_state LoopInit value].
-  ssplit; [ solve_is_total | reflexivity | ].
+  ssplit; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -116,7 +116,7 @@ Proof.
   exists (fun s1 s2 =>
        s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
   cbn [circuit_state reset_state LoopInit value].
-  ssplit; [ solve_is_total | reflexivity | ].
+  ssplit; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -139,7 +139,7 @@ Proof.
        s2 = (tt, (tt, fst (snd (fst (snd s1))), tt,
                   (snd (snd s1), snd (snd (fst (snd s1))))))).
   cbn [circuit_state reset_state LoopInit value].
-  ssplit; [ solve_is_total | reflexivity | ].
+  ssplit; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -164,7 +164,7 @@ Proof.
        s2 = (tt, (tt, fst (snd (fst s1)), tt,
                   (snd (snd (fst s1)), snd s1)))).
   cbn [circuit_state reset_state LoopInit value].
-  ssplit; [ solve_is_total | reflexivity | ].
+  ssplit; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.

--- a/cava/Cava/Semantics/LooplessProperties.v
+++ b/cava/Cava/Semantics/LooplessProperties.v
@@ -27,8 +27,7 @@ Fixpoint is_loop_free {i o} (c : Circuit i o) : bool :=
   match c with
   | Comb _ => true
   | Compose f g => (is_loop_free f && is_loop_free g)%bool
-  | First f => is_loop_free f
-  | Second f => is_loop_free f
+  | Par f g => (is_loop_free f && is_loop_free g)%bool
   | DelayInit _ => true
   | LoopInitCE _ _ => false
   end.
@@ -36,19 +35,19 @@ Fixpoint is_loop_free {i o} (c : Circuit i o) : bool :=
 Lemma is_loop_free_loopless {i o} (c : Circuit i o) :
   is_loop_free (loopless c) = true.
 Proof.
-  induction c; cbn [loopless is_loop_free];
-    boolsimpl; auto; [ ].
-  rewrite IHc1, IHc2; reflexivity.
+  induction c; cbn [loopless is_loop_free First Second];
+    boolsimpl; auto;
+      repeat match goal with H : _ = true |- _ => rewrite H end;
+      reflexivity.
 Qed.
 
 Lemma LoopInit_ignore_state {i o s} resetval (c : Circuit i o) :
   cequiv (LoopInit (s:=s) resetval (First c)) c.
 Proof.
-  exists (fun s1 s2 => fst (snd s1) = s2). cbn [circuit_state LoopInit value].
+  exists (fun s1 s2 => fst (fst (snd s1)) = s2). cbn [circuit_state LoopInit value].
   split; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
-  cbn [step LoopInit]. simpl_ident.
-  repeat (destruct_pair_let; cbn [fst snd]).
+  cbn [step LoopInit First fst snd]. simpl_ident.
   split; reflexivity.
 Qed.
 
@@ -68,9 +67,10 @@ Lemma LoopInit_merge {i1 o1 o2 s1 s2} r1 r2
                                  (fun '(o2,s2',s1') => (o2, (s1', s2')))))).
 Proof.
   exists (fun s1 s2 =>
-       s2 = (tt, (tt, fst (snd (fst s1)), tt, fst (snd (snd s1)),
-                  tt, (snd (snd (fst s1)), snd (snd (snd s1)))))).
-  cbn [circuit_state reset_state LoopInit value].
+       s2 = (tt, (tt, (fst (snd (fst s1)), tt), tt,
+             (fst (snd (snd s1)), tt), tt,
+             (snd (snd (fst s1)), snd (snd (snd s1)))))).
+  cbn [circuit_state reset_state LoopInit value fst snd First Id].
   split; [ reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.

--- a/cava/Cava/Semantics/LooplessProperties.v
+++ b/cava/Cava/Semantics/LooplessProperties.v
@@ -1,0 +1,184 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import coqutil.Tactics.Tactics.
+Require Import ExtLib.Structures.Monad.
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Semantics.Equivalence.
+Require Import Cava.Semantics.Loopless.
+Require Import Cava.Util.Tactics.
+Import Circuit.Notations.
+
+Fixpoint is_loop_free {i o} (c : Circuit i o) : bool :=
+  match c with
+  | Comb _ => true
+  | Compose f g => (is_loop_free f && is_loop_free g)%bool
+  | First f => is_loop_free f
+  | Second f => is_loop_free f
+  | DelayInit _ => true
+  | LoopInitCE _ _ => false
+  end.
+
+Lemma is_loop_free_loopless {i o} (c : Circuit i o) :
+  is_loop_free (loopless c) = true.
+Proof.
+  induction c; cbn [loopless is_loop_free];
+    boolsimpl; auto; [ ].
+  rewrite IHc1, IHc2; reflexivity.
+Qed.
+
+Lemma LoopInit_ignore_state {i o s} resetval (c : Circuit i o) :
+  cequiv (LoopInit (s:=s) resetval (First c)) c.
+Proof.
+  exists (fun s1 s2 => fst (snd s1) = s2). cbn [circuit_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  cbn [step LoopInit]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  split; reflexivity.
+Qed.
+
+Lemma LoopInit_merge {i1 o1 o2 s1 s2} r1 r2
+      (c1 : Circuit (i1 * s1) (o1 * s1))
+      (c2 : Circuit (o1 * s2) (o2 * s2)) :
+  cequiv (LoopInit r1 c1 >==> LoopInit r2 c2)
+         (LoopInit (s:=s1*s2)
+                   (r1, r2)
+                   ((Comb (i:=_*(_*_)) (o:=_*_*_)
+                          (fun '(i,(s1,s2)) => (i, s1, s2)))
+                      >==> First c1
+                      >==> (Comb (i:=_*_*_) (o:=_*_*_)
+                                 (fun '(o1,s1',s2) => (o1, s2, s1')))
+                      >==> First c2
+                      >==> (Comb (i:=_*_*_) (o:=_*(_*_))
+                                 (fun '(o2,s2',s1') => (o2, (s1', s2')))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd (fst s1)), tt, fst (snd (snd s1)),
+                  tt, (snd (snd (fst s1)), snd (snd (snd s1)))))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma First_LoopInit {i o s t} r
+      (c : Circuit (i * s) (o * s)) :
+  cequiv (First (t:=t) (LoopInit r c))
+         (LoopInit r
+                   ((Comb (i:=_*_*_) (o:=_*_*_)
+                          (fun '(i,t,s) => (i,s,t)))
+                      >==> First c
+                      >==> (Comb (i:=_*_*_) (o:=_*_*_)
+                                 (fun '(o,s,t) => (o,t,s))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma Second_LoopInit {i o s t} r
+      (c : Circuit (i * s) (o * s)) :
+  cequiv (Second (t:=t) (LoopInit r c))
+         (LoopInit r
+                   ((Comb (i:=_*_*_) (o:=_*(_*_))
+                          (fun '(t,i,s) => (t,(i,s))))
+                      >==> Second c
+                      >==> (Comb (i:=_*(_*_)) (o:=_*_*_)
+                                 (fun '(t,(o,s)) => (t,o,s))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma LoopInit_LoopInit {i o s1 s2} r1 r2
+      (c : Circuit (i * s1 * s2) (o * s1 * s2)) :
+  cequiv (LoopInit r1 (LoopInit r2 c))
+         (LoopInit (s:=s1*s2)
+                   (r1, r2)
+                   ((Comb (i:=_*(_*_)) (o:=_*_*_)
+                          (fun '(i,(s1,s2)) => (i, s1, s2)))
+                      >==> c
+                      >==> (Comb (i:=_*_*_) (o:=_*(_*_))
+                                 (fun '(o,s1,s2) => (o, (s1, s2)))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd (fst (snd s1))), tt,
+                  (snd (snd s1), snd (snd (fst (snd s1))))))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  ssplit; reflexivity.
+Qed.
+
+Lemma LoopInitCE_LoopInit {i o s1 s2} r1 r2
+      (c : Circuit (i * s1 * s2) (o * s1 * s2)) :
+  cequiv (LoopInitCE r1 (LoopInit r2 c))
+         (LoopInit (s:=s2*s1)
+                   (r2, r1)
+                   ((Comb (i:=_*_*(_*_)) (o:=_*_*(_*_*_))
+                          (fun '(x, en, (s2, s1)) => (en, s1, (x, s1, s2)))
+                          >==> Second c
+                          >==> (Comb (i:=Bit*s1*(o*s1*s2))
+                                     (o:=o*(s2*s1))
+                                     (fun '(en, s1, (y, s1', s2')) =>
+                                        (y, (s2', if (en : bool) then s1' else s1))))))).
+Proof.
+  exists (fun s1 s2 =>
+       s2 = (tt, (tt, fst (snd (fst s1)), tt,
+                  (snd (snd (fst s1)), snd s1)))).
+  cbn [circuit_state reset_state LoopInit value].
+  split; [ reflexivity | ].
+  intros; destruct_products; cbn [fst snd] in *; subst.
+  simpl_ident. logical_simplify.
+  cbn [step LoopInit fst snd]. simpl_ident.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  simpl_ident. ssplit; reflexivity.
+Qed.
+
+Lemma extract_loops {i o} (c : Circuit i o) :
+  cequiv c (LoopInit (loops_reset_state c) (loopless c)).
+Proof.
+  induction c; cbn [loopless].
+  { rewrite LoopInit_ignore_state. reflexivity. }
+  { rewrite IHc1 at 1. rewrite IHc2 at 1.
+    apply LoopInit_merge. }
+  { rewrite IHc at 1. apply First_LoopInit. }
+  { rewrite IHc at 1. apply Second_LoopInit. }
+  { simpl_ident. rewrite IHc at 1.
+    apply LoopInitCE_LoopInit. }
+  { rewrite LoopInit_ignore_state. reflexivity. }
+Qed.

--- a/cava/Cava/Semantics/LooplessProperties.v
+++ b/cava/Cava/Semantics/LooplessProperties.v
@@ -44,8 +44,10 @@ Qed.
 Lemma LoopInit_ignore_state {i o s} resetval (c : Circuit i o) :
   cequiv (LoopInit (s:=s) resetval (First c)) c.
 Proof.
-  exists (fun s1 s2 => fst (snd s1) = s2). cbn [circuit_state LoopInit value].
-  split; [ reflexivity | ].
+  exists (fun (s1 : unit * (value (circuit_state c) * value s)) s2 =>
+       fst (snd s1) = s2).
+  cbn [circuit_state LoopInit value].
+  ssplit; [ solve_is_total | reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   cbn [step LoopInit]. simpl_ident.
   repeat (destruct_pair_let; cbn [fst snd]).
@@ -67,11 +69,12 @@ Lemma LoopInit_merge {i1 o1 o2 s1 s2} r1 r2
                       >==> (Comb (i:=_*_*_) (o:=_*(_*_))
                                  (fun '(o2,s2',s1') => (o2, (s1', s2')))))).
 Proof.
-  exists (fun s1 s2 =>
+  exists (fun (s1 : unit * (value (circuit_state c1) * value s1)
+             * (unit * (value (circuit_state c2) * value s2))) s2 =>
        s2 = (tt, (tt, fst (snd (fst s1)), tt, fst (snd (snd s1)),
                   tt, (snd (snd (fst s1)), snd (snd (snd s1)))))).
   cbn [circuit_state reset_state LoopInit value].
-  split; [ reflexivity | ].
+  ssplit; [ solve_is_total | reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -92,7 +95,7 @@ Proof.
   exists (fun s1 s2 =>
        s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
   cbn [circuit_state reset_state LoopInit value].
-  split; [ reflexivity | ].
+  ssplit; [ solve_is_total | reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -113,7 +116,7 @@ Proof.
   exists (fun s1 s2 =>
        s2 = (tt, (tt, fst (snd s1), tt, snd (snd s1)))).
   cbn [circuit_state reset_state LoopInit value].
-  split; [ reflexivity | ].
+  ssplit; [ solve_is_total | reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -136,7 +139,7 @@ Proof.
        s2 = (tt, (tt, fst (snd (fst (snd s1))), tt,
                   (snd (snd s1), snd (snd (fst (snd s1))))))).
   cbn [circuit_state reset_state LoopInit value].
-  split; [ reflexivity | ].
+  ssplit; [ solve_is_total | reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.
@@ -161,7 +164,7 @@ Proof.
        s2 = (tt, (tt, fst (snd (fst s1)), tt,
                   (snd (snd (fst s1)), snd s1)))).
   cbn [circuit_state reset_state LoopInit value].
-  split; [ reflexivity | ].
+  ssplit; [ solve_is_total | reflexivity | ].
   intros; destruct_products; cbn [fst snd] in *; subst.
   simpl_ident. logical_simplify.
   cbn [step LoopInit fst snd]. simpl_ident.

--- a/cava/Cava/Semantics/Simulation.v
+++ b/cava/Cava/Semantics/Simulation.v
@@ -53,51 +53,62 @@ Lemma simulate_comb {A B} (c : value A -> ident (value B)) (input : list (value 
 Proof. apply fold_left_accumulate_to_map. Qed.
 Hint Rewrite @simulate_comb using solve [eauto] : push_simulate.
 
-Lemma simulate_par {A B C D} (f : Circuit A C) (g : Circuit B D)
-      (input : list (value (A * B))) :
-  simulate (Par f g) input = combine
-                               (simulate f (map fst input))
-                               (simulate g (map snd input)).
+Lemma simulate_first {A B C} (f : Circuit A C) (input : list (value (A * B))) :
+  simulate (First f) input = combine (simulate f (map fst input))
+                                      (map snd input).
 Proof.
-  simsimpl. rewrite !fold_left_accumulate_map. fold value.
+  simsimpl. rewrite !fold_left_accumulate_map.
   destruct input as [|i0 ?]; [ reflexivity | ].
   rewrite !fold_left_accumulate_to_seq with (default:=i0).
-  rewrite combine_fold_left_accumulate.
   factor_out_loops.
   eapply fold_left_accumulate_double_invariant_seq
     with (I:= fun i st1 st2 acc1 acc2 =>
                 st1 = st2 /\
                 length acc2 = i /\
                 length acc1 = i /\
-                acc1 = acc2).
+                acc2 = combine acc1 (map snd (firstn i (i0 :: input)))).
   { ssplit; reflexivity. }
   { intros; logical_simplify.
     subst acc2; subst.
     autorewrite with push_length natsimpl in *.
     repeat destruct_pair_let; cbn [fst snd].
-    ssplit; try reflexivity; lia. }
-  { intros; logical_simplify; subst. reflexivity. }
+    ssplit; try reflexivity; try lia; [ ].
+    rewrite firstn_succ_snoc with (d:=i0) by length_hammer.
+    autorewrite with pull_snoc. rewrite combine_append by length_hammer.
+    reflexivity. }
+  { intros; logical_simplify; subst.
+    autorewrite with push_firstn natsimpl.
+    reflexivity. }
 Qed.
-Hint Rewrite @simulate_par using solve [eauto] : push_simulate.
-
-Lemma simulate_id {t} (input : list (value t)) :
-  simulate Id input = input.
-Proof.
-  cbv [Id]. autorewrite with push_simulate.
-  apply map_id_ext; intros; reflexivity.
-Qed.
-Hint Rewrite @simulate_id using solve [eauto] : push_simulate.
-
-Lemma simulate_first {A B C} (f : Circuit A C) (input : list (value (A * B))) :
-  simulate (First f) input = combine (simulate f (map fst input))
-                                     (map snd input).
-Proof. cbv [First]. autorewrite with push_simulate. reflexivity. Qed.
 Hint Rewrite @simulate_first using solve [eauto] : push_simulate.
 
 Lemma simulate_second {A B C} (f : Circuit B C) (input : list (value (A * B))) :
   simulate (Second f) input = combine (map fst input)
-                                      (simulate f (map snd input)).
-Proof. cbv [Second]. autorewrite with push_simulate. reflexivity. Qed.
+                                       (simulate f (map snd input)).
+Proof.
+  simsimpl. rewrite !fold_left_accumulate_map.
+  destruct input as [|i0 ?]; [ reflexivity | ].
+  rewrite !fold_left_accumulate_to_seq with (default:=i0).
+  factor_out_loops.
+  eapply fold_left_accumulate_double_invariant_seq
+    with (I:= fun i st1 st2 acc1 acc2 =>
+                st1 = st2 /\
+                length acc2 = i /\
+                length acc1 = i /\
+                acc2 = combine (map fst (firstn i (i0 :: input))) acc1).
+  { ssplit; reflexivity. }
+  { intros; logical_simplify.
+    subst acc2; subst.
+    autorewrite with push_length natsimpl in *.
+    repeat destruct_pair_let; cbn [fst snd].
+    ssplit; try reflexivity; try lia; [ ].
+    rewrite firstn_succ_snoc with (d:=i0) by length_hammer.
+    autorewrite with pull_snoc. rewrite combine_append by length_hammer.
+    reflexivity. }
+  { intros; logical_simplify; subst.
+    autorewrite with push_firstn natsimpl.
+    reflexivity. }
+Qed.
 Hint Rewrite @simulate_second using solve [eauto] : push_simulate.
 
 Lemma simulate_LoopInitCE {i o s}

--- a/cava/Cava/Semantics/WeakEquivalence.v
+++ b/cava/Cava/Semantics/WeakEquivalence.v
@@ -22,283 +22,96 @@ Require Import Cava.Core.Core.
 Require Import Cava.Semantics.Combinational.
 Require Import Cava.Semantics.Equivalence.
 Require Import Cava.Semantics.Simulation.
+Require Import Cava.Semantics.Loopless.
+Require Import Cava.Semantics.LooplessProperties.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 Import Circuit.Notations.
 
-(* get the state of a circuit after running it on the specified input from the
-   specified start state *)
-Definition repeat_step {i o} (c : Circuit i o) input st : value (circuit_state c) :=
-  fold_left (fun st i => fst (step c st i)) input st.
-
-(* Circuit equivalence relation that allows the first n timesteps to differ *)
+(* Circuit equivalence relation that stipulates an equal output after n timesteps *)
 Definition cequivn {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
-  (* there exists some relation between the circuit states... *)
-  exists (R : value (circuit_state c1) -> value (circuit_state c2) -> Prop),
-    (* ...and the relation holds after n timesteps of equal input for all inputs
-       and all initial states *)
-    (forall input st1 st2,
-        length input = n ->
-        R (repeat_step c1 input st1) (repeat_step c2 input st2))
-    (* ...and if the relation holds, stepping each circuit on the same input
-         results in the same output as well as new states on which the relation
-         continues to hold *)
-    /\ (forall s1 s2 input,
-          R s1 s2 ->
-          snd (step c1 s1 input) = snd (step c2 s2 input)
-          /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))).
+  (* there exists some relation between the circuit states and a counter... *)
+  exists (R : nat -> value (circuit_state c1) -> value (circuit_state c2) -> Prop),
+    (* ...and after an equal input, R holds with a full counter (if n=0, then
+       the output is also equal) *)
+    (forall s1 s2 v, R n (fst (step c1 s1 v)) (fst (step c2 s2 v)))
+    (* ...and if n happens to be 0, then the outputs are equal on equal input *)
+    /\ (n = 0 -> forall s1 s2 v, snd (step c1 s1 v) = snd (step c2 s2 v))
+    (* ...and if the relation holds for a one counter, outputs are equal
+       regardless of input *)
+    /\ (forall s1 s2 v1 v2, R 1 s1 s2 -> snd (step c1 s1 v1) = snd (step c2 s2 v2))
+    (* ...and if the relation holds for a nonzero counter, it holds on new
+       states with a decremented counter regardless of input *)
+    /\ (forall m s1 s2 v1 v2,
+          0 < m ->
+          R (S m) s1 s2 ->
+          R m (fst (step c1 s1 v1)) (fst (step c2 s2 v2))).
 
-(* cequiv is transitive *)
-Global Instance Transitive_cequivn {i o} n : Transitive (@cequivn i o n) | 10.
-Proof.
-  intros x y z [Rxy [? Hxy]] [Ryz [? Hyz]]. logical_simplify.
-  exists (fun (st1 : value (circuit_state x)) (st2 : value (circuit_state z)) =>
-       exists st3 : value (circuit_state y), Rxy st1 st3 /\ Ryz st3 st2).
-  ssplit.
-  { intro input; intros.
-    exists (fold_left (fun st i => fst (step y st i)) input (reset_state y)).
-    eauto. }
-  { intros; logical_simplify.
-    specialize (Hxy _ _ ltac:(eassumption) ltac:(eassumption)).
-    specialize (Hyz _ _ ltac:(eassumption) ltac:(eassumption)).
-    logical_simplify. ssplit; [ congruence | ]. eauto. }
-Qed.
-
-(* cequivn is symmetric *)
-Global Instance Symmetric_cequivn {i o} n : Symmetric (@cequivn i o n) | 10.
-Proof.
-  intros x y [R [? HR]]. logical_simplify.
-  exists (fun st1 st2 => R st2 st1). ssplit; [ solve [eauto] | ].
-  intros. specialize (HR _ _ ltac:(eassumption) ltac:(eassumption)).
-  logical_simplify. eauto.
-Qed.
-
-(* Note: cequivn is NOT reflexive in general! *)
-
-Lemma skipn_fold_left_accumulate {A B C} (f : B -> A -> B * C) n ls b :
-  skipn n (fold_left_accumulate f ls b)
-  = fold_left_accumulate
-      f (skipn n ls) (fold_left (fun b a => fst (f b a)) (firstn n ls) b).
-Admitted.
-
-(* equivalent circuits produce the same output on the same input after n
-   timesteps *)
-Lemma simulate_cequivn {i o} n (c1 c2 : Circuit i o) :
-  cequivn n c1 c2 ->
-  forall input, skipn n (simulate c1 input) = skipn n (simulate c2 input).
-Proof.
-  intros [R [Hstart Hpreserved]]; intros. logical_simplify. cbv [simulate].
-  destr (length input <=? n); [ rewrite !skipn_all2 by length_hammer; reflexivity | ].
-  rewrite !skipn_fold_left_accumulate.
-  eapply fold_left_accumulate_double_invariant_In
-    with (I:=fun st1 st2 acc1 acc2 =>
-               R st1 st2 /\ acc1 = acc2).
-  { ssplit; eauto. apply Hstart. length_hammer. }
-  { intros; logical_simplify; subst.
-    lazymatch goal with
-    | H : forall _ _ _, R _ _ -> _ /\ _, HR : R _ _ |- context [step _ _ ?i] =>
-    let H1 := fresh in
-    let H2 := fresh in
-    specialize (H _ _ i HR); destruct H as [H1 H2];
-      rewrite ?H1, ?H2
-    end.
-    ssplit; eauto. }
-  { intros; logical_simplify; subst. reflexivity. }
-Qed.
-
-Lemma cequivn_cequiv {i o} (c1 c2 : Circuit i o) :
-  cequivn 0 c1 c2 -> cequiv c1 c2.
-Proof.
-  intros [R [Hstart Hstep]].
-  specialize (Hstart nil (reset_state c1) (reset_state c2) eq_refl).
-  cbn [fold_left] in Hstart. exists R; eauto.
-Qed.
-
-Lemma state_relation_fold_left_accumulate_step
-      i o (c1 c2 : Circuit i o) (R : _ -> _ -> Prop) :
-  (forall s1 s2 input,
-      R s1 s2 ->
-      snd (step c1 s1 input) = snd (step c2 s2 input)
-      /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))) ->
-  forall input s1 s2,
-    R s1 s2 ->
-    fold_left_accumulate (step c1) input s1
-    = fold_left_accumulate (step c2) input s2.
-Proof.
-  intro HR. intros.
-  apply fold_left_accumulate_double_invariant_In
-    with (I:=fun s1 s2 acc1 acc2 =>
-               R s1 s2 /\ acc1 = acc2).
-  { eauto. }
-  { intros s1' s2'; intros.
-    logical_simplify; subst.
-    specialize (HR s1' s2' ltac:(eassumption) ltac:(eassumption)).
-    logical_simplify; subst. ssplit; [ assumption | congruence ]. }
-  { intros; logical_simplify; subst; reflexivity. }
-Qed.
-
-Lemma state_relation_repeat_step
-      i o (c1 c2 : Circuit i o) (R : _ -> _ -> Prop) :
-  (forall s1 s2 input,
-      R s1 s2 ->
-      snd (step c1 s1 input) = snd (step c2 s2 input)
-      /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))) ->
-  forall input s1 s2,
-    R s1 s2 -> R (repeat_step c1 input s1) (repeat_step c2 input s2).
-Proof.
-  intro HR. intros. cbv [repeat_step].
-  eapply fold_left_double_invariant with (I:=R).
-  { eauto. }
-  { intros s1' s2'; intros.
-    logical_simplify; subst.
-    specialize (HR s1' s2' ltac:(eassumption) ltac:(eassumption)).
-    logical_simplify; subst; auto. }
-  { intros; logical_simplify; auto. }
-Qed.
-
-(*
-Global Instance Proper_cequivn i o n :
-  Proper (cequiv ==> cequiv ==> (fun A B => forall _ : A, B)) (@cequivn i o n).
-Proof.
-  intros a b [Rab [? Hab]] c d [Rcd [? Hcd]].
-  split.
-  { intros [Rac [? Hac]].
-    exists (fun sb sd =>
-         exists sa sc, Rab sa sb /\ Rcd sc sd /\ Rac sa sc).
-    ssplit.
-    { intros; cbn. do 2 eexists; ssplit; eauto.
-      {
-        apply state_relation_repeat_step; eauto.
-Qed.
-*)
-
-Lemma repeat_step_nil {i o} (c : Circuit i o) st : repeat_step c nil st = st.
-Proof. reflexivity. Qed.
-Hint Rewrite @repeat_step_nil using solve [eauto] : push_repeat_step.
-
-Lemma repeat_step_cons {i o} (c : Circuit i o) i0 input st :
-  repeat_step c (i0 :: input) st = repeat_step c input (fst (step c st i0)).
-Proof. reflexivity. Qed.
-Hint Rewrite @repeat_step_cons using solve [eauto] : push_repeat_step.
-
-Lemma repeat_step_app {i o} (c : Circuit i o) input1 input2 st :
-  repeat_step c (input1 ++ input2) st
-  = repeat_step c input2 (repeat_step c input1 st).
-Proof. apply fold_left_app. Qed.
-Hint Rewrite @repeat_step_app using solve [eauto] : push_repeat_step.
-
-Lemma repeat_step_compose {i t o} c1 c2 input st :
-  repeat_step (@Compose _ _ i t o c1 c2) input st
-  = (repeat_step c1 input (fst st),
-     repeat_step c2 (fold_left_accumulate (step c1) input (fst st)) (snd st)).
-Proof.
-  cbv [repeat_step]. revert st.
-  induction input; [ destruct st; reflexivity | ].
-  intros; cbn [circuit_state] in *. destruct_products; cbn [fst snd].
-  autorewrite with push_list_fold push_fold_acc.
-  rewrite IHinput. cbn [step].
-  repeat (destruct_pair_let; cbn [fst snd]).
-  reflexivity.
-Qed.
-Hint Rewrite @repeat_step_compose using solve [eauto] : push_repeat_step.
-
-Lemma repeat_step_First {i t o} (c : Circuit i o) input st :
-  repeat_step (First (t:=t) c) input st = repeat_step c (map fst input) st.
-Proof.
-  cbv [repeat_step]. revert st.
-  induction input; [ reflexivity | ].
-  intros; cbn [circuit_state] in *. destruct_products; cbn [fst snd].
-  autorewrite with push_list_fold push_fold_acc.
-  rewrite IHinput. cbn [step].
-  repeat (destruct_pair_let; cbn [fst snd]).
-  reflexivity.
-Qed.
-Hint Rewrite @repeat_step_First using solve [eauto] : push_repeat_step.
-
-Lemma repeat_step_Second {i t o} (c : Circuit i o) input st :
-  repeat_step (Second (t:=t) c) input st = repeat_step c (map snd input) st.
-Proof.
-  cbv [repeat_step]. revert st.
-  induction input; [ reflexivity | ].
-  intros; cbn [circuit_state] in *. destruct_products; cbn [fst snd].
-  autorewrite with push_list_fold push_fold_acc.
-  rewrite IHinput. cbn [step].
-  repeat (destruct_pair_let; cbn [fst snd]).
-  reflexivity.
-Qed.
-Hint Rewrite @repeat_step_Second using solve [eauto] : push_repeat_step.
 
 Lemma cequivn_compose {i t o} n m (a b : Circuit i t) (c d : Circuit t o) :
-  cequivn n a b -> cequivn m c d ->
-  cequivn (n + m) (a >==> c) (b >==> d).
-Proof.
-  intros [Rab [? Hab]] [Rcd [? Hcd]].
-  exists (fun st1 st2 => Rab (fst st1) (fst st2) /\ Rcd (snd st1) (snd st2)).
-  ssplit.
-  { intro input; intros. rewrite <-(firstn_skipn n input).
-    rewrite !repeat_step_app, !repeat_step_compose.
-    cbn [fst snd]. assert (length (firstn n input) = n) by length_hammer.
-    assert (length (skipn n input) = m) by length_hammer.
-    ssplit; [ apply state_relation_repeat_step; solve [eauto] | ].
-    erewrite state_relation_fold_left_accumulate_step by eauto.
-    match goal with H : _ |- _ => apply H; length_hammer end. }
-  { cbn [circuit_state step]. intros; logical_simplify.
-    pose proof (fun i => proj1 (Hab _ _ i ltac:(eassumption))) as Hab1.
-    pose proof (fun i => proj2 (Hab _ _ i ltac:(eassumption))) as Hab2.
-    pose proof (fun i => proj1 (Hcd _ _ i ltac:(eassumption))) as Hcd1.
-    pose proof (fun i => proj2 (Hcd _ _ i ltac:(eassumption))) as Hcd2.
-    clear Hab Hcd. logical_simplify.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    rewrite ?Hab1, ?Hcd1. ssplit; eauto; [ apply Hab2 | apply Hcd2 ]. }
-Qed.
+  cequivn n a b -> cequivn m c d -> cequivn (n + m) (a >==> c) (b >==> d).
+Admitted.
 
+(* count the number of delays on the critical path of a circuit *)
+Fixpoint cpath {i o} (c : Circuit i o) : nat :=
+  match c with
+  | Comb _ => 0
+  | First f => cpath f
+  | Second f => cpath f
+  | Compose f g => cpath f + cpath g
+  | DelayInit _=> 1
+  | LoopInitCE _ body => cpath body
+  end.
 
-Lemma state_relation_repeat_step_longer
-      i o n (c1 c2 : Circuit i o) (R : _ -> _ -> Prop) :
-  (forall input s1 s2,
-      length input = n ->
-      R (repeat_step c1 input s1) (repeat_step c2 input s2)) ->
-  (forall s1 s2 input,
-      R s1 s2 ->
-      snd (step c1 s1 input) = snd (step c2 s2 input)
-      /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))) ->
-  forall input s1 s2,
-    n <= length input ->
-    R (repeat_step c1 input s1) (repeat_step c2 input s2).
+Definition cequivn_reflexive {i o} (c : Circuit i o) :
+  is_loop_free c = true -> cequivn (cpath c) c c.
 Proof.
-  intros Hstart HR. intros.
-  rewrite <-(firstn_skipn n input).
-  rewrite !repeat_step_app.
-  eapply state_relation_repeat_step; [ solve [eauto] | ].
-  eapply Hstart. length_hammer.
-Qed.
+  induction c; cbn [cpath is_loop_free].
+  { exists (fun i s1 s2 => i = 0 /\ s1 = s2).
+    ssplit; cbn [value step circuit_state]; intros; subst.
+    all:logical_simplify.
+    all:ssplit; try reflexivity.
+    all:discriminate. }
+  { rewrite Bool.andb_true_iff; intros; logical_simplify.
+    apply cequivn_compose; auto. }
+  { admit. (* applies across First *) }
+  { admit. (* applies across Second *) }
+  { discriminate. }
+  { intros. exists (fun i s1 s2 => i <= 1 /\ s1 = s2).
+    cbn [value step circuit_state].
+    ssplit; intros; logical_simplify; subst; ssplit;
+      try reflexivity; try lia. }
+Admitted.
 
-(* cequivn n c1 c2 -> cequivn n (First c1) (First c2) *)
-Global Instance Proper_First {i o t} n :
-  Proper (cequivn n ==> cequivn n) (@First _ _ i o t).
-Proof.
-  intros x y [Rxy [? Hxy]].
-  exists Rxy; ssplit.
-  { intros. rewrite !repeat_step_First.
-    match goal with H : _ |- _ => apply H; length_hammer end. }
-  { cbn [circuit_state step]. intros; logical_simplify.
-    pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
-    pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
-    clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
-    rewrite Hxy1. ssplit; eauto. }
-Qed.
+(* Circuit equivalence relation that declares the circuits have equal critical
+   paths and, if both are loop-free, then they produce equivalent outputs for
+   equivalent inputs (delayed by the critical path number) *)
+Definition wequiv {i o} (c1 c2 : Circuit i o) : Prop :=
+  cpath c1 = cpath c2
+  /\ (is_loop_free c1 = true ->
+     is_loop_free c2 = true ->
+     cequivn (cpath c1) c1 c2).
 
-(* cequivn n c1 c2 -> cequivn n (Second c1) (Second c2) *)
-Global Instance Proper_Second {i o t} n :
-  Proper (cequivn n ==> cequivn n) (@Second _ _ i o t).
+Global Instance Equivalence_wequiv: forall {i o : type}, Equivalence (@wequiv i o) | 10.
+Admitted.
+
+Global Instance Proper_Second {i o t : type} :
+  Proper (@wequiv i o ==> @wequiv (t * i) (t * o)) Second.
+Admitted.
+
+Global Instance Proper_First {i o t : type} :
+  Proper (@wequiv i o ==> @wequiv (i * t) (o * t)) First.
+Admitted.
+
+Global Instance Proper_Compose {i o t : type} :
+  Proper (@wequiv i t ==> @wequiv t o ==> wequiv) Compose.
+Admitted.
+
+Lemma wequiv_delays {t} (r1 r2 : value t) : wequiv (DelayInit r1) (DelayInit r2).
 Proof.
-  intros x y [Rxy [? Hxy]].
-  exists Rxy; ssplit.
-  { intros. rewrite !repeat_step_Second.
-    match goal with H : _ |- _ => apply H; length_hammer end. }
-  { cbn [circuit_state step]. intros; logical_simplify.
-    pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
-    pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
-    clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
-    rewrite Hxy1. ssplit; eauto. }
+  cbv [wequiv]. cbn [cpath is_loop_free]. ssplit; [ reflexivity | intros ].
+  intros. exists (fun i s1 s2 => i <= 1 /\ s1 = s2).
+  cbn [value step circuit_state].
+  ssplit; intros; logical_simplify; subst; ssplit;
+    try reflexivity; try lia.
 Qed.

--- a/cava/Cava/Semantics/WeakEquivalence.v
+++ b/cava/Cava/Semantics/WeakEquivalence.v
@@ -28,13 +28,13 @@ Import Circuit.Notations.
 
 (* get the state of a circuit after running it on the specified input from the
    specified start state *)
-Definition repeat_step {i o} (c : Circuit i o) input st : circuit_state c :=
+Definition repeat_step {i o} (c : Circuit i o) input st : value (circuit_state c) :=
   fold_left (fun st i => fst (step c st i)) input st.
 
 (* Circuit equivalence relation that allows the first n timesteps to differ *)
 Definition cequivn {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
   (* there exists some relation between the circuit states... *)
-  exists (R : circuit_state c1 -> circuit_state c2 -> Prop),
+  exists (R : value (circuit_state c1) -> value (circuit_state c2) -> Prop),
     (* ...and the relation holds after n timesteps of equal input for all inputs
        and all initial states *)
     (forall input st1 st2,
@@ -52,8 +52,8 @@ Definition cequivn {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
 Global Instance Transitive_cequivn {i o} n : Transitive (@cequivn i o n) | 10.
 Proof.
   intros x y z [Rxy [? Hxy]] [Ryz [? Hyz]]. logical_simplify.
-  exists (fun (st1 : circuit_state x) (st2 : circuit_state z) =>
-       exists st3 : circuit_state y, Rxy st1 st3 /\ Ryz st3 st2).
+  exists (fun (st1 : value (circuit_state x)) (st2 : value (circuit_state z)) =>
+       exists st3 : value (circuit_state y), Rxy st1 st3 /\ Ryz st3 st2).
   ssplit.
   { intro input; intros.
     exists (fold_left (fun st i => fst (step y st i)) input (reset_state y)).
@@ -249,7 +249,7 @@ Proof.
     pose proof (fun i => proj2 (Hcd _ _ i ltac:(eassumption))) as Hcd2.
     clear Hab Hcd. logical_simplify.
     repeat (destruct_pair_let; cbn [fst snd]).
-    rewrite ?Hab1, ?Hcd1. ssplit; eauto. }
+    rewrite ?Hab1, ?Hcd1. ssplit; eauto; [ apply Hab2 | apply Hcd2 ]. }
 Qed.
 
 

--- a/cava/Cava/Semantics/WeakEquivalence.v
+++ b/cava/Cava/Semantics/WeakEquivalence.v
@@ -28,6 +28,7 @@ Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 Import Circuit.Notations.
 
+(*
 (* Circuit equivalence relation that stipulates an equal output after n timesteps *)
 Definition cequivn {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
   (* there exists some relation between the circuit states and a counter... *)
@@ -50,49 +51,120 @@ Definition cequivn {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
 
 Lemma cequivn_compose {i t o} n m (a b : Circuit i t) (c d : Circuit t o) :
   cequivn n a b -> cequivn m c d -> cequivn (n + m) (a >==> c) (b >==> d).
-Admitted.
-
-(* count the number of delays on the critical path of a circuit *)
-Fixpoint cpath {i o} (c : Circuit i o) : nat :=
-  match c with
-  | Comb _ => 0
-  | First f => cpath f
-  | Second f => cpath f
-  | Compose f g => cpath f + cpath g
-  | DelayInit _=> 1
-  | LoopInitCE _ body => cpath body
-  end.
-
-Definition cequivn_reflexive {i o} (c : Circuit i o) :
-  is_loop_free c = true -> cequivn (cpath c) c c.
 Proof.
-  induction c; cbn [cpath is_loop_free].
-  { exists (fun i s1 s2 => i = 0 /\ s1 = s2).
-    ssplit; cbn [value step circuit_state]; intros; subst.
-    all:logical_simplify.
-    all:ssplit; try reflexivity.
-    all:discriminate. }
-  { rewrite Bool.andb_true_iff; intros; logical_simplify.
-    apply cequivn_compose; auto. }
-  { admit. (* applies across First *) }
-  { admit. (* applies across Second *) }
-  { discriminate. }
-  { intros. exists (fun i s1 s2 => i <= 1 /\ s1 = s2).
-    cbn [value step circuit_state].
-    ssplit; intros; logical_simplify; subst; ssplit;
-      try reflexivity; try lia. }
+  intros [Rab [Hab1 [Hab2 [Hab3 Hab4]]]].
+  intros [Rcd [Hcd1 [Hcd2 [Hcd3 Hcd4]]]].
+  exists (fun i s1 s2 =>
+       (m < i -> Rab (i - m) (fst s1) (fst s2))
+       /\ (i <= m -> Rcd i (snd s1) (snd s2))).
+  cbn [value circuit_state].
+  ssplit; intros; destruct_products; cbn [fst snd step] in *;
+    repeat
+      lazymatch goal with
+      | H : ?x + ?y <= ?y |- _ =>
+        destruct x; [ | lia ]; autorewrite with natsimpl in *
+      | H : ?x < 1 |- _ =>
+        destruct x; [ clear H | lia ]; autorewrite with natsimpl in *
+      | H1 : ?y < ?x -> _, H2 : ?x <= ?y -> _ |- _ =>
+        destr (x <=? y); [ specialize (H2 ltac:(lia)); clear H1
+                         | specialize (H1 ltac:(lia)); clear H2 ]
+      | H : Rab 1 ?s1 ?s2 |- context [step a ?s1] => erewrite Hab3 by eassumption
+      | H1 : ?x <= ?y, H2 : ?y < S ?x |- _ =>
+        assert (x = y) by lia; subst; clear H1
+      | _ => first
+              [ progress (ssplit; intros)
+              | erewrite Hab2 by lia
+              | apply Hcd2; lia
+              | apply Hab4; [ lia | solve [auto] ]
+              | solve [auto]
+              | lia
+              | rewrite Nat.sub_succ_l in * by lia
+              | progress autorewrite with natsimpl in * ]
+      end.
+Qed.
+
+Lemma cequivn_delays {t} (r1 r2 : value t) : cequivn 1 (DelayInit r1) (DelayInit r2).
+Proof.
+  exists (fun i s1 s2 => i <= 1 /\ s1 = s2). cbn [value step circuit_state].
+  ssplit; intros; logical_simplify; subst; ssplit; try reflexivity; lia.
+Qed.
+
+Lemma cequivn_comb {i o} (f g : value i -> cava (value o)) :
+  (forall x, f x = g x) -> cequivn 0 (Comb f) (Comb g).
+Proof.
+  intro Hfg. exists (fun i s1 s2 => i = 0). cbn [value step circuit_state].
+  ssplit; intros; logical_simplify; subst; ssplit;
+    repeat lazymatch goal with x : unit |- _ => destruct x end;
+    rewrite ?Hfg; try reflexivity; lia.
+Qed.
+
+Instance Symmetric_cequivn {i o} n : Symmetric (@cequivn i o n) | 10.
+Proof.
+  intros x y [R ?]. logical_simplify. exists (fun i sx sy => R i sy sx).
+  ssplit; intros; auto; symmetry; auto.
+Qed.
+
+(* Restriction that states a circuit is cequivn-equivalent to itself for some n;
+   that is, the number of delays betweeen the inputs and each of the outputs is
+   the same. This will not include most circuits with loops. *)
+Definition uniformly_timed {i o} n (c : Circuit i o) : Prop := cequivn n c c.
+
+Definition wequiv {i o} (c1 c2 : Circuit i o) : Prop :=
+  (* either both circuits are non-uniformly timed *)
+  ((forall n, ~ uniformly_timed n c1)
+   /\ (forall n, ~ uniformly_timed n c2))
+  (* ...or both are uniformly timed with the same timing, and they are
+     cequivn-equivalent with respect to that timing *)
+  \/ (exists n, uniformly_timed n c1
+          /\ uniformly_timed n c2
+          /\ cequivn n c1 c2).
+
+Instance Reflexive_wequiv {i o} : Reflexive (@wequiv i o) | 10.
+Proof.
+  repeat intro. cbv [wequiv].
+  (* here's where we need to *decide* if c is uniformly timed or not *)
+
+  (* thing that returns value nat i -> value nat o
+     Compose f g := fun is => match time f is with
+                              | Some ns => utime g ns
+
+   *)
+Qed.
+Instance Symmetric_wequiv {i o} : Symmetric (@wequiv i o) | 10.
+Proof.
+  repeat intro. cbv [wequiv] in *. logical_simplify.
+  symmetry; auto.
+Qed.
+Instance Transitive_wequiv {i o} : Transitive (@wequiv i o) | 10.
+Proof.
+  repeat intro. cbv [wequiv] in *. logical_simplify.
+  (* This relation is not transitive; a non-uniform y could make both preconditions vacuous *)
+  symmetry; auto.
+Qed.
+
+Print Circuit.
+
+(* Circuits with uniform timing characteristics; all outputs have the same
+   number of delays between them and the circuit inputs *)
+Inductive UCircuit `{semantics:Cava} : nat -> type -> type -> Type :=
+| Comb : forall {i o : type}, (value i -> cava (value o)) -> UCircuit 0 i o
+| Compose : forall {i t o n m}, UCircuit n i t -> UCircuit m t o -> UCircuit (n + m) i o
+| Par : forall {i1 i2 o1 o2 n}, UCircuit n i1 o1 -> UCircuit n i2 o2 -> UCircuit n (i1 * i2) (o1 * o2)
+| LoopInitCE : forall {i o s n}, @value combType s -> UCircuit n (i * s) (o * s) -> UCircuit 0 (i * Bit) o
+| DelayInitCE
+
+
+
+
+(* Circuit equivalence relation that declares the circuits produce equivalent
+   outputs for equivalent inputs after a certain number of delays *)
+Definition wequiv {i o} (c1 c2 : Circuit i o) : Prop :=
+  exists n, cequivn n c1 c2.
+
+Global Instance Transitive_wequiv {i o : type} : Transitive (@wequiv i o) | 10.
 Admitted.
 
-(* Circuit equivalence relation that declares the circuits have equal critical
-   paths and, if both are loop-free, then they produce equivalent outputs for
-   equivalent inputs (delayed by the critical path number) *)
-Definition wequiv {i o} (c1 c2 : Circuit i o) : Prop :=
-  cpath c1 = cpath c2
-  /\ (is_loop_free c1 = true ->
-     is_loop_free c2 = true ->
-     cequivn (cpath c1) c1 c2).
-
-Global Instance Equivalence_wequiv: forall {i o : type}, Equivalence (@wequiv i o) | 10.
+Global Instance Symmetric_wequiv {i o : type} : Symmetric (@wequiv i o) | 10.
 Admitted.
 
 Global Instance Proper_Second {i o t : type} :
@@ -109,9 +181,9 @@ Admitted.
 
 Lemma wequiv_delays {t} (r1 r2 : value t) : wequiv (DelayInit r1) (DelayInit r2).
 Proof.
-  cbv [wequiv]. cbn [cpath is_loop_free]. ssplit; [ reflexivity | intros ].
-  intros. exists (fun i s1 s2 => i <= 1 /\ s1 = s2).
+  cbv [wequiv]. exists 1. exists (fun i s1 s2 => i <= 1 /\ s1 = s2).
   cbn [value step circuit_state].
   ssplit; intros; logical_simplify; subst; ssplit;
-    try reflexivity; try lia.
+    try reflexivity; lia.
 Qed.
+*)

--- a/cava/Cava/Semantics/WeakEquivalence.v
+++ b/cava/Cava/Semantics/WeakEquivalence.v
@@ -126,29 +126,3 @@ Proof.
       repeat match goal with H : _ |- _ => rewrite H end;
       reflexivity.
 Qed.
-
-Lemma chreset_cequiv {i o} (c1 c2 : Circuit i o) :
-  cequiv c1 c2 -> forall r1, exists r2, cequiv (chreset c1 r1) (chreset c2 r2).
-Proof.
-  intros [R ?] r1. logical_simplify.
-  lazymatch goal with HR : is_total R |- _ =>
-                      pose proof (proj1 HR r1) as [r2 ?] end.
-  logical_simplify. exists r2.
-  exists (fun s1 s2 => R (from_chreset_state s1) (from_chreset_state s2)).
-  ssplit.
-  { lazymatch goal with H : is_total R |- _ =>
-                        destruct H as [Hl Hr] end.
-    cbv [is_total]. ssplit; intro x; [ specialize (Hl (from_chreset_state x))
-                                     | specialize (Hr (from_chreset_state x)) ].
-    all:logical_simplify; eexists (to_chreset_state _);
-      rewrite from_to_chreset_state; eassumption. }
-  { rewrite !chreset_reset, !from_to_chreset_state. eauto. }
-  { intros.
-    lazymatch goal with
-      H : forall _ _ _, R _ _ -> _ |- _ =>
-      specialize (H _ _ ltac:(eassumption) ltac:(eassumption))
-    end. logical_simplify.
-    rewrite !step_chreset; cbn [fst snd].
-    rewrite !from_to_chreset_state.
-    ssplit; eauto. }
-Qed.

--- a/cava/Cava/Semantics/WeakEquivalence.v
+++ b/cava/Cava/Semantics/WeakEquivalence.v
@@ -252,6 +252,27 @@ Proof.
     rewrite ?Hab1, ?Hcd1. ssplit; eauto. }
 Qed.
 
+
+Lemma state_relation_repeat_step_longer
+      i o n (c1 c2 : Circuit i o) (R : _ -> _ -> Prop) :
+  (forall input s1 s2,
+      length input = n ->
+      R (repeat_step c1 input s1) (repeat_step c2 input s2)) ->
+  (forall s1 s2 input,
+      R s1 s2 ->
+      snd (step c1 s1 input) = snd (step c2 s2 input)
+      /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))) ->
+  forall input s1 s2,
+    n <= length input ->
+    R (repeat_step c1 input s1) (repeat_step c2 input s2).
+Proof.
+  intros Hstart HR. intros.
+  rewrite <-(firstn_skipn n input).
+  rewrite !repeat_step_app.
+  eapply state_relation_repeat_step; [ solve [eauto] | ].
+  eapply Hstart. length_hammer.
+Qed.
+
 (* cequivn n c1 c2 -> cequivn n (First c1) (First c2) *)
 Global Instance Proper_First {i o t} n :
   Proper (cequivn n ==> cequivn n) (@First _ _ i o t).

--- a/cava/Cava/Semantics/WeakEquivalence.v
+++ b/cava/Cava/Semantics/WeakEquivalence.v
@@ -1,0 +1,233 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Classes.Morphisms.
+Require Import coqutil.Tactics.Tactics.
+Require Import Cava.Core.Core.
+Require Import Cava.Semantics.Combinational.
+Require Import Cava.Semantics.Equivalence.
+Require Import Cava.Semantics.Simulation.
+Require Import Cava.Util.List.
+Require Import Cava.Util.Tactics.
+
+Definition mealy {i o} (c : Circuit i o)
+  : Circuit (i * circuit_state c) (o * circuit_state c) :=
+  Comb (fun '(input, st) =>
+          let st_out := step c st input in
+          (snd st_out, fst st_out)).
+
+(* Weaker notion of circuit equivalence that allows circuits to have equal
+   behavior only for certain timesteps
+
+   If weak_cequiv n m c1 c2 holds, then after the first n timesteps from a
+   reset, c1 will compute the same values as c2 but take m additional timesteps
+   for each step taken by c2.
+ *)
+Definition cequivn {i o} (n m : nat) (c1 c2 : Circuit i o) : Prop :=
+  
+  (* there exists some relation between the circuit states and a counter value... *)
+  exists (R : nat -> circuit_state c1 -> circuit_state c2 -> Prop),
+    (* ...and the relation holds after the first n timesteps for all inputs *)
+    (forall input,
+        length input = n ->
+        R 0 (fold_left (fun st i => fst (step c1 st i)) input (reset_state c1))
+          (fold_left (fun st i => fst (step c2 st i)) input (reset_state c2)))
+    (* ... and if the relation holds for a 0 counter, then the outputs must
+       match if the inputs are the same *)
+    /\ (forall s1 s2 input,
+          R 0 s1 s2 ->
+          snd (step c1 s1 input) = snd (step c2 s2 input))
+          
+    (* ...and if the relation holds, stepping each circuit on the same input
+         results in the same output as well as new states on which the relation
+         continues to hold *)
+    /\ (forall s1 s2 input,
+          R s1 s2 ->
+          snd (step c1 s1 input) = snd (step c2 s2 input)
+          /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))).
+
+(* Circuit equivalence relation that allows the first n timesteps to differ *)
+Definition cequivn {i o} (n : nat) (c1 c2 : Circuit i o) : Prop :=
+  (* there exists some relation between the circuit states... *)
+  exists (R : circuit_state c1 -> circuit_state c2 -> Prop),
+    (* ...and the relation holds after the first n timesteps for all inputs *)
+    (forall input,
+        length input = n ->
+        R (fold_left (fun st i => fst (step c1 st i)) input (reset_state c1))
+          (fold_left (fun st i => fst (step c2 st i)) input (reset_state c2)))
+    (* ...and if the relation holds, stepping each circuit on the same input
+         results in the same output as well as new states on which the relation
+         continues to hold *)
+    /\ (forall s1 s2 input,
+          R s1 s2 ->
+          snd (step c1 s1 input) = snd (step c2 s2 input)
+          /\ R (fst (step c1 s1 input)) (fst (step c2 s2 input))).
+
+(* cequiv is transitive *)
+Global Instance Transitive_cequivn {i o} n : Transitive (@cequivn i o n) | 10.
+Proof.
+  intros x y z [Rxy [? Hxy]] [Ryz [? Hyz]]. logical_simplify.
+  exists (fun (st1 : circuit_state x) (st2 : circuit_state z) =>
+       exists st3 : circuit_state y, Rxy st1 st3 /\ Ryz st3 st2).
+  ssplit.
+  { intro input; intros.
+    exists (fold_left (fun st i => fst (step y st i)) input (reset_state y)).
+    eauto. }
+  { intros; logical_simplify.
+    specialize (Hxy _ _ ltac:(eassumption) ltac:(eassumption)).
+    specialize (Hyz _ _ ltac:(eassumption) ltac:(eassumption)).
+    logical_simplify. ssplit; [ congruence | ]. eauto. }
+Qed.
+
+(* cequivn is reflexive *)
+Global Instance Reflexive_cequivn {i o} n : Reflexive (@cequivn i o n) | 10.
+Proof.
+  repeat intro. exists eq. ssplit; [ reflexivity | ].
+  intros; subst. ssplit; reflexivity.
+Qed.
+
+(* cequivn is symmetric *)
+Global Instance Symmetric_cequivn {i o} n : Symmetric (@cequivn i o n) | 10.
+Proof.
+  intros x y [R [? HR]]. logical_simplify.
+  exists (fun st1 st2 => R st2 st1). ssplit; [ assumption | ].
+  intros. specialize (HR _ _ ltac:(eassumption) ltac:(eassumption)).
+  logical_simplify. eauto.
+Qed.
+
+(* cequivn is an equivalence relation *)
+Global Instance Equivalence_cequivn {i o} n : Equivalence (@cequivn i o n) | 10.
+Proof. constructor; typeclasses eauto. Qed.
+
+Lemma skipn_fold_left_accumulate {A B C} (f : B -> A -> B * C) n ls b :
+  skipn n (fold_left_accumulate f ls b)
+  = fold_left_accumulate
+      f (skipn n ls) (fold_left (fun b a => fst (f b a)) (firstn n ls) b).
+Admitted.
+
+(* equivalent circuits produce the same output on the same input after n
+   timesteps *)
+Lemma simulate_cequivn {i o} n (c1 c2 : Circuit i o) :
+  cequivn n c1 c2 ->
+  forall input, skipn n (simulate c1 input) = skipn n (simulate c2 input).
+Proof.
+  intros [R [Hstart Hpreserved]]; intros. logical_simplify. cbv [simulate].
+  destr (length input <=? n); [ rewrite !skipn_all2 by length_hammer; reflexivity | ].
+  rewrite !skipn_fold_left_accumulate.
+  eapply fold_left_accumulate_double_invariant_In
+    with (I:=fun st1 st2 acc1 acc2 =>
+               R st1 st2 /\ acc1 = acc2).
+  { ssplit; eauto. apply Hstart. length_hammer. }
+  { intros; logical_simplify; subst.
+    lazymatch goal with
+    | H : forall _ _ _, R _ _ -> _ /\ _, HR : R _ _ |- context [step _ _ ?i] =>
+    let H1 := fresh in
+    let H2 := fresh in
+    specialize (H _ _ i HR); destruct H as [H1 H2];
+      rewrite ?H1, ?H2
+    end.
+    ssplit; eauto. }
+  { intros; logical_simplify; subst. reflexivity. }
+Qed.
+
+Lemma cequivn_cequiv_iff {i o} (c1 c2 : Circuit i o) :
+  cequivn 0 c1 c2 <-> cequiv c1 c2.
+Proof.
+  split.
+  { intros [R [Hstart Hstep]].
+    specialize (Hstart nil eq_refl). cbn [fold_left] in Hstart.
+    exists R; eauto. }
+  { intros [R [Hstart Hstep]].
+    exists R; ssplit; [ | solve [eauto] ].
+    intro input; destruct input; [ | length_hammer ].
+    intros; cbn [fold_left]. assumption. }
+Qed.
+
+(* 0-equivalent circuits produce exactly the same output on the same input *)
+Lemma simulate_cequivn0 {i o} (c1 c2 : Circuit i o) :
+  cequivn 0 c1 c2 -> forall input, simulate c1 input = simulate c2 input.
+Proof.
+  rewrite cequivn_cequiv_iff.
+  apply simulate_cequiv.
+Qed.
+
+(* Proper instance allows rewriting under simulate *)
+Global Instance Proper_simulate i o :
+  Proper (cequivn 0 ==> eq ==> eq) (@simulate i o).
+Proof. repeat intro; subst. eapply simulate_cequivn0; auto. Qed.
+
+Global Instance Proper_Compose {i t o} :
+  Proper (cequivn n ==> cequivn ==> cequivn) (@Compose _ _ i t o).
+Proof.
+  intros a b [Rab [? Hab]].
+  intros c d [Rcd [? Hcd]].
+  exists (fun st1 st2 => Rab (fst st1) (fst st2) /\ Rcd (snd st1) (snd st2)).
+  ssplit; [ assumption .. | ].
+  cbn [circuit_state step]. intros; logical_simplify.
+  pose proof (fun i => proj1 (Hab _ _ i ltac:(eassumption))) as Hab1.
+  pose proof (fun i => proj2 (Hab _ _ i ltac:(eassumption))) as Hab2.
+  pose proof (fun i => proj1 (Hcd _ _ i ltac:(eassumption))) as Hcd1.
+  pose proof (fun i => proj2 (Hcd _ _ i ltac:(eassumption))) as Hcd2.
+  clear Hab Hcd. logical_simplify.
+  repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite ?Hab1, ?Hcd1. ssplit; eauto.
+Qed.
+
+(* cequivn c1 c2 -> cequivn (First c1) (First c2) *)
+Global Instance Proper_First {i o t} :
+  Proper (cequivn ==> cequivn) (@First _ _ i o t).
+Proof.
+  intros x y [Rxy [? Hxy]].
+  exists Rxy; ssplit; [ assumption | ].
+  cbn [circuit_state step]. intros; logical_simplify.
+  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
+  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
+  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite Hxy1. ssplit; eauto.
+Qed.
+
+(* cequivn c1 c2 -> cequivn (Second c1) (Second c2) *)
+Global Instance Proper_Second {i o t} :
+  Proper (cequivn ==> cequivn) (@Second _ _ i o t).
+Proof.
+  intros x y [Rxy [? Hxy]].
+  exists Rxy; ssplit; [ assumption | ].
+  cbn [circuit_state step]. intros; logical_simplify.
+  pose proof (fun i => proj1 (Hxy _ _ i ltac:(eassumption))) as Hxy1.
+  pose proof (fun i => proj2 (Hxy _ _ i ltac:(eassumption))) as Hxy2.
+  clear Hxy. logical_simplify. repeat (destruct_pair_let; cbn [fst snd]).
+  rewrite Hxy1. ssplit; eauto.
+Qed.
+
+(* r1 = r2 -> cequivn c1 c2 -> cequivn (LoopInit r1 c1) (LoopInit r2 c2) *)
+Global Instance Proper_LoopInit {i s o} :
+  Proper (eq ==> cequivn ==> cequivn) (@LoopInit _ _ i o s).
+Proof.
+  cbv [LoopInit]. simpl_ident. repeat intro; subst.
+  lazymatch goal with H : cequivn _ _ |- _ => rewrite H end.
+  reflexivity.
+Qed.
+
+(* cequivn c1 c2 -> cequivn (LoopCE c1) (LoopCE c2) *)
+Global Instance Proper_LoopCE {i s o} :
+  Proper (cequivn ==> cequivn) (@LoopCE _ _ i o s).
+Proof. apply Proper_LoopInitCE. reflexivity. Qed.
+
+(* cequivn c1 c2 -> cequivn (Loop c1) (Loop c2) *)
+Global Instance Proper_Loop {i s o} :
+  Proper (cequivn ==> cequivn) (@Loop _ _ i o s).
+Proof. apply Proper_LoopInit. reflexivity. Qed.

--- a/cava/Cava/Util/List.v
+++ b/cava/Cava/Util/List.v
@@ -271,6 +271,32 @@ Section Combine.
     cbn [combine length Nat.min]. rewrite IHla.
     lia.
   Qed.
+  Lemma map_fst_combine {A B} (la : list A) (lb : list B) :
+    length la = length lb ->
+    map fst (combine la lb) = la.
+  Proof.
+    revert lb; induction la; [ reflexivity | ].
+    destruct lb; [ length_hammer | ].
+    cbn [combine map length]; intros.
+    rewrite IHla by lia. reflexivity.
+  Qed.
+
+  Lemma map_snd_combine {A B} (la : list A) (lb : list B) :
+    length la = length lb ->
+    map snd (combine la lb) = lb.
+  Proof.
+    revert lb; induction la; destruct lb;
+      try length_hammer; [ ].
+    cbn [combine map length]; intros.
+    rewrite IHla by lia. reflexivity.
+  Qed.
+
+  Lemma combine_same {A} (l : list A) :
+    combine l l = map (fun x => (x,x)) l.
+  Proof.
+    induction l; [ reflexivity | ].
+    cbn [combine map]. congruence.
+  Qed.
 End Combine.
 Hint Rewrite @combine_length : push_length.
 

--- a/cava/Cava/Util/List.v
+++ b/cava/Cava/Util/List.v
@@ -1157,20 +1157,6 @@ Section FoldLeftAccumulate.
     rewrite Nat.sub_0_r. reflexivity.
   Qed.
 
-  Lemma combine_fold_left_accumulate
-        {A B C D E} (f : B -> A -> B * C) (g : D -> A -> D * E) ls b d :
-    combine (fold_left_accumulate f ls b) (fold_left_accumulate g ls d)
-    = fold_left_accumulate
-        (fun bd a =>
-           let bc := f (fst bd) a in
-           let de := g (snd bd) a in
-           (fst bc, fst de, (snd bc, snd de))) ls (b,d).
-  Proof.
-    revert b d. induction ls; intros; [ reflexivity | ].
-    rewrite !fold_left_accumulate_cons. cbn [combine fst snd].
-    rewrite IHls; reflexivity.
-  Qed.
-
   Lemma fold_left_accumulate_to_seq
         {A B C} (f : B -> A -> B * C) ls b default :
     fold_left_accumulate f ls b =

--- a/cava/Cava/Util/List.v
+++ b/cava/Cava/Util/List.v
@@ -1157,6 +1157,20 @@ Section FoldLeftAccumulate.
     rewrite Nat.sub_0_r. reflexivity.
   Qed.
 
+  Lemma combine_fold_left_accumulate
+        {A B C D E} (f : B -> A -> B * C) (g : D -> A -> D * E) ls b d :
+    combine (fold_left_accumulate f ls b) (fold_left_accumulate g ls d)
+    = fold_left_accumulate
+        (fun bd a =>
+           let bc := f (fst bd) a in
+           let de := g (snd bd) a in
+           (fst bc, fst de, (snd bc, snd de))) ls (b,d).
+  Proof.
+    revert b d. induction ls; intros; [ reflexivity | ].
+    rewrite !fold_left_accumulate_cons. cbn [combine fst snd].
+    rewrite IHls; reflexivity.
+  Qed.
+
   Lemma fold_left_accumulate_to_seq
         {A B C} (f : B -> A -> B * C) ls b default :
     fold_left_accumulate f ls b =

--- a/cava/Cava/Util/Tactics.v
+++ b/cava/Cava/Util/Tactics.v
@@ -232,6 +232,7 @@ Ltac logical_simplify_step :=
     inversion H; subst; clear H
   | H : (_, _) = (_,_) |- _ =>
     inversion H; subst; clear H
+  | x : unit |- _ => destruct x
   end.
 Ltac logical_simplify := repeat logical_simplify_step.
 
@@ -255,6 +256,11 @@ Section LogicalSimplifyTests.
     intros; logical_simplify. eexists. eassumption.
   Qed.
 
+  (* prove units are equal *)
+  Goal (forall x y : unit, x = y).
+    intros; logical_simplify. reflexivity.
+  Qed.
+
   (* nested tuples *)
   Goal (forall T (a0 a1 a2 a3 b0 b1 b2 b3 : T),
            (a0,a1,a2,a3) = (b0,b1,b2,b3) ->
@@ -270,11 +276,11 @@ Section LogicalSimplifyTests.
   Qed.
 
   (* more complex expression *)
-  Goal (forall T (a0 a1 a2 a3 b0 b1 b2 b3 : T),
+  Goal (forall T (a0 a1 a2 a3 b0 b1 b2 b3 : T) (u0 u1 : unit),
            (exists x,
                Some (a0, a1) = Some (b0, x)
                /\ Some x = Some b3) ->
-           a1 = b3).
+           (a1, u0) = (b3, u1)).
     intros; logical_simplify. reflexivity.
   Qed.
 End LogicalSimplifyTests.


### PR DESCRIPTION
This code is a big mess still -- I've redefined weak equivalence and retiming about a million times, most recently about two hours ago. But the core of the idea is in `RetimingProperties.v`; I want to be able to use lemmas to interactively push delays around inside a proof. More details about some of the thought process here are in the notes document I've shared. Retiming inside of loops is the hard part -- you have to reason about keeping the loop state and input in sync.

This adds a lightweight type system on top of the existing Circuit structure to make reasoning about adding delays to arbitrary circuits' states possible.