### PR TITLE
Replace parameter records by individual parameters

### DIFF
--- a/firmware/Aes/AesExampleToRiscV.v
+++ b/firmware/Aes/AesExampleToRiscV.v
@@ -48,7 +48,7 @@ Definition main : func :=
 Definition funcs : list func := [main; aes_encrypt].
 
 Derive aes_example_compile_result
-       SuchThat (compile (map.of_list (funcs ++ AesToRiscV.funcs))
+       SuchThat (compile compile_ext_call (map.of_list (funcs ++ AesToRiscV.funcs))
                  = Some aes_example_compile_result)
        As aes_example_compile_result_eq.
 Proof.

--- a/firmware/Aes/AesProperties.v
+++ b/firmware/Aes/AesProperties.v
@@ -1618,10 +1618,6 @@ Section Proofs.
 
     (* store result in memory *)
     ring_simplify_store_addr.
-    (* the following line is in [straightline] but needs simplify_implicits for
-       it to work *)
-    eapply store_four_of_sep;
-      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 1 *)
@@ -1632,10 +1628,6 @@ Section Proofs.
 
     (* store result in memory *)
     ring_simplify_store_addr.
-    (* the following line is in [straightline] but needs simplify_implicits for
-       it to work *)
-    eapply store_four_of_sep;
-      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 3 *)
@@ -1646,10 +1638,6 @@ Section Proofs.
 
     (* store result in memory *)
     ring_simplify_store_addr.
-    (* the following line is in [straightline] but needs simplify_implicits for
-       it to work *)
-    eapply store_four_of_sep;
-      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 3 *)
@@ -1660,10 +1648,6 @@ Section Proofs.
 
     (* store result in memory *)
     ring_simplify_store_addr.
-    (* the following line is in [straightline] but needs simplify_implicits for
-       it to work *)
-    eapply store_four_of_sep;
-      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 4; loop done *)

--- a/firmware/Aes/AesProperties.v
+++ b/firmware/Aes/AesProperties.v
@@ -23,6 +23,7 @@ Require Import coqutil.Z.Lia.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 Require Import Bedrock2Experiments.LibBase.MMIOLabels.
+Require Import Bedrock2Experiments.ProgramSemantics32.
 Require Import Bedrock2Experiments.StateMachineSemantics.
 Require Import Bedrock2Experiments.StateMachineProperties.
 Require Import Bedrock2Experiments.Tactics.
@@ -43,46 +44,27 @@ Local Open Scope Z_scope.
 Ltac normalize_body_of_function f ::= Tactics.rdelta.rdelta f.
 
 Section Proofs.
-  Context {p : AesSemantics.parameters} {p_ok : parameters.ok p}
-          {consts : aes_constants Z} {timing : timing}.
-  Context {consts_ok : aes_constants_ok consts}.
-  Existing Instance state_machine_parameters.
-
-  (* this duplicate of locals_ok helps when Semantics.word has been changed to
-     parameters.word *)
-  Local Instance localsok : @map.ok string parameters.word Semantics.locals
-    := Semantics.locals_ok.
+  Context {word: word.word 32} {mem: map.map word Byte.byte}
+          {word_ok: word.ok word} {mem_ok: map.ok mem}
+          {ASpec: AesSpec}
+          {consts : aes_constants Z} {timing : timing}
+          {consts_ok : aes_constants_ok consts}.
 
   (* Plug in the right state machine parameters; typeclass inference struggles here *)
-  Local Notation execution := (execution (p:=state_machine_parameters)).
+  Local Notation execution := (execution (M := aes_state_machine)).
 
   (***** General-purpose lemmas/tactics and setup *****)
 
-  Add Ring wring : (Properties.word.ring_theory (word := parameters.word))
+  Add Ring wring : (Properties.word.ring_theory (word := word))
         (preprocess [autorewrite with rew_word_morphism],
-         morphism (Properties.word.ring_morph (word := parameters.word)),
+         morphism (Properties.word.ring_morph (word := word)),
          constants [Properties.word_cst]).
 
   Existing Instance constant_literals | 10.
 
-  (* This tactic simplifies implicit types so that they all agree; otherwise
-     tactic has trouble connecting, for instance, a word of type parameters.word
-     and a word of type Semantics.word, even though they are the same *)
-  Local Ltac simplify_implicits :=
-    change Semantics.word with parameters.word in *;
-    change Semantics.mem with parameters.mem in *;
-    change Semantics.width with 32 in *;
-    change Semantics.word_ok with parameters.word_ok in *;
-    change Semantics.mem_ok with parameters.mem_ok in *.
-
-  (* tactic to solve the side conditions of interact_read and interact_write *)
-  Local Ltac solve_dexprs ::=
-    repeat straightline_with_map_lookup;
-    simplify_implicits; repeat straightline_with_map_lookup.
-
   (* tactic to simplify side conditions in terms of [dexpr] *)
   Local Ltac dexpr_hammer :=
-    subst_lets; simplify_implicits;
+    subst_lets;
     repeat first [ progress push_unsigned
                  | rewrite word.unsigned_of_Z in *
                  | rewrite word.wrap_small in * by lia
@@ -103,16 +85,12 @@ Section Proofs.
     | H1 : execution t ?s1, H2 : execution t ?s2 |- _ =>
       specialize (IHt _ _ H1 H2); subst
     end.
-    cbv [step] in *. cbn [ parameters.read_step
-                             parameters.write_step
-                             state_machine_parameters] in *.
+    cbv [step] in *. cbn [state_machine.read_step state_machine.write_step aes_state_machine] in *.
     repeat destruct_one_match_hyp; try contradiction; [ | ].
     all:logical_simplify; subst.
     all: lazymatch goal with
-         | H : parameters.reg_addr ?x = parameters.reg_addr ?y |- _ =>
-           eapply (parameters.reg_addr_unique
-                     (ok:=state_machine_parameters_ok) x y) in H
-         end.
+         | H : state_machine.reg_addr ?x = state_machine.reg_addr ?y |- _ =>
+           eapply (state_machine.reg_addr_unique x y) in H end.
     all:cbv [write_step read_step] in *; subst.
     all:repeat destruct_one_match_hyp; try congruence.
     all:logical_simplify; subst.
@@ -143,15 +121,15 @@ Section Proofs.
     repeat first [ progress infer_states_equal
                  | progress infer_state_data_equal
                  | match goal with
-                   | H: parameters.read_step _ _ _ _ _ |- _ => apply proj2 in H
-                   | H: parameters.write_step _ _ _ _ _ |- _ => apply proj2 in H
+                   | H: state_machine.read_step _ _ _ _ _ |- _ => apply proj2 in H
+                   | H: state_machine.write_step _ _ _ _ _ |- _ => apply proj2 in H
                    end ].
 
   (* TODO: lots of annoying bit arithmetic here, maybe try to clean it up *)
   Lemma status_read_always_ok s :
     exists val s', read_step s STATUS val s'.
   Proof.
-    assert (forall x y : parameters.word,
+    assert (forall x y : word,
                word.slu (word.of_Z 1) x <> word.slu (word.of_Z 1) y -> x <> y)
            as Hshift_neq by (intros; subst; congruence).
     pose proof status_flags_unique_and_nonzero as Hflags.
@@ -188,7 +166,7 @@ Section Proofs.
                 assert (word.unsigned (word.and x y) = word.unsigned y)
                   as H;
                   [ | rewrite H; intro Heq; apply word.unsigned_inj in Heq;
-                      simplify_implicits; cbn in *; congruence ]
+                      cbn in *; congruence ]
               end.
       all:push_unsigned; cbv [word.wrap]; rewrite <-!Z.land_ones by lia;
         bitblast.Z.bitblast.
@@ -204,7 +182,7 @@ Section Proofs.
             H2 : ?i - ?y = 0 |- _ =>
             assert (word.of_Z x = word.of_Z y) by (f_equal; lia)
           end.
-      all:simplify_implicits; cbn in *; congruence. }
+      all:cbn in *; congruence. }
     { exists (word.slu (word.of_Z 1) (word.of_Z AES_STATUS_OUTPUT_VALID)).
       destruct data. rewrite is_flag_set_shift by (cbv [boolean]; tauto || lia).
       rewrite word.eqb_ne by
@@ -218,14 +196,14 @@ Section Proofs.
       rewrite !is_flag_set_shift_neq by
           (cbv [boolean];
            first [ tauto | lia
-                   | intro; cbn in *; simplify_implicits; congruence ]).
+                   | intro; cbn in *; congruence ]).
       reflexivity. }
   Qed.
 
   (* solve common side conditions from interactions *)
   Local Ltac post_interaction :=
     lazymatch goal with
-    | |- dexprs _ _ _ _ => solve_dexprs; reflexivity
+    | |- dexprs _ _ _ _ => repeat straightline_with_map_lookup; reflexivity
     | |- reg_addr _ = _ => reflexivity
     | |- execution _ _ => eassumption
     | |- ?G => tryif is_lia G then lia else eauto
@@ -245,7 +223,7 @@ Section Proofs.
     cmd call (cmd.interact [bind] READ32 [addre]) t m l post.
   Proof.
     intros; eapply (interact_read 4); intros; infer;
-      cbv [parameters.read_step state_machine_parameters] in *;
+      cbv [state_machine.read_step aes_state_machine] in *;
       eauto.
     pose proof status_read_always_ok s. logical_simplify.
     do 3 eexists; eauto.
@@ -288,7 +266,7 @@ Section Proofs.
     (* Hi below needs to go away once the issue #854 is fixed *)
     (Hi : i <= i) :
     call functions AbsMMIO.abs_mmio_read32 tr m [word.of_Z AES_STATUS0]
-      (fun (t : trace) (m0 : mem) (rets : list Semantics.word) =>
+      (fun (t : trace) (m0 : mem) (rets : list word) =>
        exists l : locals,
          map.putmany_of_list_zip ["status"] rets map.empty = Some l /\
          cmd (call functions)
@@ -297,8 +275,8 @@ Section Proofs.
                  (expr.op bopname.slu 1 i))) t m0 l
            (fun (t0 : trace) (m1 : mem) (l0 : locals) =>
             list_map (get l0) ["out"]
-              (fun rets0 : list Semantics.word =>
-               exists (status out : Semantics.word) (s' : state),
+              (fun rets0 : list word =>
+               exists (status out : word) (s' : state),
                  execution t0 s' /\
                  read_step s STATUS status s' /\
                  R m1 /\
@@ -313,7 +291,7 @@ Section Proofs.
     straightline_call; ssplit.
     (* specialize abs_mmio to AES STATUS *)
     { instantiate ( 1 := STATUS ). reflexivity. }
-    { cbv [parameters.read_step state_machine_parameters] in *. eauto. }
+    { cbv [state_machine.read_step aes_state_machine] in *. eauto. }
     { eauto. }
     { repeat straightline.
       (* keep "execution a x" for later eassumption *)
@@ -358,7 +336,7 @@ Section Proofs.
     cmd call (cmd.interact [] WRITE32 [addre;vale]) t m l post.
   Proof.
     intros; eapply (interact_write 4); intros; infer;
-      cbv [parameters.write_step state_machine_parameters] in *;
+      cbv [state_machine.write_step aes_state_machine] in *;
       eauto.
     cbv [write_step]. cbn [reg_category].
     exists s; destruct s; try contradiction;
@@ -378,7 +356,7 @@ Section Proofs.
   Qed.
 
   Lemma interact_write_key i call addre vale t m l
-        (post : trace -> mem -> locals -> Prop) rs (addr val: Semantics.word) :
+        (post : trace -> mem -> locals -> Prop) rs (addr val: word) :
     dexprs m l [addre; vale] [addr; val] ->
     addr = word.add (word.of_Z AES_KEY00) (word.mul (word.of_Z (Z.of_nat i)) (word.of_Z 4)) ->
     (i < 8)%nat ->
@@ -391,7 +369,7 @@ Section Proofs.
     cmd call (cmd.interact [] WRITE32 [addre;vale]) t m l post.
   Proof.
     intros; eapply (interact_write 4); intros; infer;
-      cbv [parameters.write_step state_machine_parameters] in *;
+      cbv [state_machine.write_step aes_state_machine] in *;
       eauto.
     { repeat (destruct i; try lia); subst; cbn; ring. }
     { cbv [write_step]. rewrite key_from_index_category by lia.
@@ -423,7 +401,7 @@ Section Proofs.
     cmd call (cmd.interact [] WRITE32 [addre;vale]) t m l post.
   Proof.
     intros; eapply (interact_write 4); intros; infer;
-      cbv [parameters.write_step state_machine_parameters] in *;
+      cbv [state_machine.write_step aes_state_machine] in *;
       eauto.
     { repeat (destruct i; try lia); subst; cbn; ring. }
     { cbv [write_step]. rewrite iv_from_index_category by lia.
@@ -455,7 +433,7 @@ Section Proofs.
     cmd call (cmd.interact [] WRITE32 [addre;vale]) t m l post.
   Proof.
     intros; eapply (interact_write 4); intros; infer;
-      cbv [parameters.write_step state_machine_parameters] in *;
+      cbv [state_machine.write_step aes_state_machine] in *;
       eauto.
     { repeat (destruct i; try lia); subst; cbn; ring. }
     { cbv [write_step]. rewrite data_in_from_index_category by lia.
@@ -497,7 +475,7 @@ Section Proofs.
   Proof.
     intros; eapply (interact_read 4) with (r:=data_out_from_index i);
       intros; infer;
-        cbv [parameters.read_step state_machine_parameters] in *;
+        cbv [state_machine.read_step aes_state_machine] in *;
         eauto.
     { repeat (destruct i; try lia); subst; cbn; ring. }
     { cbv [read_step]. rewrite data_out_from_index_category by lia.
@@ -559,7 +537,7 @@ Section Proofs.
     eapply interact_write_data_in with (i:=n);
     [ lazymatch goal with
       | |- _ = word.add _ _ =>
-        subst_lets; simplify_implicits;
+        subst_lets;
         cbn [Z.of_nat Pos.of_succ_nat Pos.succ]; ring
       | _ => idtac
       end;
@@ -594,7 +572,7 @@ Section Proofs.
     eapply interact_read_data_out with (i:=n);
     [lazymatch goal with
       | |- _ = word.add _ _ =>
-        subst_lets; simplify_implicits;
+        subst_lets;
         cbn [Z.of_nat Pos.of_succ_nat Pos.succ]; ring
       | _ => idtac
       end;
@@ -621,13 +599,13 @@ Section Proofs.
   Local Notation aes_mode_t := (enum_member (aes_mode (aes_constants_ok := consts_ok))) (only parsing).
   Local Notation aes_key_len_t := (enum_member (aes_key_len (aes_constants_ok := consts_ok))) (only parsing).
 
-  Definition ctrl_operation (ctrl : parameters.word) : bool :=
+  Definition ctrl_operation (ctrl : word) : bool :=
     is_flag_set ctrl AES_CTRL_OPERATION.
-  Definition ctrl_mode (ctrl : parameters.word) : parameters.word :=
+  Definition ctrl_mode (ctrl : word) : word :=
     select_bits ctrl (word.of_Z AES_CTRL_MODE_OFFSET) (word.of_Z AES_CTRL_MODE_MASK).
-  Definition ctrl_key_len (ctrl : parameters.word) : parameters.word :=
+  Definition ctrl_key_len (ctrl : word) : word :=
     select_bits ctrl (word.of_Z AES_CTRL_KEY_LEN_OFFSET) (word.of_Z AES_CTRL_KEY_LEN_MASK).
-  Definition ctrl_manual_operation (ctrl : parameters.word) : bool :=
+  Definition ctrl_manual_operation (ctrl : word) : bool :=
     is_flag_set ctrl AES_CTRL_MANUAL_OPERATION.
 
   (***** Proofs for specific functions *****)
@@ -641,7 +619,7 @@ Section Proofs.
         execution tr s ->
         call function_env aes_data_ready tr m []
              (fun tr' m' rets =>
-                exists (status out : Semantics.word) (s' : state),
+                exists (status out : word) (s' : state),
                   (* the new state matches the new trace *)
                   execution tr' s'
                   (* ...and there exists a single valid status-read step between
@@ -674,7 +652,7 @@ Section Proofs.
         execution tr s ->
         call function_env aes_data_valid tr m []
              (fun tr' m' rets =>
-                exists (status out : Semantics.word) (s' : state),
+                exists (status out : word) (s' : state),
                   (* the new state matches the new trace *)
                   execution tr' s'
                   (* ...and there exists a single valid status-read step between
@@ -708,7 +686,7 @@ Section Proofs.
         execution tr s ->
         call function_env aes_idle tr m []
              (fun tr' m' rets =>
-                exists (status out : Semantics.word) (s' : state),
+                exists (status out : word) (s' : state),
                   (* the new state matches the new trace *)
                   execution tr' s'
                   (* ...and there exists a single valid status-read step between
@@ -779,7 +757,7 @@ Section Proofs.
 
     straightline_call; ssplit.
     { instantiate ( 1 := CTRL ). reflexivity. }
-    { cbv [parameters.write_step state_machine_parameters] in *;
+    { cbv [state_machine.write_step aes_state_machine] in *;
       ssplit; eauto.
       instantiate ( 2 := UNINITIALIZED ). reflexivity. }
     { eauto. }
@@ -807,8 +785,6 @@ Section Proofs.
       apply enum_member_size in H;
       pose proof has_size_nonneg _ _ H
     end.
-
-    simplify_implicits.
 
     assert (0 <= AES_CTRL_MODE_MASK < 2 ^ 32). {
       rewrite mode_mask_eq.
@@ -941,7 +917,7 @@ Section Proofs.
   Global Instance spec_of_aes_key_put : spec_of "b2_key_put" :=
     fun function_env =>
       forall (tr : trace) (m : mem) R (data : idle_data)
-        (key_len key_arr_ptr : Semantics.word) (key_arr : list Semantics.word),
+        (key_len key_arr_ptr : word) (key_arr : list word),
         (* key_len is a member of the aes_key_len enum *)
         aes_key_len_t key_len ->
         (* key array is in memory *)
@@ -972,7 +948,6 @@ Section Proofs.
     (* we want to avoid letting [straightline] go too far here, so we can apply
        [cond_nobreak], which requires a [seq] in front of [cond] *)
     do 2 straightline. repeat straightline_cleanup.
-    simplify_implicits.
 
     (* setup: assert useful facts and simplify hypotheses *)
     (* assert that key length enum members are unique *)
@@ -987,7 +962,7 @@ Section Proofs.
     end.
 
     (* this assertion helps prove that i does not get truncated *)
-    assert (9 < 2 ^ Semantics.width) by (cbn; lia).
+    assert (9 < 2 ^ 32) by (cbn; lia).
     pose proof nregs_key_eq.
 
     (* upper bound key_len *)
@@ -1096,7 +1071,7 @@ Section Proofs.
                | _ := map.put _ "i" (word.of_Z (Z.of_nat ?i)) |- _ => i end in
       let a := constr:(word.add key_arr_ptr (word.mul (word.of_Z (Z.of_nat i)) (word.of_Z 4))) in
       let offset := constr:(word.sub a key_arr_ptr) in
-      assert (i = Z.to_nat (word.unsigned offset / word.unsigned (width:=width) (word.of_Z 4))) as Hindex;
+      assert (i = Z.to_nat (word.unsigned offset / word.unsigned (word.of_Z 4))) as Hindex;
         [ ring_simplify offset | ].
       { push_unsigned. rewrite (Z.mul_comm 4), Z.div_mul by lia. lia. }
 
@@ -1333,7 +1308,7 @@ Section Proofs.
   Global Instance spec_of_aes_iv_put : spec_of "b2_iv_put" :=
     fun function_env =>
       forall (tr : trace) (m : mem) R (data : idle_data)
-        (iv_ptr : Semantics.word) (iv_arr : list Semantics.word),
+        (iv_ptr : word) (iv_arr : list word),
         (* iv array is in memory *)
         (array scalar32 (word.of_Z 4) iv_ptr iv_arr * R)%sep m ->
         (* iv array has 4 elements *)
@@ -1359,7 +1334,6 @@ Section Proofs.
   Proof.
     (* intial processing *)
     repeat straightline.
-    simplify_implicits.
 
     (* simplify array predicate *)
     destruct_lists_by_length.
@@ -1369,8 +1343,6 @@ Section Proofs.
              progress ring_simplify addr in H
            end.
 
-    (* this assertion helps prove that i does not get truncated *)
-    assert (4 < 2 ^ Semantics.width) by (cbn; lia).
     pose proof nregs_iv_eq.
 
     (* unroll while loop *)
@@ -1385,17 +1357,17 @@ Section Proofs.
 
     (* i = 1 *)
     split; repeat straightline; [ dexpr_hammer | ].
-    write_iv_n 1%nat; [ simplify_implicits; subst_lets; ring | ].
+    write_iv_n 1%nat; [ subst_lets; ring | ].
     repeat straightline.
 
     (* i = 2 *)
     split; repeat straightline; [ dexpr_hammer | ].
-    write_iv_n 2%nat; [ simplify_implicits; subst_lets; ring | ].
+    write_iv_n 2%nat; [ subst_lets; ring | ].
     repeat straightline.
 
     (* i = 3 *)
     split; repeat straightline; [ dexpr_hammer | ].
-    write_iv_n 3%nat; [ simplify_implicits; subst_lets; ring | ].
+    write_iv_n 3%nat; [ subst_lets; ring | ].
     repeat straightline.
 
     (* i = 4; loop done *)
@@ -1413,7 +1385,7 @@ Section Proofs.
   Global Instance spec_of_aes_data_put : spec_of "b2_data_put" :=
     fun function_env =>
       forall (tr : trace) (m : mem) R (data : idle_data) all_aes_input
-        (input_ptr : Semantics.word) (input_arr : list Semantics.word),
+        (input_ptr : word) (input_arr : list word),
         (* input array is in memory *)
         (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m ->
         (* input array has 4 elements *)
@@ -1439,7 +1411,7 @@ Section Proofs.
                 execution tr' (BUSY (Build_busy_data
                                        (idle_ctrl data)
                                        (aes_expected_output all_aes_input)
-                                       timing.ndelays_core))
+                                       ndelays_core))
                 (* ...and the same properties as before hold on the memory *)
                 /\ (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m'
                 (* ...and there is no output *)
@@ -1450,7 +1422,6 @@ Section Proofs.
   Proof.
     (* initial processing *)
     repeat straightline.
-    simplify_implicits.
 
     (* simplify array predicate *)
     destruct_lists_by_length.
@@ -1460,8 +1431,6 @@ Section Proofs.
              progress ring_simplify addr in H
            end.
 
-    (* this assertion helps prove that i does not get truncated *)
-    assert (4 < 2 ^ Semantics.width) by (cbn; lia).
     pose proof nregs_data_eq.
 
     (* unroll while loop *)
@@ -1512,7 +1481,7 @@ Section Proofs.
   Global Instance spec_of_aes_data_put_wait : spec_of "b2_data_put_wait" :=
     fun function_env =>
       forall (tr : trace) (m : mem) R (data : idle_data) all_aes_input
-        (input_ptr : Semantics.word) (input_arr : list Semantics.word),
+        (input_ptr : word) (input_arr : list word),
         (* input array is in memory *)
         (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m ->
         (* input array has 4 elements *)
@@ -1538,7 +1507,7 @@ Section Proofs.
                 execution tr' (BUSY (Build_busy_data
                                        (idle_ctrl data)
                                        (aes_expected_output all_aes_input)
-                                       timing.ndelays_core))
+                                       ndelays_core))
                 (* ...and the same properties as before hold on the memory *)
                 /\ (array scalar32 (word.of_Z 4) input_ptr input_arr * R)%sep m'
                 (* ...and there is no output *)
@@ -1549,7 +1518,6 @@ Section Proofs.
   Proof.
     (* initial processing *)
     repeat straightline.
-    simplify_implicits.
 
     (* we know the circuit is in IDLE state, so loop has exactly 1 iteration *)
     eapply unroll_while with (iterations:=1%nat). cbn [repeat_logic_step].
@@ -1564,7 +1532,7 @@ Section Proofs.
     logical_simplify; subst.
     cbn [read_step reg_category] in *.
     cbv [status_matches_state] in *.
-    logical_simplify; simplify_implicits.
+    logical_simplify.
     repeat match goal with
            | H : (_ && _)%bool = true |- _ => apply Bool.andb_true_iff in H; destruct H
            | H : word.eqb _ _ = _ |- _ => apply word.eqb_false in H
@@ -1589,8 +1557,8 @@ Section Proofs.
   Global Instance spec_of_aes_data_get : spec_of "b2_data_get" :=
     fun function_env =>
       forall (tr : trace) (m : mem) R (data : done_data)
-        (data_ptr out0 out1 out2 out3 : Semantics.word)
-        (data_arr : list Semantics.word),
+        (data_ptr out0 out1 out2 out3 : word)
+        (data_arr : list word),
         (* data array is in memory, with arbitrary initital values *)
         (array scalar32 (word.of_Z 4) data_ptr data_arr * R)%sep m ->
         length data_arr = 4%nat ->
@@ -1618,7 +1586,6 @@ Section Proofs.
   Proof.
     (* initial processing *)
     repeat straightline.
-    simplify_implicits.
 
     (* simplify array predicate *)
     destruct_lists_by_length.
@@ -1628,8 +1595,6 @@ Section Proofs.
              progress ring_simplify addr in H
            end.
 
-    (* this assertion helps prove that i does not get truncated *)
-    assert (4 < 2 ^ Semantics.width) by (cbn; lia).
     pose proof nregs_data_eq.
 
     (* unroll while loop *)
@@ -1652,12 +1617,11 @@ Section Proofs.
     read_data_out_n 0%nat. repeat straightline.
 
     (* store result in memory *)
-    simplify_implicits.
     ring_simplify_store_addr.
     (* the following line is in [straightline] but needs simplify_implicits for
        it to work *)
     eapply store_four_of_sep;
-      [ simplify_implicits; solve [ ecancel_assumption ] |  ].
+      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 1 *)
@@ -1667,12 +1631,11 @@ Section Proofs.
     read_data_out_n 1%nat. repeat straightline.
 
     (* store result in memory *)
-    simplify_implicits.
     ring_simplify_store_addr.
     (* the following line is in [straightline] but needs simplify_implicits for
        it to work *)
     eapply store_four_of_sep;
-      [ simplify_implicits; solve [ ecancel_assumption ] |  ].
+      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 3 *)
@@ -1682,12 +1645,11 @@ Section Proofs.
     read_data_out_n 2%nat. repeat straightline.
 
     (* store result in memory *)
-    simplify_implicits.
     ring_simplify_store_addr.
     (* the following line is in [straightline] but needs simplify_implicits for
        it to work *)
     eapply store_four_of_sep;
-      [ simplify_implicits; solve [ ecancel_assumption ] |  ].
+      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 3 *)
@@ -1697,12 +1659,11 @@ Section Proofs.
     read_data_out_n 3%nat. repeat straightline.
 
     (* store result in memory *)
-    simplify_implicits.
     ring_simplify_store_addr.
     (* the following line is in [straightline] but needs simplify_implicits for
        it to work *)
     eapply store_four_of_sep;
-      [ simplify_implicits; solve [ ecancel_assumption ] |  ].
+      [ solve [ ecancel_assumption ] |  ].
     repeat straightline.
 
     (* i = 4; loop done *)
@@ -1716,7 +1677,6 @@ Section Proofs.
            end.
 
     ssplit; eauto; [ ].
-    simplify_implicits.
     ecancel_assumption.
   Qed.
 
@@ -1728,7 +1688,7 @@ Section Proofs.
     | _ => False
     end.
 
-  Definition get_ctrl (s : state) : Semantics.word :=
+  Definition get_ctrl (s : state) : word :=
     match s with
     | UNINITIALIZED => word.of_Z 0 (* dummy value *)
     | IDLE data => idle_ctrl data
@@ -1739,7 +1699,7 @@ Section Proofs.
   Global Instance spec_of_aes_data_get_wait : spec_of "b2_data_get_wait" :=
     fun function_env =>
       forall (tr : trace) (m : mem) R (out : aes_output)
-        (data_ptr : Semantics.word) (data_arr : list Semantics.word) (s : state),
+        (data_ptr : word) (data_arr : list word) (s : state),
         (* data array is in memory, with arbitrary initital values *)
         (array scalar32 (word.of_Z 4) data_ptr data_arr * R)%sep m ->
         length data_arr = 4%nat ->
@@ -1767,7 +1727,6 @@ Section Proofs.
   Proof.
     (* initial processing *)
     repeat straightline.
-    simplify_implicits.
 
     (* separate out cases where s is initially BUSY or DONE *)
     cbv [output_matches_state] in *.
@@ -1851,7 +1810,6 @@ Section Proofs.
             exfalso.
             cbv [status_matches_state] in *.
             repeat invert_bool.
-            simplify_implicits.
             lazymatch goal with
             | br := if word.eqb _ (word.of_Z 0) then _ else _,
                     H : word.unsigned br <> 0 |- _ =>
@@ -1904,12 +1862,6 @@ Section Proofs.
             exfalso.
             cbv [status_matches_state] in *.
             repeat invert_bool; try congruence; [ ].
-            simplify_implicits.
-            lazymatch goal with
-            | H : word.eqb _ _ = negb (is_flag_set ?x ?flag),
-                  H' : is_flag_set ?x ?flag = _ |- _ =>
-              rewrite H' in H; cbn [negb] in H
-            end.
             lazymatch goal with
             | br := if word.eqb ?x (word.of_Z 0) then _ else _,
                     Heq : word.eqb ?x (word.of_Z 0) = _,
@@ -1953,7 +1905,6 @@ Section Proofs.
       cbv [status_matches_state] in *.
       logical_simplify; subst.
       repeat invert_bool; try congruence; [ ].
-      simplify_implicits.
       lazymatch goal with
       | H : word.eqb _ _ = negb (is_flag_set ?x ?flag),
             H' : is_flag_set ?x ?flag = _ |- _ =>
@@ -1965,7 +1916,7 @@ Section Proofs.
 
       (* prove the loop breaks *)
       ssplit;
-        [ subst_lets; simplify_implicits;
+        [ subst_lets;
           destruct_one_match; push_unsigned; congruence | ].
 
       repeat straightline.

--- a/firmware/Hmac/CavaHmacDevice.v
+++ b/firmware/Hmac/CavaHmacDevice.v
@@ -36,7 +36,7 @@ Section WithParameters.
   (* TODO [for milestone 2: end-to-end proof]:
      Fill in these proofs to show that Cava Hmac device satisfies state machine *)
   Global Instance cava_hmac_satisfies_state_machine:
-    device_implements_state_machine hmac_device state_machine_parameters.
+    device_implements_state_machine hmac_device hmac_state_machine.
   Proof.
     eapply Build_device_implements_state_machine.
   Admitted.

--- a/firmware/Hmac/HmacSemantics.v
+++ b/firmware/Hmac/HmacSemantics.v
@@ -162,23 +162,21 @@ Section WithParams.
   Definition HMAC_MMIO_PAST_END: Z :=
     TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET + HMAC_MSG_FIFO_SIZE_BYTES.
 
-  Global Instance state_machine_parameters: StateMachineSemantics.parameters 32 word mem := {|
-    StateMachineSemantics.parameters.state := state ;
-    StateMachineSemantics.parameters.register := word;
-    StateMachineSemantics.parameters.is_initial_state s :=
+  Global Instance hmac_state_machine : state_machine.parameters := {|
+    state_machine.state := state ;
+    state_machine.register := word;
+    state_machine.is_initial_state s :=
       match s with
       | IDLE digest_buffer _ => List.length digest_buffer = 8%nat
       | _ => False
       end;
-    StateMachineSemantics.parameters.read_step := read_step;
-    StateMachineSemantics.parameters.write_step := write_step;
-    StateMachineSemantics.parameters.reg_addr := id;
-    StateMachineSemantics.parameters.isMMIOAddr a :=
-      HMAC_MMIO_START <= word.unsigned a < HMAC_MMIO_PAST_END;
+    state_machine.read_step := read_step;
+    state_machine.write_step := write_step;
+    state_machine.reg_addr := id;
+    state_machine.isMMIOAddr a := HMAC_MMIO_START <= word.unsigned a < HMAC_MMIO_PAST_END;
   |}.
 
-  Global Instance state_machine_parameters_ok
-    : StateMachineSemantics.parameters.ok state_machine_parameters.
+  Global Instance hmac_state_machine_ok : state_machine.ok hmac_state_machine.
   Proof.
     constructor; cbn; unfold id; intros; try exact _;
       match goal with

--- a/firmware/Hmac/RunSha256SoftwareOnCava.v
+++ b/firmware/Hmac/RunSha256SoftwareOnCava.v
@@ -11,12 +11,12 @@ Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.InstructionCoercions.
 Open Scope ilist_scope.
 
-Definition code_start    : Utility.word := word.of_Z 0.
-Definition code_pastend  : Utility.word := word.of_Z (4*2^10).
-Definition heap_start    : Utility.word := word.of_Z (4*2^10).
-Definition heap_pastend  : Utility.word := word.of_Z (8*2^10).
-Definition stack_start   : Utility.word := word.of_Z (8*2^10).
-Definition stack_pastend : Utility.word := word.of_Z (16*2^10).
+Definition code_start    : word := word.of_Z 0.
+Definition code_pastend  : word := word.of_Z (4*2^10).
+Definition heap_start    : word := word.of_Z (4*2^10).
+Definition heap_pastend  : word := word.of_Z (8*2^10).
+Definition stack_start   : word := word.of_Z (8*2^10).
+Definition stack_pastend : word := word.of_Z (16*2^10).
 
 Definition main_relative_pos :=
   match map.get (snd (fst sha256_compile_result)) (fst main) with
@@ -24,7 +24,7 @@ Definition main_relative_pos :=
   | None => -1111
   end.
 
-Definition p_call: Utility.word :=
+Definition p_call: word :=
   word.add code_start (word.of_Z (4 * Z.of_nat (List.length sha256_example_asm))).
 
 Definition all_insts: list Instruction :=

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -113,6 +113,7 @@ Require Import bedrock2.ZnWords.
 Require Import Bedrock2Experiments.RiscvMachineWithCavaDevice.InternalMMIOMachine.
 Require Import Bedrock2Experiments.IncrementWait.Constants.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWaitSemantics.
+Require Import Bedrock2Experiments.StateMachineSemantics.
 Require Import Bedrock2Experiments.RiscvMachineWithCavaDevice.MMIOToCava.
 
 Section WithParameters.
@@ -162,7 +163,7 @@ Section WithParameters.
   Set Printing Depth 100000.
 
   Global Instance cava_counter_satisfies_state_machine:
-    device_implements_state_machine counter_device state_machine_parameters.
+    device_implements_state_machine counter_device increment_wait_state_machine.
   Proof.
     eapply Build_device_implements_state_machine with (device_state_related := counter_related);
       intros.
@@ -202,7 +203,7 @@ Section WithParameters.
     - (* state_machine_read_to_device_read: *)
       (* simpler because device.maxRespDelay=1 *)
       unfold device.maxRespDelay, device.runUntilResp, device.state, device.run1, counter_device.
-      unfold StateMachineSemantics.parameters.read_step, state_machine_parameters in *.
+      unfold state_machine.read_step, increment_wait_state_machine in *.
       simp.
       unfold read_step in *.
       destruct r.
@@ -227,7 +228,7 @@ Section WithParameters.
           destruct Hp1 as [H | H].
           -- (* transition to DONE *)
              destruct H; subst.
-             simpl (StateMachineSemantics.parameters.reg_addr _).
+             simpl (state_machine.reg_addr _).
              unfold STATUS_ADDR, INCR_BASE_ADDR, word_to_bv, status_value, STATUS_DONE.
              rewrite !word.unsigned_of_Z. unfold word.wrap. simpl.
              inversion H0; subst.
@@ -257,7 +258,7 @@ Section WithParameters.
                    rewrite !word.unsigned_of_Z. reflexivity.
           -- (* stay BUSY *)
              destruct H as (n & ? & ? & ?); subst.
-             simpl (StateMachineSemantics.parameters.reg_addr _).
+             simpl (state_machine.reg_addr _).
              unfold STATUS_ADDR, INCR_BASE_ADDR, word_to_bv, status_value, STATUS_BUSY.
              rewrite !word.unsigned_of_Z. unfold word.wrap. simpl.
              inversion H0; subst.
@@ -287,7 +288,7 @@ Section WithParameters.
                    rewrite !word.unsigned_of_Z. reflexivity.
         * (* sH=DONE *)
           destruct Hp1. subst. inversion H0. subst.
-          simpl (StateMachineSemantics.parameters.reg_addr _).
+          simpl (state_machine.reg_addr _).
           unfold STATUS_ADDR, INCR_BASE_ADDR, word_to_bv, status_value, STATUS_DONE.
           cbn.
           rewrite !word.unsigned_of_Z. unfold word.wrap. cbn -[Vec.hd Vec.tl incrN].

--- a/firmware/IncrementWait/IncrementWaitProperties.v
+++ b/firmware/IncrementWait/IncrementWaitProperties.v
@@ -236,11 +236,7 @@ Section Proofs.
       rewrite Z.land_0_l, Z.eqb_refl in *.
       congruence. }
     { (* proof that invariant holds at loop start *)
-      ssplit; [ | map_lookup .. | assumption ].
-      cbn [execution]. eexists; ssplit; [ eassumption | ].
-      cbv [step write_step]. change (if (_: bool) then ?x else _) with x.
-      exists VALUE, 4%nat; ssplit;
-        cbv [state_machine.write_step increment_wait_state_machine write_step]; eauto. }
+      cbn [execution]. eauto. }
     { (* invariant holds through loop (or postcondition holds, if loop breaks) *)
       repeat straightline.
 

--- a/firmware/IncrementWait/IncrementWaitProperties.v
+++ b/firmware/IncrementWait/IncrementWaitProperties.v
@@ -18,6 +18,7 @@ Require Import Cava.Util.Tactics.
 Require Import Bedrock2Experiments.Tactics.
 Require Import Bedrock2Experiments.Word.
 Require Import Bedrock2Experiments.WordProperties.
+Require Import Bedrock2Experiments.ProgramSemantics32.
 Require Import Bedrock2Experiments.IncrementWait.Constants.
 Require Import Bedrock2Experiments.StateMachineSemantics.
 Require Import Bedrock2Experiments.StateMachineProperties.
@@ -37,25 +38,20 @@ Section Proofs.
         (* no special requirements of the memory *)
         R m ->
         (* circuit must start in IDLE state *)
-        execution (p := state_machine_parameters) tr IDLE ->
+        execution (M := increment_wait_state_machine) tr IDLE ->
         let args := [input] in
         call function_env put_wait_get tr m args
              (fun tr' m' rets =>
                 (* the circuit is back in IDLE state *)
-                execution (p := state_machine_parameters) tr' IDLE
+                execution (M := increment_wait_state_machine) tr' IDLE
                 (* ...and the same properties as before hold on the memory *)
                 /\ R m'
                 (* ...and output matches spec *)
                 /\ rets = [proc input]).
 
-  Local Ltac simplify_implicits :=
-    change Semantics.word with word in *;
-    change Semantics.mem with mem in *;
-    change Semantics.width with 32 in *.
-
   Lemma execution_unique (t : trace) s1 s2 :
-    execution (p := state_machine_parameters) t s1 ->
-    execution (p := state_machine_parameters) t s2 ->
+    execution (M := increment_wait_state_machine) t s1 ->
+    execution (M := increment_wait_state_machine) t s2 ->
     s1 = s2.
   Proof.
     revert s1 s2.
@@ -73,11 +69,11 @@ Section Proofs.
            | |- _ => destruct_one_match_hyp
            | |- _ => progress logical_simplify; subst
            | |- _ => congruence
-           | |- _ => progress cbv [read_step parameters.read_step
-                                   write_step parameters.write_step parameters.reg_addr
-                                   state_machine_parameters] in *
+           | |- _ => progress cbv [read_step state_machine.read_step
+                                   write_step state_machine.write_step state_machine.reg_addr
+                                   increment_wait_state_machine] in *
            | H: reg_addr _ = reg_addr _ |- _ => eapply reg_addrs_unique in H
-           | |- _ => progress cbv [reg_addr status_value] in *; simplify_implicits
+           | |- _ => progress cbv [reg_addr status_value] in *
            | H : _ \/ _ |- _ => destruct H
            end.
     all: match goal with
@@ -110,12 +106,12 @@ Section Proofs.
   Qed.
 
   Lemma word_and_shiftl_1_diff n m :
-    word.unsigned n < width ->
-    word.unsigned m < width ->
+    word.unsigned n < 32 ->
+    word.unsigned m < 32 ->
     word.slu (word.of_Z 1) n <> word.slu (word.of_Z (word:=word) 1) m ->
     word.and (word.slu (word.of_Z 1) n) (word.slu (word.of_Z 1) m) = word.of_Z 0.
   Proof.
-    pose proof word.width_pos. simplify_implicits.
+    pose proof word.width_pos.
     intros. apply word.unsigned_inj. push_unsigned.
     cbv [word.wrap]. rewrite <-Z.land_ones by lia.
     Z.bitblast.
@@ -159,20 +155,20 @@ Section Proofs.
   Qed.
 
   Local Ltac interact_read_reg reg :=
-    eapply (interact_read (p := state_machine_parameters) 4 reg);
+    eapply (interact_read (M := increment_wait_state_machine) 4 reg);
     [ repeat straightline_with_map_lookup; reflexivity
     | reflexivity
     | do 3 eexists; split; [ eassumption | ];
-      cbv [read_step parameters.read_step state_machine_parameters]; eauto
+      cbv [read_step state_machine.read_step increment_wait_state_machine]; eauto
     | ];
     repeat straightline.
 
   Local Ltac interact_write_reg reg :=
-    eapply (interact_write (p := state_machine_parameters) 4 reg);
+    eapply (interact_write (M := increment_wait_state_machine) 4 reg);
     [ repeat straightline_with_map_lookup; reflexivity
     | reflexivity
     | do 2 eexists; ssplit; [ eassumption | ];
-      cbv [write_step parameters.write_step state_machine_parameters]; eauto
+      cbv [write_step state_machine.write_step increment_wait_state_machine]; eauto
     | ];
     repeat straightline.
 
@@ -212,7 +208,7 @@ Section Proofs.
     interact_write_reg VALUE.
 
     (* simplify post-write guarantees *)
-    cbv [parameters.write_step state_machine_parameters write_step] in *.
+    cbv [state_machine.write_step increment_wait_state_machine write_step] in *.
     repeat straightline.
     repeat (destruct_one_match_hyp; try contradiction).
     subst.
@@ -223,7 +219,7 @@ Section Proofs.
            (lt:=lt)
            (invariant:=
               fun i tr m l =>
-                execution (p := state_machine_parameters) tr (BUSY input i) /\ R m).
+                execution (M := increment_wait_state_machine) tr (BUSY input i) /\ R m).
     { apply lt_wf. }
     { (* case in which the loop breaks immediately (cannot happen) *)
       repeat straightline.
@@ -244,7 +240,7 @@ Section Proofs.
       cbn [execution]. eexists; ssplit; [ eassumption | ].
       cbv [step write_step]. change (if (_: bool) then ?x else _) with x.
       exists VALUE, 4%nat; ssplit;
-        cbv [parameters.write_step state_machine_parameters write_step]; eauto. }
+        cbv [state_machine.write_step increment_wait_state_machine write_step]; eauto. }
     { (* invariant holds through loop (or postcondition holds, if loop breaks) *)
       repeat straightline.
 
@@ -261,14 +257,13 @@ Section Proofs.
 
         match goal with H : _ |- _ => apply word.if_nonzero, word.eqb_true in H end.
 
-        cbv [parameters.read_step state_machine_parameters read_step] in *. straightline.
+        cbv [state_machine.read_step increment_wait_state_machine read_step] in *. straightline.
         (* break into two possible read cases : DONE and BUSY *)
         lazymatch goal with H : _ \/ _ |- _ => destruct H end;
           logical_simplify; subst.
         { (* DONE case; contradiction *)
           exfalso; infer.
           pose proof check_done_flag_done as Hflag.
-          simplify_implicits.
           unfold STATUS_DONE in *.
           match goal with H : word.and _ _ = word.of_Z 0 |- _ =>
                           rewrite H in Hflag end.
@@ -282,16 +277,16 @@ Section Proofs.
 
         ssplit; [ | map_lookup .. | assumption ].
         eapply execution_step_read with (r:=STATUS); [ eassumption | reflexivity | ].
-        cbv [read_step parameters.read_step state_machine_parameters]. split; [reflexivity|].
+        cbv [read_step state_machine.read_step increment_wait_state_machine]. split; [reflexivity|].
         right; eauto. }
       { (* break case -- postcondition holds *)
 
         (* break into two possible read cases : DONE and BUSY *)
-        cbv [parameters.read_step state_machine_parameters read_step] in *. straightline.
+        cbv [state_machine.read_step increment_wait_state_machine read_step] in *. straightline.
         lazymatch goal with H : _ \/ _ |- _ => destruct H end;
           logical_simplify; subst.
         2:{ (* BUSY case; contradiction *)
-          exfalso; infer. simplify_implicits.
+          exfalso; infer.
           unfold STATUS_BUSY in *.
           lazymatch goal with H : word.unsigned (if _ then _ else _) = 0 |- _ =>
                           erewrite word.eqb_eq in H by apply check_done_flag_busy;
@@ -303,7 +298,7 @@ Section Proofs.
         interact_read_reg VALUE. repeat straightline.
 
         (* simplify post-read guarantees *)
-        infer. cbv [read_step parameters.read_step state_machine_parameters] in *. repeat straightline.
+        infer. cbv [read_step state_machine.read_step increment_wait_state_machine] in *. repeat straightline.
         repeat (destruct_one_match_hyp; try contradiction);
           try lazymatch goal with
               | H : word.unsigned (word.of_Z 1) = 0 |- _ =>

--- a/firmware/IncrementWait/IncrementWaitSemantics.v
+++ b/firmware/IncrementWait/IncrementWaitSemantics.v
@@ -99,25 +99,20 @@ Section WithParameters.
       end
     end.
 
-  Global Instance state_machine_parameters
-    : StateMachineSemantics.parameters 32 word mem :=
-    {| StateMachineSemantics.parameters.state := state ;
-       StateMachineSemantics.parameters.register := Register ;
-       StateMachineSemantics.parameters.is_initial_state := eq IDLE ;
-       StateMachineSemantics.parameters.read_step sz s a v s' :=
-         sz = 4%nat /\ read_step s a v s';
-       StateMachineSemantics.parameters.write_step sz s a v s' :=
-         sz = 4%nat /\ write_step s a v s' ;
-       StateMachineSemantics.parameters.reg_addr := reg_addr ;
-       StateMachineSemantics.parameters.isMMIOAddr a :=
-           INCR_BASE_ADDR <= word.unsigned a < INCR_END_ADDR;
-    |}.
+  Global Instance increment_wait_state_machine : state_machine.parameters := {
+    state_machine.state := state;
+    state_machine.register := Register;
+    state_machine.is_initial_state := eq IDLE;
+    state_machine.read_step sz s a v s' := sz = 4%nat /\ read_step s a v s';
+    state_machine.write_step sz s a v s' := sz = 4%nat /\ write_step s a v s';
+    state_machine.reg_addr := reg_addr;
+    state_machine.isMMIOAddr a := INCR_BASE_ADDR <= word.unsigned a < INCR_END_ADDR;
+  }.
 
-  Global Instance state_machine_parameters_ok
-    : StateMachineSemantics.parameters.ok state_machine_parameters.
+  Global Instance increment_wait_state_machine_ok : state_machine.ok increment_wait_state_machine.
   Proof.
     constructor;
-      unfold parameters.isMMIOAddr; cbn;
+      unfold state_machine.isMMIOAddr; cbn;
       intros;
       try exact _;
       repeat match goal with
@@ -131,9 +126,4 @@ Section WithParameters.
     all: exfalso; ZnWords.
   Qed.
 
-  (* COPY-PASTE this *)
-  Add Ring wring : (Properties.word.ring_theory (word := Semantics.word))
-        (preprocess [autorewrite with rew_word_morphism],
-         morphism (Properties.word.ring_morph (word := Semantics.word)),
-         constants [Properties.word_cst]).
 End WithParameters.

--- a/firmware/IncrementWait/IncrementWaitToCava.v
+++ b/firmware/IncrementWait/IncrementWaitToCava.v
@@ -52,7 +52,7 @@ Proof.
   { instantiate (2 := "main"). reflexivity. }
   { reflexivity. }
   { ZnWords. }
-  { refine (@WeakestPreconditionProperties.Proper_cmd _ StateMachineSemantics.ok _ _ _ _ _ _ _ _ _ _ _).
+  { refine (WeakestPreconditionProperties.Proper_cmd _ _ _ _ _ _ _ _ _ _ _).
     1: eapply WeakestPreconditionProperties.Proper_call.
     2: {
       eapply main_correct. 1: eassumption.

--- a/firmware/IncrementWait/IncrementWaitToRiscVProperties.v
+++ b/firmware/IncrementWait/IncrementWaitToRiscVProperties.v
@@ -32,37 +32,33 @@ Definition post_main
      * scalar (word.of_Z output_ptr) (proc input)
      * R)%sep m'.
 
-Lemma main_correct
-      fs input output_placeholder
-      R (t : trace) m l :
+Lemma main_correct fs input output_placeholder R (t : trace) m :
   (scalar (word.of_Z input_ptr) input
    * scalar (word.of_Z output_ptr) output_placeholder
    * R)%sep m ->
   execution t IDLE ->
   WeakestPrecondition.cmd
     (WeakestPrecondition.call (put_wait_get :: fs))
-    main_body t m l
-    (fun t' m' _ => post_main input output_placeholder R t' m').
+    main_body t m map.empty
+    (fun t' m' (_: ProgramSemantics32.locals) => post_main input output_placeholder R t' m').
 Proof.
   intros.
   repeat straightline.
   pose proof (put_wait_get_correct fs).
   straightline_call; [ eassumption .. | ].
-  repeat straightline_with_map_lookup.
-  eexists; split; repeat straightline_with_map_lookup; [ ].
+  repeat straightline.
   split; [ assumption | ].
   ecancel_assumption.
 Qed.
 
-Lemma exec_put_wait_get fs input output_placeholder R
-      (t : trace) (m : mem) (l : ProgramSemantics32.locals) mc :
+Lemma exec_put_wait_get fs input output_placeholder R (t : trace) (m : mem) mc :
   (scalar (word.of_Z input_ptr) input
    * scalar (word.of_Z output_ptr) output_placeholder
    * R)%sep m ->
   execution t IDLE ->
   NoDup (map fst (main :: put_wait_get :: fs)) ->
   exec (map.of_list (main :: put_wait_get :: fs))
-       main_body t m l mc
+       main_body t m map.empty mc
        (fun t' m' _ _ => post_main input output_placeholder R t' m').
 Proof.
   intros. apply sound_cmd; [ assumption | ].

--- a/firmware/IncrementWait/RunIncrementWaitSoftwareOnCava.v
+++ b/firmware/IncrementWait/RunIncrementWaitSoftwareOnCava.v
@@ -10,12 +10,12 @@ Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.InstructionCoercions.
 Open Scope ilist_scope.
 
-Definition code_start    : Utility.word := word.of_Z 0.
-Definition code_pastend  : Utility.word := word.of_Z (4*2^10).
-Definition heap_start    : Utility.word := word.of_Z (4*2^10).
-Definition heap_pastend  : Utility.word := word.of_Z (8*2^10).
-Definition stack_start   : Utility.word := word.of_Z (8*2^10).
-Definition stack_pastend : Utility.word := word.of_Z (16*2^10).
+Definition code_start    : word := word.of_Z 0.
+Definition code_pastend  : word := word.of_Z (4*2^10).
+Definition heap_start    : word := word.of_Z (4*2^10).
+Definition heap_pastend  : word := word.of_Z (8*2^10).
+Definition stack_start   : word := word.of_Z (8*2^10).
+Definition stack_pastend : word := word.of_Z (16*2^10).
 
 Definition main_relative_pos :=
   match map.get (snd (fst put_wait_get_compile_result)) (fst main) with
@@ -23,7 +23,7 @@ Definition main_relative_pos :=
   | None => -1111
   end.
 
-Definition p_call: Utility.word :=
+Definition p_call: word :=
   word.add code_start (word.of_Z (4 * Z.of_nat (List.length put_wait_get_asm))).
 
 Definition all_insts: list Instruction :=

--- a/firmware/LibBase/AbsMMIOProperties.v
+++ b/firmware/LibBase/AbsMMIOProperties.v
@@ -24,8 +24,8 @@ Require Import Bedrock2Experiments.Tactics.
 Require Import Bedrock2Experiments.WhileProperties.
 Require Import Bedrock2Experiments.Word.
 Require Import Bedrock2Experiments.WordProperties.
+Require Import Bedrock2Experiments.ProgramSemantics32.
 Require Import Bedrock2Experiments.LibBase.AbsMMIO.
-Require Import coqutil.Map.SortedListString.
 Require Import Bedrock2Experiments.StateMachineSemantics.
 Require Import Bedrock2Experiments.StateMachineProperties.
 Import Syntax.Coercions List.ListNotations.
@@ -35,15 +35,15 @@ Local Open Scope Z_scope.
 
 
 Section Proof.
-  Context {width word mem} {p : StateMachineSemantics.parameters width word mem}.
-  Context {p_ok : StateMachineSemantics.parameters.ok p}.
-  Import parameters.
+  Context {word: word.word 32} {mem: map.map word Byte.byte}
+          {word_ok: word.ok word} {mem_ok: map.ok mem}
+          {M: state_machine.parameters} {M_ok: state_machine.ok M}.
 
   Global Instance spec_of_abs_mmio_write8 : spec_of "abs_mmio_write8" :=
     fun function_env =>
-      forall (tr : trace) (m : mem) (s : state) (s' : state) (addr : word) (value : word) r,
-        StateMachineSemantics.parameters.reg_addr r = addr ->
-        parameters.write_step 1 s r value s' ->
+      forall (tr : trace) (m : mem) (s : M) (s' : M) (addr : word) (value : word) r,
+        state_machine.reg_addr r = addr ->
+        state_machine.write_step 1 s r value s' ->
         execution tr s ->
         call function_env abs_mmio_write8 tr m [addr; value]
         (fun tr' m' rets =>
@@ -64,9 +64,9 @@ Section Proof.
 
   Global Instance spec_of_abs_mmio_write32 : spec_of "abs_mmio_write32" :=
     fun function_env =>
-      forall (tr : trace) (m : mem) (s : state) (s' : state) (addr : word) (value : word) r,
-        StateMachineSemantics.parameters.reg_addr r = addr ->
-        parameters.write_step 4 s r value s' ->
+      forall (tr : trace) (m : mem) (s : M) (s' : M) (addr : word) (value : word) r,
+        state_machine.reg_addr r = addr ->
+        state_machine.write_step 4 s r value s' ->
         execution tr s ->
         call function_env abs_mmio_write32 tr m [addr; value]
         (fun tr' m' rets =>
@@ -87,9 +87,9 @@ Section Proof.
 
   Global Instance spec_of_abs_mmio_read8 : spec_of "abs_mmio_read8" :=
     fun function_env =>
-      forall (tr : trace) (m : mem) (s : state) (addr : word) r val s',
-        StateMachineSemantics.parameters.reg_addr r = addr ->
-        parameters.read_step 1 s r val s' ->
+      forall (tr : trace) (m : mem) (s : M) (addr : word) r val s',
+        state_machine.reg_addr r = addr ->
+        state_machine.read_step 1 s r val s' ->
         execution tr s ->
         call function_env abs_mmio_read8 tr m [addr]
         (fun tr' m' rets =>
@@ -106,15 +106,14 @@ Section Proof.
     eapply (interact_read 1); repeat straightline; eauto.
     - rewrite <- H. reflexivity.
     - do 3 eexists; ssplit; eauto.
-      cbv [parameters.read_step ] in *.
       rewrite <- H. reflexivity.
   Qed.
 
   Global Instance spec_of_abs_mmio_read32 : spec_of "abs_mmio_read32" :=
     fun function_env =>
-      forall (tr : trace) (m : mem) (s : state) (addr : word) r val s',
-        StateMachineSemantics.parameters.reg_addr r = addr ->
-        parameters.read_step 4 s r val s' ->
+      forall (tr : trace) (m : mem) (s : M) (addr : word) r val s',
+        state_machine.reg_addr r = addr ->
+        state_machine.read_step 4 s r val s' ->
         execution tr s ->
         call function_env abs_mmio_read32 tr m [addr]
         (fun tr' m' rets =>
@@ -131,7 +130,6 @@ Section Proof.
     eapply (interact_read 4); repeat straightline; eauto.
     - rewrite <- H. reflexivity.
     - do 3 eexists; ssplit; eauto.
-      cbv [parameters.read_step ] in *.
       rewrite <- H. reflexivity.
   Qed.
 

--- a/firmware/LibBase/BitfieldProperties.v
+++ b/firmware/LibBase/BitfieldProperties.v
@@ -20,6 +20,7 @@ Require Import coqutil.Tactics.Tactics.
 Require Import coqutil.Tactics.syntactic_unify.
 Require Import coqutil.Tactics.letexists.
 Require Import coqutil.Z.Lia.
+Require Import Bedrock2Experiments.ProgramSemantics32.
 Require Import Bedrock2Experiments.Tactics.
 Require Import Bedrock2Experiments.WhileProperties.
 Require Import Bedrock2Experiments.Word.
@@ -32,11 +33,13 @@ Local Open Scope list_scope.
 Local Open Scope Z_scope.
 
 Section Proof.
-  Context {p : parameters} {p_ok : parameters_ok p}.
+  Context {word: word.word 32} {mem: map.map word Byte.byte}
+          {word_ok: word.ok word} {mem_ok: map.ok mem}
+          {ext_spec: ExtSpec} {ext_spec_ok: ext_spec.ok ext_spec}.
 
   Global Instance spec_of_bitfield_field32_read : spec_of "b2_bitfield_field32_read" :=
     fun function_env =>
-      forall (field mask index : Semantics.word) (m : mem) (t : trace),
+      forall (field mask index : word) (m : mem) (t : trace),
         call function_env bitfield_field32_read t m [field; mask; index]
           (fun t' m' rets =>
           t = t' /\ m = m' /\ rets = [select_bits field index mask]
@@ -52,7 +55,7 @@ Section Proof.
 
   Global Instance spec_of_bitfield_bit32_read : spec_of "b2_bitfield_bit32_read" :=
     fun function_env =>
-      forall (field : Semantics.word) (index: Semantics.word) (m : mem) (t : trace),
+      forall (field : word) (index: word) (m : mem) (t : trace),
         call function_env bitfield_bit32_read t m [field; index]
           (fun t' m' rets =>
           t = t' /\ m = m' /\
@@ -63,20 +66,10 @@ Section Proof.
     program_logic_goal_for_function! bitfield_bit32_read.
   Proof.
     repeat straightline.
-    eexists; ssplit; repeat straightline.
-    {
-      (* TODO: here we can't proceed with straightline so use straightline_with_map_lookup.
-         make it a bit verbose so that we can see where it's needed explicitly. *)
-      straightline_with_map_lookup.
-      repeat straightline.
-      straightline_with_map_lookup.
-      repeat straightline.
-    }
     (* call bitfield_field32_read *)
     straightline_call; eauto; try reflexivity; [ ].
-
-    repeat straightline_with_map_lookup.
+    unfold select_bits in *.
+    repeat straightline.
     repeat split; try reflexivity.
   Qed.
-
 End Proof.

--- a/firmware/LibBase/BitfieldProperties.v
+++ b/firmware/LibBase/BitfieldProperties.v
@@ -49,7 +49,6 @@ Section Proof.
     program_logic_goal_for_function! bitfield_field32_read.
   Proof.
     repeat straightline.
-    eexists; ssplit; repeat straightline_with_map_lookup.
     repeat split; try reflexivity.
   Qed.
 

--- a/firmware/ProgramSemantics32.v
+++ b/firmware/ProgramSemantics32.v
@@ -1,0 +1,22 @@
+Require Import Coq.ZArith.ZArith. Open Scope Z_scope.
+Require Import coqutil.Word.Interface.
+Require Import coqutil.Word.Bitwidth32.
+Require Import coqutil.Map.Interface.
+Require Import coqutil.Map.SortedListString.
+Require Import bedrock2.Syntax.
+
+Instance locals{word: word.word 32}: map.map String.string word := SortedListString.map _.
+Instance env: map.map String.string (list String.string * list String.string * cmd) :=
+  SortedListString.map _.
+
+Instance locals_ok{word: word.word 32}{word_ok: word.ok word}: map.ok locals := SortedListString.ok _.
+Instance env_ok: map.ok env := SortedListString.ok _.
+
+Arguments locals: simpl never.
+Arguments env: simpl never.
+
+(* See https://github.com/mit-plv/bedrock2/pull/180,
+       https://github.com/mit-plv/bedrock2/issues/193,
+       https://github.com/coq/coq/issues/14707 *)
+#[global] Hint Mode word.word - : typeclass_instances.
+#[global] Hint Mode map.map - - : typeclass_instances.

--- a/firmware/Riscv/MetricMinimalMMIO.v
+++ b/firmware/Riscv/MetricMinimalMMIO.v
@@ -29,7 +29,7 @@ Section Riscv.
   Import List.
   Import free.
 
-  Context {W: Words}.
+  Context {width: Z} {BW: Bitwidth width} {word: word width} {word_ok: word.ok word}.
   Context {Mem: map.map word byte}.
   Context {Registers: map.map Register word}.
 
@@ -77,8 +77,8 @@ Section Riscv.
   {
     Primitives.mcomp_sat := @free.interp _ _ _ interp_action;
     Primitives.is_initial_register_value x := True;
-    Primitives.nonmem_load := @Primitives.nonmem_load _ _ _ _ _ MinimalMMIOPrimitivesParams;
-    Primitives.nonmem_store := @Primitives.nonmem_store _ _ _ _ _ MinimalMMIOPrimitivesParams;
+    Primitives.nonmem_load := Primitives.nonmem_load (PrimitivesParams := MinimalMMIOPrimitivesParams);
+    Primitives.nonmem_store := Primitives.nonmem_store (PrimitivesParams := MinimalMMIOPrimitivesParams);
     Primitives.valid_machine mach :=
       map.undef_on mach.(getMem) isMMIOAddr /\
       PropSet.disjoint (PropSet.of_list mach.(getXAddrs)) isMMIOAddr;

--- a/firmware/Riscv/MinimalMMIO.v
+++ b/firmware/Riscv/MinimalMMIO.v
@@ -36,7 +36,7 @@ Require Import riscv.Platform.Sane.
 Local Open Scope Z_scope.
 Local Open Scope bool_scope.
 
-Class MMIOSpec{W: Words} {Mem : map.map word byte} := {
+Class MMIOSpec{width: Z}{BW: Bitwidth width}{word: word width}{Mem : map.map word byte} := {
   (* should not say anything about alignment, just whether it's in the MMIO range *)
   isMMIOAddr: word -> Prop;
 
@@ -54,7 +54,8 @@ Definition natToStr(n: nat): string := DecimalString.NilEmpty.string_of_uint (Na
 
 Section Riscv.
   Import free.
-  Context {W: Words} {Mem: map.map word byte} {Registers: map.map Register word}.
+  Context {width: Z} {BW: Bitwidth width} {word: word width} {word_ok: word.ok word}.
+  Context {Mem: map.map word byte} {Registers: map.map Register word}.
 
   Definition mmioLoadEvent(addr: word){n: nat}(v: HList.tuple byte n): LogItem :=
     ((map.empty, ("MMIOREAD" ++ natToStr (n * 8))%string, [addr]),

--- a/firmware/RiscvMachineWithCavaDevice/ExtraRiscvMachine.v
+++ b/firmware/RiscvMachineWithCavaDevice/ExtraRiscvMachine.v
@@ -12,8 +12,7 @@ Require Import riscv.Platform.RiscvMachine.
 Notation Register := Z (only parsing).
 
 Section Machine.
-
-  Context {W: Words}.
+  Context {width: Z} {BW: Bitwidth width} {word: word width} {word_ok: word.ok word}.
   Context {Registers: map.map Register word}.
   Context {Mem: map.map word byte}.
   Context {E: Type}. (* extra state (eg for devices) *)
@@ -60,4 +59,4 @@ Section Machine.
       (mkExtraRiscvMachine (withLogItems items mach) e).
 
 End Machine.
-Arguments ExtraRiscvMachine {_} {_} {_} _.
+Arguments ExtraRiscvMachine {_ _ _ _ _} _.

--- a/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
+++ b/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
@@ -20,6 +20,7 @@ Require Export riscv.Platform.MaterializeRiscvProgram.
 Require Export Bedrock2Experiments.RiscvMachineWithCavaDevice.ExtraRiscvMachine.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Map.Interface.
+Require Import coqutil.Word.Bitwidth32.
 Require Import riscv.Platform.Sane.
 
 Local Open Scope Z_scope.
@@ -112,11 +113,6 @@ End WithParams. End word.
 Section WithParams.
   Context {word: Interface.word.word 32}.
   Context {word_ok: word.ok word}.
-
-  Global Instance mkWords: Words := {|
-    Utility.word := word;
-    Utility.width_cases := or_introl eq_refl;
-  |}.
 
   Context {D: device}.
   Context {mem: map.map word byte}.

--- a/firmware/StateMachineMMIOSpec.v
+++ b/firmware/StateMachineMMIOSpec.v
@@ -7,42 +7,43 @@ Require Import coqutil.Map.Interface coqutil.Word.Interface.
 Require Import riscv.Utility.Utility.
 Require Import Bedrock2Experiments.Riscv.MinimalMMIO.
 Require Import Bedrock2Experiments.Riscv.MetricMinimalMMIO.
+Require Import Bedrock2Experiments.ProgramSemantics32.
 Require Import Bedrock2Experiments.StateMachineSemantics.
 
-Instance StateMachineMMIOSpec{W: Words}{mem: map.map word byte}
-         {parameters: StateMachineSemantics.parameters width word mem}: MMIOSpec :=
-  {| isMMIOAddr := parameters.isMMIOAddr;
+Instance StateMachineMMIOSpec{word: word.word 32}{mem: map.map word Byte.byte}
+         {M: state_machine.parameters}: MMIOSpec :=
+  {  isMMIOAddr := state_machine.isMMIOAddr;
      isMMIOAligned n a := word.unsigned a mod (Z.of_nat n) = 0;
      MMIOReadOK :=
        fun sz log addr val =>
          exists s s' r,
            execution log s
-           /\ parameters.reg_addr r = addr
-           /\ parameters.read_step sz s r val s';
+           /\ state_machine.reg_addr r = addr
+           /\ state_machine.read_step sz s r val s';
      MMIOWriteOK :=
        fun sz log addr val =>
          exists s s' r,
            execution log s
-           /\ parameters.reg_addr r = addr
-           /\ parameters.write_step sz s r val s';
-  |}.
+           /\ state_machine.reg_addr r = addr
+           /\ state_machine.write_step sz s r val s';
+  }.
 
 Section TODO_Why_not_like_this. (* (would also require a corresponding update in ext_spec) *)
-  Instance StateMachineMMIOSpec_Alt{W: Words}{mem: map.map word byte}
-           {parameters: StateMachineSemantics.parameters width word mem}: MMIOSpec :=
-    {| isMMIOAddr := parameters.isMMIOAddr;
+  Instance StateMachineMMIOSpec_Alt{word: word.word 32}{mem: map.map word Byte.byte}
+           {M: state_machine.parameters}: MMIOSpec :=
+    {| isMMIOAddr := state_machine.isMMIOAddr;
        isMMIOAligned n a := word.unsigned a mod (Z.of_nat n) = 0;
        MMIOReadOK :=
          fun sz log addr val =>
-           exists r, parameters.reg_addr r = addr /\
+           exists r, state_machine.reg_addr r = addr /\
                      (* for all states s that could be the explanation of the trace t,
                         this read_step must be possible *)
-                     forall s, execution log s -> exists s', parameters.read_step sz s r val s';
+                     forall s, execution log s -> exists s', state_machine.read_step sz s r val s';
        MMIOWriteOK :=
          fun sz log addr val =>
-           exists r, parameters.reg_addr r = addr /\
+           exists r, state_machine.reg_addr r = addr /\
                      (* for all states s that could be the explanation of the trace t,
                         this write_step must be possible *)
-                     forall s, execution log s -> exists s', parameters.write_step sz s r val s';
+                     forall s, execution log s -> exists s', state_machine.write_step sz s r val s';
     |}.
 End TODO_Why_not_like_this.

--- a/firmware/WhileProperties.v
+++ b/firmware/WhileProperties.v
@@ -7,6 +7,7 @@ Require Import bedrock2.WeakestPrecondition.
 Require Import bedrock2.WeakestPreconditionProperties.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Word.Properties.
+Require Import coqutil.Word.Bitwidth.
 Require Import coqutil.Map.Interface.
 Require Import coqutil.Tactics.letexists.
 Require Import coqutil.Tactics.Tactics.
@@ -16,7 +17,14 @@ Local Open Scope Z_scope.
 (* Proofs about cmd.while *)
 
 Section Proofs.
-  Context {p : Semantics.parameters} {p_pk : Semantics.parameters_ok p}.
+  Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}.
+  Context {locals: map.map String.string word}.
+  Context {env: map.map String.string (list String.string * list String.string * Syntax.cmd)}.
+  Context {ext_spec: ExtSpec}.
+  Context {word_ok : word.ok word} {mem_ok : map.ok mem}.
+  Context {locals_ok : map.ok locals}.
+  Context {env_ok : map.ok env}.
+  Context {ext_spec_ok : Semantics.ext_spec.ok ext_spec}.
 
   Fixpoint repeat_logic_step
            (logic : trace -> mem -> locals ->


### PR DESCRIPTION
This PR updates bedrock2 to a new version that uses individual parameters instead of parameter records, and also replaces the parameter records in `firmware` by individual parameters.

While this results in slightly longer lists of `Context` variables at `Section` heads, it saves us from writing parameter record transformer instances, and solves all implicit parameter mismatch problems.

A few examples (from the diff of this PR) of how things become simpler:

```
execution (p := state_machine_parameters) (getLog initial) IDLE
```

becomes just

```
execution (getLog initial) IDLE
```

Beasts like eg this one

```coq
  (* change the implicit arguments of scalar to match hypothesis *)
  lazymatch goal with
  | H : sep _ _ ?m |- sep _ _ ?m =>
    lazymatch type of H with
    | context [(@scalar ?a1 ?b1 ?c1)] =>
      lazymatch goal with
      | |- context [(@scalar ?a2 ?b2 ?c2)] =>
        change a2 with a1; change b2 with b1; change c2 with c1
      end
    end
  end.
  subst a2.

  use_sep_assumption.
  cancel.
  cancel_seps_at_indices 0%nat 0%nat. 1: reflexivity.
  reflexivity.
```

now can be replaced by just

```coq
  ecancel_assumption.
```

and this one

```coq
    (* store result in memory *)
    simplify_implicits.
    ring_simplify_store_addr.
    (* the following line is in [straightline] but needs simplify_implicits for
       it to work *)
    eapply store_four_of_sep;
      [ simplify_implicits; solve [ ecancel_assumption ] |  ].
    repeat straightline.
```

now is just

```coq
    (* store result in memory *)
    ring_simplify_store_addr.
    repeat straightline.
```
