### PR TITLE
Better support for typechecking Cava constants

### DIFF
--- a/investigations/cava2/Fib.v
+++ b/investigations/cava2/Fib.v
@@ -35,13 +35,11 @@ Section Var.
     fun a => (a, a)
   }}.
 
-  Definition fib_init sz := val_of (BitVec sz) (2^(N.of_nat sz)-1).
-
   Definition fibonacci {sz: nat}: Circuit (BitVec sz ** BitVec sz) [] (BitVec sz) := {{
     let/delay r1 :=
-      let r2 := delay r1 initially (fib_init sz) in
+      let r2 := delay r1 initially (2^(N.of_nat sz)-1) in
       r1 + r2
-      initially (val_of (BitVec sz) 1) in
+      initially 1 in
     r1
   }}.
 End Var.
@@ -76,7 +74,8 @@ Lemma fibonacci_step sz state input :
     let sum := (fst state + snd state) mod (2 ^ N.of_nat sz) in
     (sum, fst state, sum).
 Proof.
-  intros; cbn [step fibonacci Bv2N Vector.of_list Primitives.binary_semantics ].
+  intros.
+  cbn [step fibonacci Bv2N Vector.of_list Primitives.binary_semantics Constant Delay LetDelay cast].
   repeat (destruct_pair_let; cbn [split_absorbed_denotation combine_absorbed_denotation List.app absorb_any fst snd ]).
   reflexivity.
 Qed.
@@ -145,4 +144,3 @@ Proof.
     autorewrite with push_length.
     erewrite <-list_unit_equiv. reflexivity. }
 Qed.
-

--- a/investigations/cava2/Hmac.v
+++ b/investigations/cava2/Hmac.v
@@ -38,8 +38,8 @@ Section Var.
   Definition hmac_register_index := 5%nat.
   Definition hmac_register := BitVec hmac_register_index.
 
-  Definition REG_INTR_STATE := Constant (0: denote_type hmac_register).
-  Definition REG_CMD := Constant (5: denote_type hmac_register).
+  Definition REG_INTR_STATE : Circuit [] [] hmac_register := Constant 0.
+  Definition REG_CMD : Circuit [] [] hmac_register := Constant 5.
 
   Definition hmac_top : Circuit _ [tl_h2d_t] tl_d2h_t := {{
     fun incoming_tlp =>
@@ -50,7 +50,7 @@ Section Var.
         := `tlul_adapter_reg` incoming_tlp registers in
       let aligned_address := `slice 2 5` write_address in
 
-      let fifo_write := write_address >= `Constant (2048: denote_type (BitVec _))` in
+      let fifo_write := write_address >= `Constant 2048` in
 
       (* TODO(blaxill): ignore/mask writes to CMD etc ? *)
       (* TODO(blaxill): apply mask to register writes*)
@@ -62,10 +62,10 @@ Section Var.
 
       (* cmd_start is set when host writes to hmac.CMD.hash_start *)
       (* and signifies the start of a new message *)
-      let cmd_start := write_en && aligned_address == `REG_CMD` && write_data == `_1` && !fifo_write in
+      let cmd_start := write_en && aligned_address == `REG_CMD` && write_data == `Constant 1` && !fifo_write in
       (* cmd_process is set when host writes to hmac.CMD.hash_process *)
       (* and signifies the end of a message *)
-      let cmd_process := write_en && aligned_address == `REG_CMD` && write_data == `_2` && !fifo_write in
+      let cmd_process := write_en && aligned_address == `REG_CMD` && write_data == `Constant 2` && !fifo_write in
 
       let '(packer_valid; packer_data)
         := `tlul_pack` (write_en && fifo_write) write_data write_mask cmd_process in
@@ -84,4 +84,3 @@ Section Var.
   }}.
 
 End Var.
-

--- a/investigations/cava2/Semantics.v
+++ b/investigations/cava2/Semantics.v
@@ -51,13 +51,13 @@ Fixpoint step {i s o} (c : Circuit s i o)
     let '(nsx, x) := step x sx tt in
     let '(nsf, o) := step f sf (x, i) in
     (combine_absorbed_denotation nsx nsf, o)
-  | Delay _ => fun s '(i,tt) => (i, s)
+  | DelayRaw _ => fun s '(i,tt) => (i, s)
   | Let x f => fun s i =>
     let '(sx, sf) := split_absorbed_denotation s in
     let '(nsx, x) := step x sx tt in
     let '(nsf, o) := step (f x) sf i in
     (combine_absorbed_denotation nsx nsf, o)
-  | LetDelay _ x f => fun s i =>
+  | LetDelayRaw _ x f => fun s i =>
     let '(sx, s12) := split_absorbed_denotation s in
     let '(s1, s2) := split_absorbed_denotation s12 in
 
@@ -81,7 +81,7 @@ Fixpoint step {i s o} (c : Circuit s i o)
     let '(nsf, x) := step f sf tt in
     let '(nsg, y) := step g sg tt in
     (combine_absorbed_denotation nsf nsg, (x,y))
-  | Constant v => fun _ _ =>
+  | ConstantRaw v => fun _ _ =>
     (tt, v)
   | UnaryOp op x => fun _ _ => (tt, unary_semantics op x)
   | BinaryOp op x y => fun _ _ => (tt, binary_semantics op x y)
@@ -94,12 +94,12 @@ Fixpoint reset_state {i s o} (c : Circuit (var:=denote_type) s i o) : denote_typ
   | Abs f => reset_state (f default)
   | App f x => combine_absorbed_denotation (reset_state x) (reset_state f)
   | Let x f => combine_absorbed_denotation (reset_state x) (reset_state (f default))
-  | LetDelay initial x f =>
+  | LetDelayRaw initial x f =>
     combine_absorbed_denotation initial
       (combine_absorbed_denotation (reset_state (x default)) (reset_state (f default)))
-  | Delay initial => initial
+  | DelayRaw initial => initial
   | MakeTuple f g => combine_absorbed_denotation (reset_state f) (reset_state g)
-  | Constant _ => tt
+  | ConstantRaw _ => tt
   | ElimPair f _ =>  reset_state (f default default)
   | ElimBool b f g => combine_absorbed_denotation (reset_state f) (reset_state g)
   | UnaryOp op x => tt
@@ -110,4 +110,3 @@ Fixpoint reset_state {i s o} (c : Circuit (var:=denote_type) s i o) : denote_typ
 Definition simulate {s i o} (c : Circuit (var:=denote_type) s i o) (input : list (denote_type i))
   : list (denote_type o) :=
     fold_left_accumulate (step c) input (reset_state c).
-

--- a/investigations/cava2/TLUL.v
+++ b/investigations/cava2/TLUL.v
@@ -102,17 +102,17 @@ Section Var.
   (*   Get            = 3'h 4 *)
   (* } tl_a_op_e; *)
   Definition tl_a_op_e      := Vec Bit 3.
-  Definition PutFullData    := Constant (0: denote_type tl_a_op_e).
-  Definition PutPartialData := Constant (1: denote_type tl_a_op_e).
-  Definition Get            := Constant (4: denote_type tl_a_op_e).
+  Definition PutFullData    : Circuit [] [] tl_a_op_e := Constant 0.
+  Definition PutPartialData : Circuit [] [] tl_a_op_e := Constant 1.
+  Definition Get            : Circuit [] [] tl_a_op_e := Constant 4.
 
   (* typedef enum logic [2:0] { *)
   (*   AccessAck     = 3'h 0, *)
   (*   AccessAckData = 3'h 1 *)
   (* } tl_d_op_e; *)
   Definition tl_d_op_e     := Vec Bit 3.
-  Definition AccessAck     := Constant (0: denote_type tl_d_op_e).
-  Definition AccessAckData := Constant (1: denote_type tl_d_op_e).
+  Definition AccessAck     : Circuit [] [] tl_d_op_e := Constant 0.
+  Definition AccessAckData : Circuit [] [] tl_d_op_e := Constant 1.
 
   Definition io_req :=
     Bit **          (* write *)
@@ -156,8 +156,8 @@ Section Var.
         (a_opcode == `PutFullData` || a_opcode == `PutPartialData`) in
 
       (* TODO(blaxill): skipping malformed tl packet detection *)
-      let err_internal := `False` in
-      let error_i := `False` in
+      let err_internal := `Constant false` in
+      let error_i := `Constant false` in
 
       let '(reqid, reqsz, rspop, error; outstanding) :=
         if a_ack then
@@ -165,10 +165,10 @@ Section Var.
           , a_size
           , if rd_req then `AccessAckData` else `AccessAck`
           , error_i || err_internal
-          , `False`
+          , `Constant false`
           )
         else
-          (reqid, reqsz, rspop, error, if d_ack then `False` else outstanding)
+          (reqid, reqsz, rspop, error, if d_ack then `Constant false` else outstanding)
       in
 
       let we_o := wr_req && !err_internal in
@@ -176,7 +176,6 @@ Section Var.
 
       (reqid, reqsz, rspop, error, outstanding, we_o, re_o)
       initially (0,(0,(0,(false,(false,(false,false))))))
-        : denote_type (BitVec _ ** BitVec _ ** BitVec _ ** Bit ** Bit ** Bit ** Bit)
     in
 
     let wdata_o := a_data in
@@ -184,12 +183,12 @@ Section Var.
 
     ( ( outstanding
       , rspop
-      , `_0`
+      , `Constant 0`
       , reqsz
       , reqid
-      , `_0`
+      , `Constant 0`
       , `index` registers (`slice 2 30` a_address)
-      , `_0`
+      , `Constant 0`
       , error
       , !outstanding
       )
@@ -206,4 +205,3 @@ Section Var.
   }}.
 
 End Var.
-

--- a/investigations/cava2/Types.v
+++ b/investigations/cava2/Types.v
@@ -181,52 +181,17 @@ Notation "[ x ; y ; .. ; z ]" := (Pair x (Pair y .. (Pair z Unit) ..)) : circuit
 Notation "x ** y" := (Pair x y)(at level 60, right associativity) : circuit_type_scope.
 Notation "x ++ y" := (absorb_any x y) (at level 60, right associativity): circuit_type_scope.
 
-
-Inductive denote_rel: type -> Type -> Type :=
-| denote_Unit: denote_rel Unit unit
-| denote_Bit: denote_rel Bit bool
-| denote_Vec_of_Unit: forall n,
-    denote_rel (Vec Unit n) unit
-| denote_Vec_of_Bit: forall n,
-    denote_rel (Vec Bit n) N
-| denote_Vec_of_Vec: forall t T n m,
-    denote_rel (Vec t m) T ->
-    denote_rel (Vec (Vec t m) n) (list T)
-| denote_Vec_of_Pair: forall t1 t2 T n,
-    denote_rel (Pair t1 t2) T ->
-    denote_rel (Vec (Pair t1 t2) n) (list T)
-| denote_Pair: forall x y X Y,
-    denote_rel x X -> denote_rel y Y -> denote_rel (Pair x y) (X * Y).
-
-Lemma denote_rel_to_denote_type: forall t T, denote_rel t T -> T = denote_type t.
-Proof. induction 1; subst; try reflexivity. Qed.
-
-Fixpoint denote_rel_of_denote_type(t: type): denote_rel t (denote_type t) :=
-  match t with
-  | Unit => denote_Unit
-  | Bit => denote_Bit
-  | Vec t1 n =>
-    match t1
-      return denote_rel t1 (denote_type t1) -> denote_rel (Vec t1 n) (denote_type (Vec t1 n))
-    with
-    | Unit => fun r => denote_Vec_of_Unit n
-    | Bit => fun r => denote_Vec_of_Bit n
-    | Vec t2 m => fun r => denote_Vec_of_Vec t2 (denote_type (Vec t2 m)) n m r
-    | Pair x y => fun r  => denote_Vec_of_Pair _ _ _ n r
-    end (denote_rel_of_denote_type t1)
-  | Pair x y => denote_Pair x y _ _ (denote_rel_of_denote_type x) (denote_rel_of_denote_type y)
-  end.
+(* `denote_type` as a relation (but living in `Type` instead of `Prop`
+   so that we can compute on it.
+   Similar to Logic.eq, but a separate definition, because we don't want to mark Logic.eq
+   as a typeclass. *)
+Inductive denote_rel(t: type): Type -> Type :=
+  mk_denote_rel: denote_rel t (denote_type t).
 
 Existing Class denote_rel.
-Existing Instance denote_rel_of_denote_type.
+Existing Instance mk_denote_rel.
 
-Fixpoint cast{x X}(dx: denote_rel x X){struct dx}: X -> denote_type x :=
+Definition cast{x X}(dx: denote_rel x X): X -> denote_type x :=
   match dx with
-  | denote_Unit => id
-  | denote_Bit => id
-  | denote_Vec_of_Unit _ => id
-  | denote_Vec_of_Bit _ => id
-  | denote_Vec_of_Vec t T n m dV => List.map (cast dV)
-  | denote_Vec_of_Pair t1 t2 T n dt => List.map (cast dt)
-  | denote_Pair x y X Y d1 d2 => fun '(e1, e2) => (cast d1 e1, cast d2 e2)
+  | mk_denote_rel _ => id
   end.


### PR DESCRIPTION
Currently,

```coq
Check (Constant 1 : Circuit [] [] (BitVec 32)).
```

yields

```
Error:
In environment
var : tvar
The term "1" has type "N" while it is expected to have type "denote_type ?x".
```

This PR adds a trick that makes the above `Check` succeed, as well as typechecking problems involving `LetDelay` and `Delay`, which suffer from the same problem.

`Constant`, `LetDelay` and `Delay` all expect an argument of type `denote_type ?x`, and even if the expression being typechecked has a known expected type like eg `Circuit [] [] (BitVec 32)`, Coq's typechecker does not propagate `(BitVec 32)` into the `?x` argument of `Constant`.

The trick is to temporarily give the typechecker an additional degree of freedom by introducing a variable type variable `X` for the type of the constant, and by requiring a constraint `denote_rel x X` whose purpose is to ensure that `denote_type x = X`, in a way which can be inferred by typeclass search, which, contrary to ordinary typechecking, does propagate `(BitVec 32)` from the expected type into the `?x` argument of `Constant`.

