### PR TITLE
make type argument of `Constant` explicit

### DIFF
--- a/investigations/cava2/Expr.v
+++ b/investigations/cava2/Expr.v
@@ -52,7 +52,7 @@ Section Vars.
     -> var (x**y)
     -> Circuit s [] z
 
-  | Constant: forall {x}, denote_type x -> Circuit [] [] x
+  | Constant: forall x, denote_type x -> Circuit [] [] x
   | MakePair: forall {s1 s2 x y}, Circuit s1 [] x
     -> Circuit s2 [] y
     -> Circuit (s1++s2) [] (x**y)
@@ -126,10 +126,9 @@ End ExprNotations.
 Section Var.
   Context {var : tvar}.
 
-  Definition True := Constant (true: denote_type Bit).
-  Definition False := Constant (false: denote_type Bit).
-  Definition K {sz}: N -> Circuit [] [] (BitVec sz) :=
-    fun x : denote_type (BitVec sz) => Constant x.
+  Definition True := Constant Bit true.
+  Definition False := Constant Bit false.
+  Definition K {sz}(x: N) := Constant (BitVec sz) x.
 
 End Var.
 
@@ -155,7 +154,7 @@ Section RegressionTests.
       if `silly_id` flag then (a) else a
   }}.
 
-  Definition inital_state {sz} := (0,1)%N : denote_type (BitVec sz ** BitVec sz).
+  Definition inital_state {sz} : denote_type (BitVec sz ** BitVec sz) := (0,1)%N.
 
   Definition test {sz: nat}: Circuit (BitVec 10**BitVec 10) [] (BitVec 10) := {{
     let/delay '(x;y) := (y,x) initially inital_state in y
@@ -247,7 +246,7 @@ Module PrimitiveNotations.
       BinaryOp BinVecConcat v1 v2
   ))) (in custom expr at level 19, right associativity) : expr_scope.
 
-  Notation "[ ]" := (Constant (simple_denote_to_denote (t:=Vec _ 0) nil)) (in custom expr at level 19) : expr_scope.
+  Notation "[ ]" := (Constant _ (simple_denote_to_denote (t:=Vec _ 0) nil)) (in custom expr at level 19) : expr_scope.
 
   Import ExprNotations.
   Definition index {var t n i}: Circuit (var:=var) [] [Vec t n; BitVec i] t :=

--- a/investigations/cava2/Fib.v
+++ b/investigations/cava2/Fib.v
@@ -35,7 +35,7 @@ Section Var.
     fun a => (a, a)
   }}.
 
-  Definition fib_init sz := 2^(N.of_nat sz)-1 : denote_type (BitVec sz).
+  Definition fib_init sz : denote_type (BitVec sz) := 2^(N.of_nat sz)-1.
 
   Definition fibonacci {sz: nat}: Circuit (BitVec sz ** BitVec sz) [] (BitVec sz) := {{
     let/delay r1 :=
@@ -147,4 +147,3 @@ Proof.
     autorewrite with push_length.
     erewrite <-list_unit_equiv. reflexivity. }
 Qed.
-

--- a/investigations/cava2/Fifo.v
+++ b/investigations/cava2/Fifo.v
@@ -52,7 +52,7 @@ Section Var.
 
     ( current_length >= `K 0`
     , `index` fifo (current_length - `K 1`)
-    , (current_length >= `Constant ((N.of_nat fifo_size - 1) : denote_type fifo_bits)` ) )
+    , (current_length >= `Constant fifo_bits (N.of_nat fifo_size - 1)` ) )
   }}.
 
 End Var.
@@ -110,4 +110,3 @@ Proof.
   rewrite fold_left_accumulate'_snd_acc_invariant with (acc_b:=[]%list).
   apply H0.
 Qed.
-

--- a/investigations/cava2/Hmac.v
+++ b/investigations/cava2/Hmac.v
@@ -38,8 +38,8 @@ Section Var.
   Definition hmac_register_index := 5%nat.
   Definition hmac_register := BitVec hmac_register_index.
 
-  Definition REG_INTR_STATE := Constant (0: denote_type hmac_register).
-  Definition REG_CMD := Constant (5: denote_type hmac_register).
+  Definition REG_INTR_STATE := Constant hmac_register 0.
+  Definition REG_CMD := Constant hmac_register 5.
 
   Definition hmac_top : Circuit _ [tl_h2d_t] tl_d2h_t := {{
     fun incoming_tlp =>
@@ -50,7 +50,7 @@ Section Var.
         := `tlul_adapter_reg` incoming_tlp registers in
       let aligned_address := `slice 2 5` write_address in
 
-      let fifo_write := write_address >= `Constant (2048: denote_type (BitVec _))` in
+      let fifo_write := write_address >= `Constant (BitVec _) 2048` in
 
       (* TODO(blaxill): ignore/mask writes to CMD etc ? *)
       (* TODO(blaxill): apply mask to register writes*)
@@ -73,7 +73,7 @@ Section Var.
       (* TODO(blaxill): FIX ME *)
       (* let '(_, padded_block; padded_valid) := `sha256_padder` packer_valid packer_data cmd_process `circuit_hole` cmd_start in *)
       (* TODO(blaxill): sha needs to block FIFO writes and process HMAC key first *)
-      (* let inital_digest := `Constant sha256_initial_digest` in *)
+      (* let inital_digest := `Constant _ sha256_initial_digest` in *)
       (* let '(digest; digest_valid) := `sha256_inner` padded_block padded_valid `circuit_hole` in *)
       (* let next_digest := if digest_valid then digest else digest_buffer in *)
 
@@ -84,4 +84,3 @@ Section Var.
   }}.
 
 End Var.
-

--- a/investigations/cava2/Semantics.v
+++ b/investigations/cava2/Semantics.v
@@ -81,8 +81,7 @@ Fixpoint step {i s o} (c : Circuit s i o)
     let '(nsf, x) := step f sf tt in
     let '(nsg, y) := step g sg tt in
     (combine_absorbed_denotation nsf nsg, (x,y))
-  | Constant v => fun _ _ =>
-    (tt, v)
+  | Constant _ v => fun _ _ => (tt, v)
   | UnaryOp op x => fun _ _ => (tt, unary_semantics op x)
   | BinaryOp op x y => fun _ _ => (tt, binary_semantics op x y)
   | TernaryOp op x y z => fun _ _ => (tt, ternary_semantics op x y z)
@@ -99,7 +98,7 @@ Fixpoint reset_state {i s o} (c : Circuit (var:=denote_type) s i o) : denote_typ
       (combine_absorbed_denotation (reset_state (x default)) (reset_state (f default)))
   | Delay initial => initial
   | MakePair f g => combine_absorbed_denotation (reset_state f) (reset_state g)
-  | Constant _ => tt
+  | Constant _ _ => tt
   | ElimPair f _ =>  reset_state (f default default)
   | ElimBool b f g => combine_absorbed_denotation (reset_state f) (reset_state g)
   | UnaryOp op x => tt
@@ -113,4 +112,3 @@ Definition simulate' {s i o} (c : Circuit (var:=denote_type) s i o) (input : lis
 
 Definition simulate {s i o} (c : Circuit (var:=denote_type) s i o) (input : list (denote_type i))
   : list (denote_type o) := fst (simulate' c input (reset_state c)).
-

--- a/investigations/cava2/TLUL.v
+++ b/investigations/cava2/TLUL.v
@@ -102,17 +102,17 @@ Section Var.
   (*   Get            = 3'h 4 *)
   (* } tl_a_op_e; *)
   Definition tl_a_op_e      := Vec Bit 3.
-  Definition PutFullData    := Constant (0: denote_type tl_a_op_e).
-  Definition PutPartialData := Constant (1: denote_type tl_a_op_e).
-  Definition Get            := Constant (4: denote_type tl_a_op_e).
+  Definition PutFullData    := Constant tl_a_op_e 0.
+  Definition PutPartialData := Constant tl_a_op_e 1.
+  Definition Get            := Constant tl_a_op_e 4.
 
   (* typedef enum logic [2:0] { *)
   (*   AccessAck     = 3'h 0, *)
   (*   AccessAckData = 3'h 1 *)
   (* } tl_d_op_e; *)
   Definition tl_d_op_e     := Vec Bit 3.
-  Definition AccessAck     := Constant (0: denote_type tl_d_op_e).
-  Definition AccessAckData := Constant (1: denote_type tl_d_op_e).
+  Definition AccessAck     := Constant tl_d_op_e 0.
+  Definition AccessAckData := Constant tl_d_op_e 1.
 
   Definition io_req :=
     Bit **          (* write *)
@@ -206,4 +206,3 @@ Section Var.
   }}.
 
 End Var.
-


### PR DESCRIPTION
This allows us to write constants without a cast, ie instead of `Constant (literal : denote_type T)` we simply can write `Constant T literal`, thus saving us a `:`, a pair of parentheses, and a `denote_type`.

In the rare cases where the value passed to `Constant` has already a type of the form `denote_type _`, this approach costs us one `_`: Instead of `Constant value`, we now have to write `Constant _ value`.

Compared to https://github.com/project-oak/silveroak/pull/868, this is still a bit more verbose, but has about one fewer bell and whistle :wink: