### PR TITLE
Robust testing for HMAC and SHA-256

### DIFF
--- a/silveroak-opentitan/hmac/Spec/HMAC.v
+++ b/silveroak-opentitan/hmac/Spec/HMAC.v
@@ -14,6 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
 Require Import Cava.Util.BitArithmetic.
@@ -75,8 +76,19 @@ Section HMAC_SHA256.
           (K : N) (* key *)
           (data : N).
 
+  (* From section 3:
+
+     The key for HMAC can be of any length (keys longer than B bytes are
+     first hashed using H). *)
+  Definition K0 : N := if (lK <=? B)%nat
+                       then K
+                       else sha256 (N.of_nat lK * 8) K.
+
+  (* length of K0 in bytes *)
+  Definition lK0 : nat := if (lK <=? B)%nat then lK else L.
+
   (* step 1 *)
-  Definition padded_key : N := N.shiftl K (N.of_nat ((B - lK) * 8)).
+  Definition padded_key : N := N.shiftl K0 (N.of_nat ((B - lK0) * 8)).
 
   (* lx = length of x in bytes, ly = length of y in bytes *)
   Definition H (lx ly : nat) (x y : N) :=

--- a/silveroak-opentitan/hmac/Spec/SHA256.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256.v
@@ -16,9 +16,7 @@
 
 Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
-Require Import Coq.Strings.String. (* for tests *)
 Require Import Coq.ZArith.ZArith.
-Require Import Cava.Util.String. (* for tests *)
 Import ListNotations.
 Local Open Scope N_scope.
 
@@ -236,18 +234,3 @@ Section WithMessage.
     let H := fold_left sha256_step (seq 0 n) H0 in
     concat_digest H.
 End WithMessage.
-
-(**** Test vectors from
-      https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA256.pdf ****)
-
-Goal (let msg := "abc"%string in
-      let l := N.of_nat (String.length msg * 8) in
-      let digest :=0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad in
-      sha256 l (string_to_N msg) = digest).
-Proof. vm_compute. reflexivity. Qed.
-
-Goal (let msg := "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"%string in
-      let l := N.of_nat (String.length msg * 8) in
-      let digest := 0x248D6A61D20638B8E5C026930C3E6039A33CE45964FF2167F6ECEDD419DB06C1 in
-      sha256 l (string_to_N msg) = digest).
-Proof. vm_compute. reflexivity. Qed.

--- a/silveroak-opentitan/hmac/Spec/Tests/HMACTestVectors.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/HMACTestVectors.v
@@ -1,0 +1,75 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.NArith.NArith.
+Local Open Scope N_scope.
+
+Record hmac_test_vector :=
+  { lK : nat;
+    ldata : nat;
+    K : N;
+    data : N;
+    expected_output : N }.
+
+Record hmac_step_by_step_test : Type :=
+  { test :> hmac_test_vector;
+    expected_padded_key : N;
+    (* K ^ ipad *)
+    expected_xor_K_ipad : N;
+    (* K ^ opad *)
+    expected_xor_K_opad : N;
+    (* inner hash result *)
+    expected_inner : N;
+  }.
+
+(**** Test vectors from
+      https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA256.pdf *)
+
+Definition test1 : hmac_step_by_step_test :=
+  {| test :=
+       {| lK := 64;
+          ldata := 34;
+          K := 0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F;
+          data := 0x53616D706C65206D65737361676520666F72206B65796C656E3D626C6F636B6C656E;
+          expected_output := 0x8BB9A1DB9806F20DF7F77B82138C7914D174D59E13DC4D0169C9057B133E1D62 |};
+     expected_padded_key := 0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F;
+     expected_xor_K_ipad := 0x36373435323330313E3F3C3D3A3B383926272425222320212E2F2C2D2A2B282916171415121310111E1F1C1D1A1B181906070405020300010E0F0C0D0A0B0809;
+     expected_xor_K_opad := 0x5C5D5E5F58595A5B54555657505152534C4D4E4F48494A4B44454647404142437C7D7E7F78797A7B74757677707172736C6D6E6F68696A6B6465666760616263;
+     expected_inner := 0xC0918E14C43562B910DB4B8101CF8812C3DA2783C670BFF34D88B3B88E731716 |}.
+
+Definition test2 : hmac_step_by_step_test :=
+  {| test :=
+       {| lK := 32;
+          ldata := 34;
+          K := 0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F;
+          data := 0x53616D706C65206D65737361676520666F72206B65796C656E3C626C6F636B6C656E;
+          expected_output := 0xA28CF43130EE696A98F14A37678B56BCFCBDD9E5CF69717FECF5480F0EBDF790 |};
+     expected_padded_key := 0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F0000000000000000000000000000000000000000000000000000000000000000;
+     expected_xor_K_ipad := 0x36373435323330313E3F3C3D3A3B383926272425222320212E2F2C2D2A2B28293636363636363636363636363636363636363636363636363636363636363636;
+     expected_xor_K_opad := 0x5C5D5E5F58595A5B54555657505152534C4D4E4F48494A4B44454647404142435C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C;
+     expected_inner := 0xB3C52720B330A1D3C4D8B594A9A73D207ED02EE5078A4A422258BD6514070A5F |}.
+
+Definition test3 : hmac_step_by_step_test :=
+  {| test :=
+       {| lK := 100;
+          ldata := 34;
+          K := 0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60616263;
+          data := 0x53616D706C65206D65737361676520666F72206B65796C656E3D626C6F636B6C656E;
+          expected_output := 0xBDCCB6C72DDEADB500AE768386CB38CC41C63DBB0878DDB9C7A38A431B78378D |};
+     expected_padded_key := 0xBCE0AFF19CF5AA6A7469A30D61D04E4376E4BBF6381052EE9E7F33925C954D520000000000000000000000000000000000000000000000000000000000000000;
+     expected_xor_K_ipad := 0x8AD699C7AAC39C5C425F953B57E6787540D28DC00E2664D8A84905A46AA37B643636363636363636363636363636363636363636363636363636363636363636;
+     expected_xor_K_opad := 0xE0BCF3ADC0A9F6362835FF513D8C121F2AB8E7AA644C0EB2C2236FCE00C9110E5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C5C;
+     expected_inner := 0x1E0DFB0CBB61E9F060769E9DF57501292426F0DB58194BC85BC63DAC4670C2C1 |}.

--- a/silveroak-opentitan/hmac/Spec/Tests/HMACTests.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/HMACTests.v
@@ -1,0 +1,106 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Lists.List.
+Require Import Coq.NArith.NArith.
+Require Import HmacSpec.HMAC.
+Require Import HmacSpec.Tests.HMACTestVectors.
+Import ListNotations.
+Local Open Scope N_scope.
+
+(* Uncomment the below for step-by-step tests of intermediate values for test1
+   (useful for debugging) *)
+(*
+(* Check key padding *)
+Goal (let t := test1 in
+      padded_key t.(lK) t.(K) = t.(expected_padded_key)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check K ^ ipad *)
+Goal (let t := test1 in
+      N.lxor t.(expected_padded_key) ipad = t.(expected_xor_K_ipad)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check K ^ opad *)
+Goal (let t := test1 in
+      N.lxor t.(expected_padded_key) opad = t.(expected_xor_K_opad)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check inner hash result *)
+Goal (let t := test1 in
+      H B t.(ldata) t.(expected_xor_K_ipad) t.(data) = t.(expected_inner)).
+Proof. vm_compute. reflexivity. Qed.
+*)
+
+Goal (let t := test1 in
+      hmac_sha256 t.(lK) t.(ldata) t.(K) t.(data) = t.(expected_output)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Uncomment the below for step-by-step tests of intermediate values for test2
+   (useful for debugging) *)
+(*
+(* Check key padding *)
+Goal (let t := test2 in
+      padded_key t.(lK) t.(K) = t.(expected_padded_key)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check K ^ ipad *)
+Goal (let t := test2 in
+      N.lxor t.(expected_padded_key) ipad = t.(expected_xor_K_ipad)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check K ^ opad *)
+Goal (let t := test2 in
+      N.lxor t.(expected_padded_key) opad = t.(expected_xor_K_opad)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check inner hash result *)
+Goal (let t := test2 in
+      H B t.(ldata) t.(expected_xor_K_ipad) t.(data) = t.(expected_inner)).
+Proof. vm_compute. reflexivity. Qed.
+*)
+
+Goal (let t := test2 in
+      hmac_sha256 t.(lK) t.(ldata) t.(K) t.(data) = t.(expected_output)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Uncomment the below for step-by-step tests of intermediate values for test3
+   (useful for debugging) *)
+(*
+(* Check key padding *)
+Goal (let t := test3 in
+      padded_key t.(lK) t.(K) = t.(expected_padded_key)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check K ^ ipad *)
+Goal (let t := test3 in
+      N.lxor t.(expected_padded_key) ipad = t.(expected_xor_K_ipad)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check K ^ opad *)
+Goal (let t := test3 in
+      N.lxor t.(expected_padded_key) opad = t.(expected_xor_K_opad)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Check inner hash result *)
+Goal (let t := test3 in
+      H B t.(ldata) t.(expected_xor_K_ipad) t.(data) = t.(expected_inner)).
+Proof. vm_compute. reflexivity. Qed.
+ *)
+
+Goal (let t := test3 in
+      hmac_sha256 t.(lK) t.(ldata) t.(K) t.(data) = t.(expected_output)).
+Proof. vm_compute. reflexivity. Qed.

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
@@ -1,0 +1,135 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Lists.List.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Strings.String.
+Require Import Cava.Util.String.
+Import ListNotations.
+Local Open Scope N_scope.
+
+Record sha256_test_vector :=
+  { msg : string;
+    msg_N := string_to_N msg;
+    l := N.of_nat (String.length msg * 8);
+    expected_digest : N }.
+
+Record sha256_step_by_step_test : Type :=
+  { test :> sha256_test_vector;
+    expected_padded_msg : N;
+    (* first 16 blocks of W for each round *)
+    expected_blocks : list (list N);
+    (* H at the end of each round *)
+    expected_intermediate_digests : list (list N) }.
+
+(**** Test vectors from
+      https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA256.pdf ****)
+
+Definition test1 : sha256_step_by_step_test :=
+  {| test :=
+       {| msg := "abc";
+          expected_digest := 0xBA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD |};
+     expected_padded_msg := 0x61626380000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018;
+     expected_blocks :=
+       [ (* first 16 blocks of W for i=0 *)
+         [ 0x61626380
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000000
+           ; 0x00000018 ] ];
+     expected_intermediate_digests :=
+       [ (* H[0] - H[7] after round 0 *)
+         [ 0xBA7816BF
+           ; 0x8F01CFEA
+           ; 0x414140DE
+           ; 0x5DAE2223
+           ; 0xB00361A3
+           ; 0x96177A9C
+           ; 0xB410FF61
+           ; 0xF20015AD ] ];
+  |}.
+
+Definition test2 : sha256_step_by_step_test :=
+  {| test :=
+       {| msg := "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+          expected_digest := 0x248D6A61D20638B8E5C026930C3E6039A33CE45964FF2167F6ECEDD419DB06C1 |};
+     expected_padded_msg := 0x6162636462636465636465666465666765666768666768696768696A68696A6B696A6B6C6A6B6C6D6B6C6D6E6C6D6E6F6D6E6F706E6F70718000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001C0;
+     expected_blocks :=
+       [ (* first 16 blocks of W for i=0 *)
+         [ 0x61626364
+           ; 0x62636465
+           ; 0x63646566
+           ; 0x64656667
+           ; 0x65666768
+           ; 0x66676869
+           ; 0x6768696A
+           ; 0x68696A6B
+           ; 0x696A6B6C
+           ; 0x6A6B6C6D
+           ; 0x6B6C6D6E
+           ; 0x6C6D6E6F
+           ; 0x6D6E6F70
+           ; 0x6E6F7071
+           ; 0x80000000
+           ; 0x00000000];
+       (* first 16 blocks of W for i=1 *)
+       [ 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x00000000
+         ; 0x000001C0 ] ];
+     expected_intermediate_digests :=
+       [ (* H[0] - H[7] after round 0 *)
+         [ 0x85E655D6
+           ; 0x417A1795
+           ; 0x3363376A
+           ; 0x624CDE5C
+           ; 0x76E09589
+           ; 0xCAC5F811
+           ; 0xCC4B32C1
+           ; 0xF20E533A ];
+       (* H[0] - H[7] after round 1 *)
+       [ 0x248D6A61
+         ; 0xD20638B8
+         ; 0xE5C02693
+         ; 0x0C3E6039
+         ; 0xA33CE459
+         ; 0x64FF2167
+         ; 0xF6ECEDD4
+         ; 0x19DB06C1 ] ];
+  |}.

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
@@ -1,0 +1,109 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Lists.List.
+Require Import Coq.NArith.NArith.
+Require Import HmacSpec.SHA256.
+Require Import HmacSpec.Tests.SHA256TestVectors.
+Import ListNotations.
+Local Open Scope N_scope.
+
+(* Tests for SHA-256 spec *)
+
+(* Uncomment the below for step-by-step tests of intermediate values for test1
+   (useful for debugging) *)
+
+(*
+(* test Nblocks *)
+Goal (let t := test1 in
+      Nblocks t.(l) = N.of_nat (List.length (t.(expected_blocks)))).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test padded_msg *)
+Goal (let t := test1 in
+      padded_msg t.(l) t.(msg_N) = t.(expected_padded_msg)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test first 16 blocks of W for round 0 *)
+Goal (let t := test1 in
+      let i := 0 in
+      let expected_W := nth (N.to_nat i) t.(expected_blocks) [] in
+      firstn 16 (W t.(l) t.(msg_N) i) = expected_W).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test round 0 *)
+Goal (let t := test1 in
+      let i := 0%nat in
+      let old_H := H0 in
+      let expected_H := nth i t.(expected_intermediate_digests) [] in
+      sha256_step t.(l) t.(msg_N) old_H i = expected_H).
+Proof. vm_compute. reflexivity. Qed.
+*)
+
+(* test final digest *)
+Goal (let t := test1 in
+      sha256 t.(l) t.(msg_N) = t.(expected_digest)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* Uncomment the below for step-by-step tests of intermediate values for test2
+   (useful for debugging) *)
+
+(*
+(* test Nblocks *)
+Goal (let t := test2 in
+      Nblocks t.(l) = N.of_nat (List.length (t.(expected_blocks)))).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test padded_msg *)
+Goal (let t := test2 in
+      padded_msg t.(l) t.(msg_N) = t.(expected_padded_msg)).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test first 16 blocks of W for round 0 *)
+Goal (let t := test2 in
+      let i := 0 in
+      let expected_W := nth (N.to_nat i) t.(expected_blocks) [] in
+      firstn 16 (W t.(l) t.(msg_N) i) = expected_W).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test round 0 *)
+Goal (let t := test2 in
+      let i := 0%nat in
+      let old_H := H0 in
+      let expected_H := nth i t.(expected_intermediate_digests) [] in
+      sha256_step t.(l) t.(msg_N) old_H i = expected_H).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test first 16 blocks of W for round 1 *)
+Goal (let t := test2 in
+      let i := 1 in
+      let expected_W := nth (N.to_nat i) t.(expected_blocks) [] in
+      firstn 16 (W t.(l) t.(msg_N) i) = expected_W).
+Proof. vm_compute. reflexivity. Qed.
+
+(* test round 1 *)
+Goal (let t := test2 in
+      let i := 1%nat in
+      let old_H := nth (i-1) t.(expected_intermediate_digests) [] in
+      let expected_H := nth i t.(expected_intermediate_digests) [] in
+      sha256_step t.(l) t.(msg_N) old_H i = expected_H).
+Proof. vm_compute. reflexivity. Qed.
+*)
+
+(* test final digest *)
+Goal (let t := test2 in
+      sha256 t.(l) t.(msg_N) = t.(expected_digest)).
+Proof. vm_compute. reflexivity. Qed.


### PR DESCRIPTION
Resolves #876 

- Transcribes test vectors from NIST documents for HMAC and SHA-256, in such a way that intermediate values can also be checked for debugging purposes
- Runs the tests on SHA-256 and HMAC specifications
- Adjusts the HMAC specification to handle keys with a length greater than `B`