### PR TITLE
Uncouple BitVec and Vec

### DIFF
--- a/investigations/cava2/Expr.v
+++ b/investigations/cava2/Expr.v
@@ -187,8 +187,12 @@ Module PrimitiveNotations.
     Let x (fun v1 => Let y (fun v2 =>
     BinaryOp BinBitVecGte v1 v2
   ))) (in custom expr at level 19, no associativity) : expr_scope.
-  Notation "! x" := (
+  Notation "~ x" := (
     Let x (fun v1 => UnaryOp UnBitVecNot v1)
+  ) (in custom expr at level 19, no associativity) : expr_scope.
+  (* ! is identical to ~ but only works on 1-bit bit vectors (i.e. booleans) *)
+  Notation "! x" := (
+    Let x (fun v1 => UnaryOp (@UnBitVecNot 1) v1)
   ) (in custom expr at level 19, no associativity) : expr_scope.
   Notation "x == y" := (
     Let x (fun v1 => Let y (fun v2 =>

--- a/investigations/cava2/Expr.v
+++ b/investigations/cava2/Expr.v
@@ -126,8 +126,8 @@ End ExprNotations.
 Section Var.
   Context {var : tvar}.
 
-  Definition True := Constant Bit true.
-  Definition False := Constant Bit false.
+  Definition True := Constant Bit 1.
+  Definition False := Constant Bit 0.
   Definition K {sz}(x: N) := Constant (BitVec sz) x.
 
 End Var.
@@ -183,28 +183,21 @@ Axiom value_hole : forall {t}, t.
 Axiom circuit_hole : forall {t var}, Circuit (var:=var) [] [] t.
 
 Module PrimitiveNotations.
-  Notation "x && y" := (
-    Let x (fun v1 => Let y (fun v2 => BinaryOp BinBitAnd v1 v2))
-  ) (in custom expr at level 20, left associativity) : expr_scope.
-  Notation "x || y" := (
-    Let x (fun v1 => Let y (fun v2 =>
-     BinaryOp BinBitOr v1 v2
-  ))) (in custom expr at level 20, left associativity) : expr_scope.
   Notation "x >= y" := (
     Let x (fun v1 => Let y (fun v2 =>
     BinaryOp BinBitVecGte v1 v2
   ))) (in custom expr at level 19, no associativity) : expr_scope.
-
   Notation "! x" := (
-    Let x (fun v1 => UnaryOp UnNot v1)
-  ) (in custom expr at level 20) : expr_scope.
-  Notation "~ x" := (
     Let x (fun v1 => UnaryOp UnBitVecNot v1)
-  ) (in custom expr at level 20) : expr_scope.
+  ) (in custom expr at level 19, no associativity) : expr_scope.
   Notation "x == y" := (
     Let x (fun v1 => Let y (fun v2 =>
       BinaryOp BinEq v1 v2
   ))) (in custom expr at level 19, no associativity) : expr_scope.
+  Notation "x | y" := (
+    Let x (fun v1 => Let y (fun v2 =>
+      BinaryOp BinBitVecOr v1 v2
+  ))) (in custom expr at level 20, left associativity) : expr_scope.
   Notation "x ^ y" := (
     Let x (fun v1 => Let y (fun v2 =>
       BinaryOp BinBitVecXor v1 v2
@@ -221,12 +214,12 @@ Module PrimitiveNotations.
     Let x (fun v1 => Let y (fun v2 =>
       BinaryOp BinBitVecSubU v1 v2
   ))) (in custom expr at level 20, left associativity) : expr_scope.
-  Notation "x >>> y" := (
-    Let x (fun v1 => UnaryOp (UnBitVecRotateRight y) v1
-  )) (in custom expr at level 19, no associativity) : expr_scope.
   Notation "x >> y" := (
     Let x (fun v1 => UnaryOp (UnBitVecShiftRight y) v1
-  )) (in custom expr at level 19, no associativity) : expr_scope.
+  )) (in custom expr at level 19, y constr, no associativity) : expr_scope.
+  Notation "x << y" := (
+    Let x (fun v1 => UnaryOp (UnBitVecShiftLeft y) v1
+  )) (in custom expr at level 19, y constr, no associativity) : expr_scope.
   Notation "x <<+ y" := (
     Let x (fun v1 => Let y (fun v2 =>
       BinaryOp BinVecShiftInRight v1 v2
@@ -246,7 +239,7 @@ Module PrimitiveNotations.
       BinaryOp BinVecConcat v1 v2
   ))) (in custom expr at level 19, right associativity) : expr_scope.
 
-  Notation "[ ]" := (Constant _ (simple_denote_to_denote (t:=Vec _ 0) nil)) (in custom expr at level 19) : expr_scope.
+  Notation "[ ]" := (Constant (Vec _ 0) List.nil) (in custom expr at level 19) : expr_scope.
 
   Import ExprNotations.
   Definition index {var t n i}: Circuit (var:=var) [] [Vec t n; BitVec i] t :=
@@ -257,12 +250,18 @@ Module PrimitiveNotations.
     {{ fun vec => `UnaryOp (UnVecSlice start length) vec` }}.
   Definition replace {var t n i}: Circuit (var:=var) [] [Vec t n; BitVec i; t] (Vec t n) :=
     {{ fun vec index val => `TernaryOp TernVecReplace vec index val` }}.
-  Definition resize {var t n m}: Circuit (var:=var) [] [Vec t n] (Vec t m) :=
+  Definition resize {var t n m} : Circuit (var:=var) [] [Vec t n] (Vec t m) :=
     {{ fun vec => `UnaryOp UnVecResize vec ` }}.
+  Definition bvresize {var n} m: Circuit (var:=var) [] [BitVec n] (BitVec m) :=
+    {{ fun vec => `UnaryOp UnBitVecResize vec` }}.
   Definition reverse {var t n}: Circuit (var:=var) [] [Vec t n] (Vec t n) :=
     {{ fun vec => `UnaryOp UnVecReverse vec ` }}.
   Definition uncons {var t n}: Circuit (var:=var) [] [Vec t (S n)] (t ** Vec t n) :=
     {{ fun vec => `UnaryOp UnVecUncons vec` }}.
+  Definition bvslice {var n} (start length: nat): Circuit (var:=var) [] [BitVec n] (BitVec length) :=
+    {{ fun vec => `bvresize length` (vec >> start) }}.
+  Definition bvconcat {var n m}: Circuit (var:=var) [] [BitVec n; BitVec m] (BitVec (n + m)) :=
+    {{ fun v1 v2 => (((`bvresize (n+m)` v1) << m) | (`bvresize (n+m)` v2)) }}.
   Fixpoint map {var t u n} (f: Circuit [] [t] u): Circuit (var:=var) [] [Vec t n] (Vec u n) :=
     match n with
     | O => {{ fun _ => [] }}

--- a/investigations/cava2/Hmac.v
+++ b/investigations/cava2/Hmac.v
@@ -48,27 +48,27 @@ Section Var.
 
       let '(tl_o, write_en, write_address, write_data; write_mask)
         := `tlul_adapter_reg` incoming_tlp registers in
-      let aligned_address := `slice 2 5` write_address in
+      let aligned_address := `bvslice 2 5` write_address in
 
       let fifo_write := write_address >= `Constant (BitVec _) 2048` in
 
       (* TODO(blaxill): ignore/mask writes to CMD etc ? *)
       (* TODO(blaxill): apply mask to register writes*)
       let nregisters :=
-        if write_en && !fifo_write
+        if write_en & !fifo_write
         then `replace (n:=hmac_register_count)` registers aligned_address write_data
         else registers
       in
 
       (* cmd_start is set when host writes to hmac.CMD.hash_start *)
       (* and signifies the start of a new message *)
-      let cmd_start := write_en && aligned_address == `REG_CMD` && write_data == `K 1` && !fifo_write in
+      let cmd_start := write_en & aligned_address == `REG_CMD` & write_data == `K 1` & !fifo_write in
       (* cmd_process is set when host writes to hmac.CMD.hash_process *)
       (* and signifies the end of a message *)
-      let cmd_process := write_en && aligned_address == `REG_CMD` && write_data == `K 2` && !fifo_write in
+      let cmd_process := write_en & aligned_address == `REG_CMD` & write_data == `K 2` & !fifo_write in
 
       let '(packer_valid; packer_data)
-        := `tlul_pack` (write_en && fifo_write) write_data write_mask cmd_process in
+        := `tlul_pack` (write_en & fifo_write) write_data write_mask cmd_process in
 
       (* TODO(blaxill): FIX ME *)
       (* let '(_, padded_block; padded_valid) := `sha256_padder` packer_valid packer_data cmd_process `circuit_hole` cmd_start in *)

--- a/investigations/cava2/Primitives.v
+++ b/investigations/cava2/Primitives.v
@@ -30,29 +30,19 @@ Inductive UnaryPrim : type -> type -> Type :=
 | UnVecReverse: forall {t n}, UnaryPrim (Vec t n) (Vec t n)
 | UnVecUncons: forall {t n}, UnaryPrim (Vec t (S n)) (t ** Vec t n)
 
-(* Our numbers are little endian but bitshifting is usually lexicographic
- * ordered, that is for X = 0x3 = 0b110, X >> 1 = 0x1 = 0b100
- * Whereas vector shifting is opposite X = [a,b,c], shift_right X 1 = [_,a,b]
- * TODO(blaxill): simplify this situation?
- *)
-| UnBitVecRotateRight: forall {t n}, nat -> UnaryPrim (Vec t n) (Vec t n)
-| UnBitVecShiftRight: forall {t n}, nat -> UnaryPrim (Vec t n) (Vec t n)
-
-| UnVecRotateRight: forall {t n}, nat -> UnaryPrim (Vec t n) (Vec t n)
-| UnVecShiftRight: forall {t n}, nat -> UnaryPrim (Vec t n) (Vec t n)
+| UnBitVecResize: forall {n m}, UnaryPrim (BitVec n) (BitVec m)
+| UnBitVecShiftRight: forall {n}, nat -> UnaryPrim (BitVec n) (BitVec n)
+| UnBitVecShiftLeft: forall {n}, nat -> UnaryPrim (BitVec n) (BitVec n)
 
 | UnVecToTuple: forall {t n}, UnaryPrim (Vec t (S n)) (ntuple t n)
 
 | UnBitVecNot: forall {n}, UnaryPrim (BitVec n) (BitVec n)
-| UnNot: UnaryPrim Bit Bit
 .
 
 Inductive BinaryPrim : type -> type -> type -> Type :=
-| BinBitAnd: BinaryPrim Bit Bit Bit
-| BinBitOr: BinaryPrim Bit Bit Bit
-
 | BinBitVecGte: forall {n}, BinaryPrim (BitVec n) (BitVec n) Bit
 
+| BinBitVecOr: forall {n}, BinaryPrim (BitVec n) (BitVec n) (BitVec n)
 | BinBitVecXor: forall {n}, BinaryPrim (BitVec n) (BitVec n) (BitVec n)
 | BinBitVecAnd: forall {n}, BinaryPrim (BitVec n) (BitVec n) (BitVec n)
 | BinBitVecAddU: forall {n}, BinaryPrim (BitVec n) (BitVec n) (BitVec n)
@@ -74,18 +64,6 @@ Inductive TernaryPrim : type -> type -> type -> type -> Type :=
 | TernVecReplace: forall {t n i}, TernaryPrim (Vec t n) (BitVec i) t (Vec t n)
 .
 
-Fixpoint drop {A} n (ls: list A): list A :=
-  match n with
-  | 0 => ls
-  | S n' => drop n' (tl ls)
-  end.
-
-Fixpoint take {A} n (ls: list (simple_denote_type A)): list (simple_denote_type A) :=
-  match n with
-  | 0 => []
-  | S n' => hd simple_default ls :: take n' (tl ls)
-  end.
-
 Fixpoint rotate_left {A} n (ls: list A): list A :=
   match n with
   | 0 => ls
@@ -95,92 +73,66 @@ Fixpoint rotate_left {A} n (ls: list A): list A :=
     | x :: xs => rotate_left n' (xs ++ [x])
     end
   end.
-Fixpoint shift_left {A} n (ls: list (simple_denote_type A)): list (simple_denote_type A) :=
+Fixpoint shift_left {A} n (ls: list (denote_type A)): list (denote_type A) :=
   match n with
   | 0 => ls
   | S n' =>
     match ls with
     | nil => []
-    | x :: xs => shift_left n' (xs ++ [simple_default])
+    | x :: xs => shift_left n' (xs ++ [default])
     end
   end.
 
-Fixpoint rotate_right {A} n (ls: list (simple_denote_type A)): list (simple_denote_type A) :=
+Fixpoint rotate_right {A} n (ls: list (denote_type A)): list (denote_type A) :=
   match n with
   | 0 => ls
   | S n' =>
-    rotate_right n' (last ls simple_default :: removelast ls)
+    rotate_right n' (last ls default :: removelast ls)
   end.
-Fixpoint shift_right {A} n (ls: list (simple_denote_type A)): list (simple_denote_type A) :=
+Fixpoint shift_right {A} n (ls: list (denote_type A)): list (denote_type A) :=
   match n with
   | 0 => ls
   | S n' =>
-    shift_right n' (simple_default :: removelast ls)
+    shift_right n' (default :: removelast ls)
   end.
+
+Definition resize {A} (d : A) n (ls : list A) : list A :=
+  firstn n ls ++ repeat d (n - length ls).
 
 Definition unary_semantics {x r} (prim: UnaryPrim x r)
   : denote_type x -> denote_type r :=
   match prim in UnaryPrim x r return denote_type x -> denote_type r with
-  | @UnVecSlice t _ start len =>
-    via_simple (b:=Vec t len) (a:= Vec t _) (fun x => take len (drop start x))
-  | @UnVecResize t n m =>
-    via_simple (b:=Vec t m) (a:= Vec t _) (fun x =>
-    if n <=? m
-    then x ++ repeat simple_default (m - n)
-    else take m x
-    )%list
-  | @UnVecReverse t n =>
-    via_simple (b:=Vec t n) (a:= Vec t _) (fun x => rev x)%list
+  | @UnVecSlice t n start len =>
+    fun x => resize default len (firstn len (skipn start x))
+  | @UnVecResize t n m => fun x => resize default m x
+  | @UnVecReverse t n => fun x => rev x
 
-  | @UnVecUncons t n =>
-    via_simple (b:=t ** Vec t n) (a:= Vec t _) (fun x => (hd simple_default x, tl x) )%list
+  | @UnVecUncons t n => fun x => (hd default x, tl x)
 
-  | UnBitVecRotateRight n =>
-    via_simple (b:=Vec _ _) (a:= Vec _ _) (fun x => rotate_left n x)
-  | UnBitVecShiftRight n =>
-    via_simple (b:=Vec _ _) (a:= Vec _ _) (fun x => shift_left n x)
+  | @UnBitVecResize n m => fun x => N.land x (N.ones (N.of_nat m))
+  | UnBitVecShiftRight n => fun x => N.shiftr x (N.of_nat n)
+  | UnBitVecShiftLeft n => fun x => N.shiftl x (N.of_nat n)
 
-  | UnVecRotateRight n =>
-    via_simple (b:=Vec _ _) (a:= Vec _ _) (fun x => rotate_right n x)
-  | UnVecShiftRight n =>
-    via_simple (b:=Vec _ _) (a:= Vec _ _) (fun x => shift_right n x)
-
-  | @UnVecToTuple t n =>
-    via_simple (a:= Vec _ _) (fun x => vector_as_tuple n t x)
-  | @UnBitVecNot n =>
-    via_simple (a:= Vec Bit n) (b:=Vec Bit n) (fun x => map negb x)
-  | UnNot => fun x => negb x
+  | @UnVecToTuple t n => vector_as_tuple n t
+  | @UnBitVecNot n => fun x => N.lnot x (N.of_nat n)
   end.
 
 Definition binary_semantics {x y r} (prim: BinaryPrim x y r)
   : denote_type x -> denote_type y -> denote_type r :=
   match prim in BinaryPrim x y r return denote_type x -> denote_type y -> denote_type r with
-  | BinBitAnd => andb
-  | BinBitOr => orb
+  | BinBitVecGte => fun x y => (if y <=? x then 1 else 0)%N
 
-  | BinBitVecGte => fun x y => (y <=? x)%N
-
-  | @BinBitVecXor n =>
-    via_simple2 (a:= Vec Bit n) (b:= Vec Bit n) (c:=Vec Bit n)
-    (fun x y => map (fun '(x,y) => xorb x y) (combine x y))
-  | @BinBitVecAnd n =>
-    via_simple2 (a:= Vec Bit n) (b:= Vec Bit n) (c:=Vec Bit n)
-    (fun x y => map (fun '(x,y) => andb x y) (combine x y))
+  | @BinBitVecOr n => N.lor
+  | @BinBitVecXor n => N.lxor
+  | @BinBitVecAnd n => N.land
   | @BinBitVecAddU n => fun x y => ((x + y) mod (2 ^ (N.of_nat n)))%N
   | @BinBitVecSubU n => fun x y => ((x - y + 2 ^ N.of_nat n) mod (2 ^ (N.of_nat n)))%N
-  | @BinVecIndex t n i =>
-    fun x n => simple_denote_to_denote (nth (N.to_nat n) (denote_to_simple_denote x) simple_default)
-  | BinVecCons =>
-    via_simple2 (b:=Vec _ _) (c:=Vec _ _) (fun x xs => x :: xs)
-  | BinVecConcat =>
-    via_simple2 (a:=Vec _ _) (b:=Vec _ _) (c:=Vec _ _) (fun x y => x ++ y)%list
-  | @BinVecShiftInRight t n =>
-    via_simple2 (a:= Vec t n) (b:=t) (c:=Vec t _)
-    (fun xs x => tl (xs ++ [x]))
-  | @BinVecShiftInLeft t n =>
-    via_simple2 (a:= t) (b:=Vec t _) (c:=Vec t _)
-    (fun x xs => removelast (x :: xs))
-  | BinEq => eqb
+  | @BinVecIndex t n i => fun x n => nth (N.to_nat n) x default
+  | BinVecCons => fun x y => x :: y
+  | BinVecConcat => fun x y => x ++ y
+  | @BinVecShiftInRight t n => (fun xs x => tl (xs ++ [x]))
+  | @BinVecShiftInLeft t n => (fun x xs => removelast (x :: xs))
+  | BinEq => fun x y => (if eqb x y then 1 else 0)%N
   end%list.
 
 Fixpoint replace {A} n a (ls: list A): list A :=
@@ -196,7 +148,6 @@ Fixpoint replace {A} n a (ls: list A): list A :=
 Definition ternary_semantics {x y z r} (prim: TernaryPrim x y z r)
   : denote_type x -> denote_type y -> denote_type z -> denote_type r :=
   match prim in TernaryPrim x y z r return denote_type x -> denote_type y -> denote_type z -> denote_type r with
-  | TernVecReplace => fun ls i x => simple_denote_to_denote (t:=Vec _ _ )
-      (replace (N.to_nat i) (denote_to_simple_denote x) (denote_to_simple_denote ls))
+  | TernVecReplace => fun ls i x => replace (N.to_nat i) x ls
   end.
 

--- a/investigations/cava2/Semantics.v
+++ b/investigations/cava2/Semantics.v
@@ -74,7 +74,7 @@ Fixpoint step {i s o} (c : Circuit s i o)
     let '(sf, sg) := split_absorbed_denotation s in
     let '(nsf, fo) := step f sf tt in
     let '(nsg, go) := step g sg tt in
-    (combine_absorbed_denotation nsf nsg, if bv then fo else go)
+    (combine_absorbed_denotation nsf nsg, if (bv =? 0)%N then go else fo)
 
   | MakePair f g => fun s _ =>
     let '(sf, sg) := split_absorbed_denotation s in

--- a/investigations/cava2/Sha256.v
+++ b/investigations/cava2/Sha256.v
@@ -173,7 +173,7 @@ Section Var.
     let '( a', b', c', d', e', f', g'; h' ) := `vec_as_tuple (n:=7)` current_digest in
 
     let s1 := (`rotr 6` e') ^ (`rotr 11` e') ^ (`rotr 25` e') in
-    let ch := (e' & f') ^ (!e' & g') in
+    let ch := (e' & f') ^ (~e' & g') in
     let temp1 := (h' + s1 + ch + k + w) in
     let s0 := (`rotr 2` a') ^ (`rotr 13` a') ^ (`rotr 22` a') in
     let maj := (a' & b') ^ (a' & c') ^ (b' & c') in

--- a/investigations/cava2/Sha256.v
+++ b/investigations/cava2/Sha256.v
@@ -221,7 +221,7 @@ Section Var.
       else if done then (current_digest, message_schedule, done, round)
       else (next_digest, w, done, round)
 
-      initially (((sha256_initial_digest, (repeat 0 16, (0, 0))))
+      initially (((sha256_initial_digest, (repeat 0 16, (1, 0))))
       : denote_type (sha_digest ** sha_block ** Bit ** sha_round )) in
 
     let updated_digest := `map2 {{fun a b => ( a + b ) }}` initial_digest current_digest in
@@ -326,7 +326,6 @@ Section SanityCheck.
     [0xBA7816BF; 0x8F01CFEA; 0x414140DE; 0x5DAE2223; 0xB00361A3; 0x96177A9C; 0xB410FF61; 0xF20015AD ].
   Proof. vm_compute. reflexivity. Qed.
 
-  (*
   (* sha256 "abc" = sha256 (0x61626300 @ byte mask 0xFFFFFF00) = correct digest *)
   Goal
     fst (snd (last (simulate sha256 (
@@ -334,6 +333,6 @@ Section SanityCheck.
        repeat (0, (0, (0, (0, (0, tt))))) (64+19)
       )) default))
     = [0xBA7816BF; 0x8F01CFEA; 0x414140DE; 0x5DAE2223; 0xB00361A3; 0x96177A9C; 0xB410FF61; 0xF20015AD ].
-  Proof. vm_compute. reflexivity. Qed.*)
+  Proof. vm_compute. reflexivity. Qed.
 
 End SanityCheck.

--- a/investigations/cava2/Sha256.v
+++ b/investigations/cava2/Sha256.v
@@ -53,12 +53,12 @@ Section Var.
     let/delay '(done, out, out_valid, state, length; current_offset) :=
       if clear
       then `Constant (Bit ** sha_word ** Bit ** BitVec 4 ** BitVec 61 ** BitVec 16)
-                     (false, (0, (false, (0, (0, 0)))))`
+                     (0, (0, (0, (0, (0, 0)))))`
       else if !consumer_ready then (done, out, out_valid, state, length, current_offset)
       else
 
       let next_state :=
-        if is_final && state == `padder_waiting` then
+        if is_final & state == `padder_waiting` then
           if final_length == `K 4`
           then `padder_emit_bit`
           else `padder_flushing`
@@ -77,47 +77,47 @@ Section Var.
         in
 
       let next_length :=
-        if state == `padder_waiting` && is_final then length + `resize` final_length
-        else if state == `padder_waiting` && data_valid then length + `K 4`
-        else if state == `padder_writing_length` && current_offset == `K 15`
+        if state == `padder_waiting` & is_final then length + `bvresize 61` final_length
+        else if state == `padder_waiting` & data_valid then length + `K 4`
+        else if state == `padder_writing_length` & current_offset == `K 15`
           then `K 0`
         else length
         in
 
       let next_out :=
-        if state == `padder_waiting` && is_final then
+        if state == `padder_waiting` & is_final then
           if final_length == `K 0`
           then `Constant (BitVec 32) 0x80000000`
           else if final_length == `K 1`
-          then `Constant (BitVec 24) 0x800000` ++ `slice 24 8` data
+          then `bvconcat` (`bvslice 24 8` data) (`Constant (BitVec 24) 0x800000`)
           else if final_length == `K 2`
-          then `Constant (BitVec 16) 0x8000` ++ `slice 16 16` data
+          then `bvconcat` (`bvslice 16 16` data) (`Constant (BitVec 16) 0x8000`)
           else if final_length == `K 3`
-          then `Constant (BitVec 8) 0x80` ++ `slice 8 24` data
+          then `bvconcat` (`bvslice 8 24` data) (`Constant (BitVec 8) 0x80`)
           else data
-        else if state == `padder_waiting` && data_valid then
+        else if state == `padder_waiting` & data_valid then
           data
         else if state == `padder_emit_bit` then
           `Constant (BitVec 32) 0x80000000`
         else if state == `padder_writing_length` then
           if current_offset == `K 14`
-          then (`slice 32 32` (`Constant (BitVec 3) 0` ++ length))
-          else (`slice 0 32` (`Constant (BitVec 3) 0` ++ length))
+          then `bvslice 32 32` (length << 3)
+          else `bvslice 0 32` (length << 3)
 
         else `K 0`
       in
 
       let step :=
-        (state == `padder_waiting` && (data_valid || is_final))
-        || (! (state == `padder_waiting`) ) in
+        (state == `padder_waiting` & (data_valid | is_final))
+        | (! (state == `padder_waiting`) ) in
 
       let next_offset := if step then current_offset + `K 1` else current_offset in
 
-      ( state == `padder_writing_length` && next_state == `padder_waiting`
+      ( state == `padder_writing_length` & next_state == `padder_waiting`
       , next_out, step, next_state, next_length, next_offset)
 
       initially
-        (false,(0,(false,(0,(0,0)))))
+        (0,(0,(0,(0,(0,0)))))
         : denote_type (Bit ** sha_word ** Bit ** BitVec 4 ** BitVec 61 ** BitVec 16)
         in
 
@@ -156,11 +156,14 @@ Section Var.
     `index` k i
   }}.
 
+  Definition rotr n : Circuit _ [sha_word] sha_word :=
+    {{ fun w =>  ((w >> n) | (w << (32 - n))) }}.
+
   (* SHA-256 message schedule update *)
   Definition sha256_message_schedule_update : Circuit _ [sha_word; sha_word; sha_word; sha_word] sha_word := {{
     fun w0 w1 w9 w14 =>
-    let sum0 := (w1 >>> `7`) ^ (w1 >>> `18`) ^ (w1 >> `3`) in
-    let sum1 := (w14 >>> `17`) ^ (w14 >>> `19`) ^ (w14 >> `10`) in
+    let sum0 := (`rotr 7` w1) ^ (`rotr 18` w1) ^ (w1 >> 3) in
+    let sum1 := (`rotr 17` w14) ^ (`rotr 19` w14) ^ (w14 >> 10) in
     w0 + sum0 + w9 + sum1
   }}%nat.
 
@@ -169,10 +172,10 @@ Section Var.
     fun current_digest k w =>
     let '( a', b', c', d', e', f', g'; h' ) := `vec_as_tuple (n:=7)` current_digest in
 
-    let s1 := (e' >>> `6`) ^ (e' >>> `11`) ^ (e' >>> `25`) in
-    let ch := (e' & f') ^ (~e' & g') in
+    let s1 := (`rotr 6` e') ^ (`rotr 11` e') ^ (`rotr 25` e') in
+    let ch := (e' & f') ^ (!e' & g') in
     let temp1 := (h' + s1 + ch + k + w) in
-    let s0 := (a' >>> `2`) ^ (a' >>> `13`) ^ (a' >>> `22`) in
+    let s0 := (`rotr 2` a') ^ (`rotr 13` a') ^ (`rotr 22` a') in
     let maj := (a' & b') ^ (a' & c') ^ (b' & c') in
     let temp2 := s0 + maj in
 
@@ -210,15 +213,15 @@ Section Var.
           else round)
         ) in
 
-      let done := (round == `K 64`) || done in
+      let done := (round == `K 64`) | done in
       let round := if inc_round then round + `K 1` else round in
 
-      if start || clear
-      then (initial_digest, block, `Constant (Bit**sha_round) (false, 0)`)
+      if start | clear
+      then (initial_digest, block, `Constant (Bit**sha_round) (0, 0)`)
       else if done then (current_digest, message_schedule, done, round)
       else (next_digest, w, done, round)
 
-      initially (((sha256_initial_digest, (repeat 0 16, (true, 0))))
+      initially (((sha256_initial_digest, (repeat 0 16, (0, 0))))
       : denote_type (sha_digest ** sha_block ** Bit ** sha_round )) in
 
     let updated_digest := `map2 {{fun a b => ( a + b ) }}` initial_digest current_digest in
@@ -231,7 +234,7 @@ Section Var.
     {{ fun fifo_data_valid fifo_data is_final final_length clear =>
 
        let/delay '(inner_done_edge, accept_input, accept_padded, block, digest, count, received_last_byte; done) :=
-         let starting := fifo_data_valid && done in
+         let starting := fifo_data_valid & done in
 
          let '(padded_valid, padded_data, padder_ready; padder_done) :=
            `sha256_padder` fifo_data_valid fifo_data is_final final_length accept_padded clear in
@@ -239,7 +242,7 @@ Section Var.
          let block_valid := count == `K 16` in
          let '(inner_digest; inner_done) := `sha256_inner` block_valid block digest clear in
 
-         let next_accept_padded := padded_valid && inner_done in
+         let next_accept_padded := padded_valid & inner_done in
 
          let '(next_block; next_count) :=
            if next_accept_padded
@@ -247,9 +250,9 @@ Section Var.
            else (block, `K 0`)
          in
 
-         let q := !inner_done_edge && inner_done  in
-         let next_received_last_byte := received_last_byte || is_final in
-         let next_done := (!starting && !is_final) && (done || (received_last_byte && q))  in
+         let q := !inner_done_edge & inner_done  in
+         let next_received_last_byte := received_last_byte | is_final in
+         let next_done := (!starting & !is_final) & (done | (received_last_byte & q))  in
          let next_digest := if q then inner_digest else digest in
 
          if ! clear then
@@ -257,9 +260,9 @@ Section Var.
          next_done)
          else
           `Constant (Bit ** Bit ** Bit ** sha_block ** sha_digest ** BitVec 6 ** Bit ** Bit)
-                    (true, (true, (true, (repeat 0 16, (sha256_initial_digest, (0, (false, false)))))))`
+                    (1, (1, (1, (repeat 0 16, (sha256_initial_digest, (0, (0, 0)))))))`
 
-         initially ((true, (true, (true, (repeat 0 16, (sha256_initial_digest, (0, (false, false))))))))
+         initially ((1, (1, (1, (repeat 0 16, (sha256_initial_digest, (0, (0, 0))))))))
          : denote_type (Bit ** Bit ** Bit ** sha_block ** sha_digest ** BitVec 6 ** Bit ** Bit)
             in
 
@@ -280,56 +283,57 @@ Section SanityCheck.
     ].
 
   Definition init :=
-    step sha256_inner default (true, (sha256_test_block, (sha256_initial_digest, (false, tt)))).
+    step sha256_inner default (1, (sha256_test_block, (sha256_initial_digest, (0, tt)))).
 
   Definition pp {n} (v: denote_type (Vec (BitVec 32) n)) :=
-      List.map HexString.of_N v.
+    List.map HexString.of_N v.
 
   (* Padding "abc" results in expected block. *)
   Goal
     simulate sha256_padder
-    ([(true, (0x61626300, (true, (3, (true, (false, tt))))))] ++
-      repeat (false, (0x99999999, (false, (0, (true, (false, tt)))))) 16
+    ([(1, (0x61626300, (1, (3, (1, (0, tt))))))] ++
+      repeat (0, (0x99999999, (0, (0, (1, (0, tt)))))) 16
       ) =
-    [ (true, (1633837952, (true, false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (0, (true,false)))
-    ; (true, (24, (true,true)))
-    ; (false, (0, (true,false)))
+    [ (1, (1633837952, (1, 0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (0, (1,0)))
+    ; (1, (24, (1,1)))
+    ; (0, (0, (1,0)))
     ].
   Proof. vm_compute. reflexivity. Qed.
 
   (* Inner state holds the correct values after 64 rounds. *)
   Goal
-    fst (snd (simulate' sha256_inner (repeat (false, ([], (sha256_initial_digest, (false, tt)))) 64) (fst init))) =
+    fst (snd (simulate' sha256_inner (repeat (0, ([], (sha256_initial_digest, (0, tt)))) 64) (fst init))) =
     [0x506E3058; 0xD39A2165; 0x04D24D6C; 0xB85E2CE9; 0x5EF50F24; 0xFB121210; 0x948D25B6; 0x961F4894].
   Proof. vm_compute. reflexivity. Qed.
 
   (* Output is the correct message digest *)
   Goal
-    fst (last (fst (simulate' sha256_inner (repeat (false, ([], (sha256_initial_digest, (false, tt)))) 64) (fst init))) default) =
+    fst (last (fst (simulate' sha256_inner (repeat (0, ([], (sha256_initial_digest, (0, tt)))) 64) (fst init))) default) =
     [0xBA7816BF; 0x8F01CFEA; 0x414140DE; 0x5DAE2223; 0xB00361A3; 0x96177A9C; 0xB410FF61; 0xF20015AD ].
   Proof. vm_compute. reflexivity. Qed.
 
+  (*
   (* sha256 "abc" = sha256 (0x61626300 @ byte mask 0xFFFFFF00) = correct digest *)
   Goal
     fst (snd (last (simulate sha256 (
-       (true, (0x61626300, (true, (3, (false, tt))))) ::
-       repeat (false, (0, (false, (0, (false, tt))))) (64+19)
+       (1, (0x61626300, (1, (3, (0, tt))))) ::
+       repeat (0, (0, (0, (0, (0, tt))))) (64+19)
       )) default))
     = [0xBA7816BF; 0x8F01CFEA; 0x414140DE; 0x5DAE2223; 0xB00361A3; 0x96177A9C; 0xB410FF61; 0xF20015AD ].
-  Proof. vm_compute. reflexivity. Qed.
+  Proof. vm_compute. reflexivity. Qed.*)
 
 End SanityCheck.

--- a/investigations/cava2/TLUL.v
+++ b/investigations/cava2/TLUL.v
@@ -101,7 +101,7 @@ Section Var.
   (*   PutPartialData = 3'h 1, *)
   (*   Get            = 3'h 4 *)
   (* } tl_a_op_e; *)
-  Definition tl_a_op_e      := Vec Bit 3.
+  Definition tl_a_op_e      := BitVec 3.
   Definition PutFullData    := Constant tl_a_op_e 0.
   Definition PutPartialData := Constant tl_a_op_e 1.
   Definition Get            := Constant tl_a_op_e 4.
@@ -110,7 +110,7 @@ Section Var.
   (*   AccessAck     = 3'h 0, *)
   (*   AccessAckData = 3'h 1 *)
   (* } tl_d_op_e; *)
-  Definition tl_d_op_e     := Vec Bit 3.
+  Definition tl_d_op_e     := BitVec 3.
   Definition AccessAck     := Constant tl_d_op_e 0.
   Definition AccessAckData := Constant tl_d_op_e 1.
 
@@ -148,12 +148,12 @@ Section Var.
 
     let/delay '(reqid, reqsz, rspop, error, outstanding, we_o; re_o) :=
 
-      let a_ack := a_valid && !outstanding in
-      let d_ack := outstanding && d_ready in
+      let a_ack := a_valid & !outstanding in
+      let d_ack := outstanding & d_ready in
 
-      let rd_req := a_ack && a_opcode == `Get` in
-      let wr_req := a_ack &&
-        (a_opcode == `PutFullData` || a_opcode == `PutPartialData`) in
+      let rd_req := a_ack & a_opcode == `Get` in
+      let wr_req := a_ack &
+        (a_opcode == `PutFullData` | a_opcode == `PutPartialData`) in
 
       (* TODO(blaxill): skipping malformed tl packet detection *)
       let err_internal := `False` in
@@ -164,18 +164,18 @@ Section Var.
           ( a_source
           , a_size
           , if rd_req then `AccessAckData` else `AccessAck`
-          , error_i || err_internal
+          , error_i | err_internal
           , `False`
           )
         else
           (reqid, reqsz, rspop, error, if d_ack then `False` else outstanding)
       in
 
-      let we_o := wr_req && !err_internal in
-      let re_o := rd_req && !err_internal in
+      let we_o := wr_req & !err_internal in
+      let re_o := rd_req & !err_internal in
 
       (reqid, reqsz, rspop, error, outstanding, we_o, re_o)
-      initially (0,(0,(0,(false,(false,(false,false))))))
+      initially (0,(0,(0,(0,(0,(0,0))))))
         : denote_type (BitVec _ ** BitVec _ ** BitVec _ ** Bit ** Bit ** Bit ** Bit)
     in
 
@@ -188,7 +188,7 @@ Section Var.
       , reqsz
       , reqid
       , `K 0`
-      , `index` registers (`slice 2 30` a_address)
+      , `index` registers (`bvslice 2 30` a_address)
       , `K 0`
       , error
       , !outstanding

--- a/investigations/cava2/Types.v
+++ b/investigations/cava2/Types.v
@@ -26,93 +26,35 @@ Require Import Cava.Util.Vector.
 
 Inductive type :=
 | Unit : type
-| Bit  : type
+| BitVec  : nat -> type
 | Vec  : type -> nat -> type
 | Pair : type -> type -> type
 .
 
-Notation BitVec n := (Vec Bit n).
+Notation Bit := (BitVec 1).
 
 Definition eq_dec_type (x y: type): {x = y} + {x <> y}.
 Proof.
-  decide equality.
-  apply Nat.eq_dec.
+  decide equality; apply Nat.eq_dec.
 Defined.
-
-(* simple_denote_type denotes all 'Vec's as lists *)
-Fixpoint simple_denote_type (t: type) :=
-  match t with
-  | Unit => unit
-  | Bit => bool
-  | Vec t n => list (simple_denote_type t)
-  | Pair x y => (simple_denote_type x * simple_denote_type y)%type
-  end.
-
-Fixpoint eqb_simple {t}: simple_denote_type t -> simple_denote_type t -> bool :=
-  match t return simple_denote_type t -> simple_denote_type t -> bool with
-  | Unit => fun _ _ => true
-  | Bit => fun x y => Bool.eqb x y
-  | Vec t n => fun x y =>
-    fold_right andb true (map (fun '(x,y) => eqb_simple (t:=t) x y) (combine x y))
-  | Pair x y => fun '(x1,y1) '(x2,y2) => andb (eqb_simple x1 x2) (eqb_simple y1 y2)
-  end.
 
 (* simple_denote_type denotes 'BitVec's as N *)
 Fixpoint denote_type (t: type) :=
   match t with
   | Unit => unit
-  | Bit => bool
-  | Vec t n =>
-    match t with
-    | Bit => N
-    | _ => list (denote_type t)
-    end
+  | BitVec n => N
+  | Vec t n =>list (denote_type t)
   | Pair x y => (denote_type x * denote_type y)%type
   end.
 
 Fixpoint eqb {t}: denote_type t -> denote_type t -> bool :=
   match t return denote_type t -> denote_type t -> bool with
   | Unit => fun _ _ => true
-  | Bit => fun x y => Bool.eqb x y
+  | BitVec n => fun x y => N.eqb x y
   | Vec t n =>
-    let eqb_f := eqb (t:=t) in
-    match t return (denote_type t -> denote_type t -> bool) -> denote_type (Vec t n) -> denote_type (Vec t n) -> bool with
-    | Bit => fun _ => N.eqb
-    | _ => fun eqb x y =>
+    fun x y =>
       fold_right andb true (map (fun '(x,y) => eqb x y) (combine x y))
-    end eqb_f
   | Pair x y => fun '(x1,y1) '(x2,y2) => andb (eqb x1 x2) (eqb y1 y2)
-  end.
-
-Fixpoint denote_to_simple_denote {t} : denote_type t -> simple_denote_type t :=
-  match t return denote_type t -> simple_denote_type t with
-  | Vec t n =>
-    let f := denote_to_simple_denote in
-    match t as t1
-      return ((denote_type t1 -> simple_denote_type t1)
-              -> denote_type (Vec t1 n) -> simple_denote_type (Vec t1 n))
-    with
-    | Bit => fun _ x =>
-      let v := N2Bv_sized n x in Vector.to_list v
-    | _ => fun f x => map f x
-    end f
-  | Pair x y => fun '(x,y) => (denote_to_simple_denote x, denote_to_simple_denote y)
-  | _ => id
-  end.
-
-Fixpoint simple_denote_to_denote {t} : simple_denote_type t -> denote_type t :=
-  match t return simple_denote_type t -> denote_type t with
-  | Vec t n =>
-    let f := simple_denote_to_denote in
-    match t as t1
-      return ((simple_denote_type t1 -> denote_type t1)
-              -> simple_denote_type (Vec t1 n) -> denote_type (Vec t1 n))
-    with
-    | Bit => fun _ x => Bv2N (Vector.of_list x)
-    | _ => fun f x => map f x
-    end f
-  | Pair x y => fun '(x,y) => (simple_denote_to_denote x, simple_denote_to_denote y)
-  | _ => id
   end.
 
 Definition absorb_any (x y: type) :=
@@ -128,44 +70,21 @@ Fixpoint ntuple t n : type :=
   | S n => Pair t (ntuple t n)
   end.
 
-Fixpoint simple_default {t: type} : simple_denote_type t :=
-  match t return simple_denote_type t with
-  | Unit => tt
-  | Bit => false
-  | Vec t1 n => List.repeat simple_default n
-  | Pair x y => (@simple_default x, @simple_default y)
-  end.
-
 Fixpoint default {t: type} : denote_type t :=
   match t return denote_type t with
   | Unit => tt
-  | Bit => false
-  | Vec t1 n =>
-    match t1 return denote_type t1 -> denote_type (Vec t1 n) with
-    | Bit => fun _ => 0%N
-    | _ => fun d => List.repeat d n
-    end default
+  | BitVec n => 0%N
+  | Vec t1 n => List.repeat default n
   | Pair x y => (@default x, @default y)
   end.
 
-Definition via_simple {a b} (f: simple_denote_type a -> simple_denote_type b)
-  : denote_type a -> denote_type b
-  := fun x => simple_denote_to_denote (f (denote_to_simple_denote x)).
-Definition via_simple2 {a b c} (f: simple_denote_type a -> simple_denote_type b -> simple_denote_type c)
-  : denote_type a -> denote_type b -> denote_type c
-  := fun x y => simple_denote_to_denote (f (denote_to_simple_denote x) (denote_to_simple_denote y)).
-
 Fixpoint vector_as_tuple n t {struct n}
-  : simple_denote_type (Vec t (S n)) -> simple_denote_type (ntuple t n) :=
+  : denote_type (Vec t (S n)) -> denote_type (ntuple t n) :=
   match n with
-  | O => fun x => hd simple_default x
+  | O => fun x => hd default x
   | S n' => fun ls =>
-    (hd simple_default ls, vector_as_tuple _ _ (tl ls))
+    (hd default ls, vector_as_tuple _ _ (tl ls))
   end.
-
-Definition vector_as_tuple1 n t (x: denote_type (Vec t (S n)))
-  : simple_denote_type (ntuple t n) :=
-  vector_as_tuple _ _ (denote_to_simple_denote x).
 
 Declare Scope circuit_type_scope.
 Delimit Scope circuit_type_scope with circuit_type.


### PR DESCRIPTION
Resolves #877 

- Makes `BitVec` a constructor of the `type` inductive, replacing `Bit`
- Removes `simple_denote_type`; it's no longer necessary if `BitVec` is always `N` and `Vec` is always `list`
- Removes `take` and `drop` in favor of `skipn` and `firstn` (they appeared to be exactly equivalent; any reason to use our own custom definitions instead of the standard library here?)
- Adjusts primitives so that "arithmetic"-type operations (e.g. shifting, addition, bitwise operations) are defined only on `BitVec`, and "vector"-type operations (e.g. uncons, reverse) are defined only on `Vec`; some operations, such as resizing and concatenation, are defined on both
- Adapts circuits to new setup

@blaxill the intermediate tests for `sha_inner` and `sha_padder` are working, but `sha256` isn't and I don't understand the desired control flow well enough to debug it. I didn't change the body of `sha256` at all, so I'm a little perplexed. Would you mind either debugging the test or writing some comments that explain what's going on and what the intermediate values of state variables are expected to be so that I can debug it more effectively?