### PR TITLE
Modify SHA-256 and HMAC specs to have interfaces based on bytes

### DIFF
--- a/cava/Cava/Util/BitArithmetic.v
+++ b/cava/Cava/Util/BitArithmetic.v
@@ -193,6 +193,8 @@ Module BigEndianBytes.
     List.map (fun i => concat_bytes (firstn n (skipn (n*i) x))) (seq 0 (length x / 4)).
 End BigEndianBytes.
 
+Definition byte_xor (x y : byte) : byte := N_to_byte (N.lxor (Byte.to_N x) (Byte.to_N y)).
+
 (******************************************************************************)
 (* Arithmetic operations                                                      *)
 (******************************************************************************)

--- a/cava/Cava/Util/String.v
+++ b/cava/Cava/Util/String.v
@@ -20,5 +20,8 @@ Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
 Require Import Cava.Util.BitArithmetic.
 
+Definition string_to_bytes (s : string) : list Byte.byte :=
+  map byte_of_ascii (list_ascii_of_string s).
+
 Definition string_to_N (s : string) : N :=
-  concat_bytes (map N_of_ascii (list_ascii_of_string s)).
+  BigEndianBytes.concat_bytes (string_to_bytes s).

--- a/silveroak-opentitan/hmac/Spec/SHA256.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256.v
@@ -144,12 +144,12 @@ Section WithMessage.
      binary representation.
    *)
   (* N.B. calculation of k is done in Z to avoid subtraction underflow *)
-  Definition k := Z.to_N ((448 - (Z.of_N l + 1)) mod 512)%Z.
+  Definition k (l : N) := Z.to_N ((448 - (Z.of_N l + 1)) mod 512)%Z.
 
   (* we know that (k+1) must be positive and a multiple of 8, so 1 << k can
      be expressed as bytes *)
   Definition padding : list byte :=
-    x80 :: (repeat x00 (((N.to_nat k+1) / 8) - 1)).
+    x80 :: (repeat x00 (((N.to_nat (k l)+1) / 8) - 1)).
 
   Definition padded_msg_bytes : list byte := msg ++ padding ++ N_to_bytes 8 l.
 
@@ -157,7 +157,7 @@ Section WithMessage.
   Definition padded_msg : list N := bytes_to_Ns (N.to_nat w / 8) padded_msg_bytes.
 
   (* Number of 512-bit blocks in padded message *)
-  Definition Nblocks : N := (N.add (N.add l k) 65) / 512.
+  Definition Nblocks : N := (N.add (N.add l (k l)) 65) / 512.
 
   (* From section 5.2.1:
 

--- a/silveroak-opentitan/hmac/Spec/SHA256.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256.v
@@ -18,28 +18,9 @@ Require Import Coq.Init.Byte.
 Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
 Require Import Coq.ZArith.ZArith.
-Import ListNotations.
+Require Import Cava.Util.BitArithmetic.
+Import ListNotations BigEndianBytes.
 Local Open Scope N_scope.
-
-(* Convert the least significant 8 bits of a number to a byte *)
-Definition N_to_byte (x : N) : byte :=
-  match Byte.of_N (x mod 2^8) with
-  | Some b => b
-  | None => x00
-  end.
-
-(* convert the least significant (n*8) bits of a number to big-endian bytes *)
-Definition N_to_bytes n (x : N) : list byte :=
-  map (fun i => N_to_byte (N.shiftr x ((N.of_nat n-1)*8-N.of_nat i))) (seq 0 n).
-
-(* evaluate a big-endian list of bytes *)
-Definition bytes_to_N (x : list byte) : N :=
-  fold_left (fun acc b => N.lor (N.shiftl acc 8) (Byte.to_N b)) x 0.
-
-(* convert a big-endian list of bytes to a list of n-byte words (length of list
-   must be a multiple of n) *)
-Definition bytes_to_Ns n (x : list byte) : list N :=
-  map (fun i => bytes_to_N (firstn 4 (skipn (4*i) x))) (seq 0 n).
 
 (* Specification of SHA-256 as described by FIPS 180-4:
    https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf  *)

--- a/silveroak-opentitan/hmac/Spec/SHA256Properties.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256Properties.v
@@ -27,13 +27,13 @@ Local Ltac t := cbv [k]; lia'.
 
 (* k is a solution to the equation:
      l + 1 + k = 448 (mod 512) *)
-Lemma k_correct l : (l + 1 + k l) mod 512 = 448.
+Lemma k_correct msg : (l msg + 1 + k msg) mod 512 = 448.
 Proof. t. Qed.
 
 (* Prove that k < 512 *)
-Lemma k_small l : k l < 512.
+Lemma k_small msg : k msg < 512.
 Proof. t. Qed.
 
 (* Prove that k is the smallest non-negative solution to the equation *)
-Lemma k_smallest l n : (l + 1 + n) mod 512 = 448 -> n >= k l.
+Lemma k_smallest msg n : (l msg + 1 + n) mod 512 = 448 -> n >= k msg.
 Proof. t. Qed.

--- a/silveroak-opentitan/hmac/Spec/Tests/HMACTestVectors.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/HMACTestVectors.v
@@ -15,13 +15,17 @@
 (****************************************************************************)
 
 Require Import Coq.NArith.NArith.
+Require Import Cava.Util.BitArithmetic.
+Import BigEndianBytes.
 Local Open Scope N_scope.
 
 Record hmac_test_vector :=
-  { lK : nat;
-    ldata : nat;
+  { lK : nat; (* length of K in bytes *)
+    ldata : nat; (* length of data in bytes *)
     K : N;
     data : N;
+    K_bytes := N_to_bytes lK K;
+    data_bytes := N_to_bytes ldata data;
     expected_output : N }.
 
 Record hmac_step_by_step_test : Type :=

--- a/silveroak-opentitan/hmac/Spec/Tests/HMACTests.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/HMACTests.v
@@ -16,9 +16,10 @@
 
 Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
+Require Import Cava.Util.BitArithmetic.
 Require Import HmacSpec.HMAC.
 Require Import HmacSpec.Tests.HMACTestVectors.
-Import ListNotations.
+Import ListNotations BigEndianBytes.
 Local Open Scope N_scope.
 
 (* Uncomment the below for step-by-step tests of intermediate values for test1
@@ -26,27 +27,30 @@ Local Open Scope N_scope.
 (*
 (* Check key padding *)
 Goal (let t := test1 in
-      padded_key t.(lK) t.(K) = t.(expected_padded_key)).
+      concat_bytes (padded_key t.(K_bytes)) = t.(expected_padded_key)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check K ^ ipad *)
 Goal (let t := test1 in
-      N.lxor t.(expected_padded_key) ipad = t.(expected_xor_K_ipad)).
+      concat_bytes (XOR (N_to_bytes B t.(expected_padded_key)) ipad)
+      = t.(expected_xor_K_ipad)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check K ^ opad *)
 Goal (let t := test1 in
-      N.lxor t.(expected_padded_key) opad = t.(expected_xor_K_opad)).
+      concat_bytes (XOR (N_to_bytes B t.(expected_padded_key)) opad)
+      = t.(expected_xor_K_opad)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check inner hash result *)
 Goal (let t := test1 in
-      H B t.(ldata) t.(expected_xor_K_ipad) t.(data) = t.(expected_inner)).
+      concat_bytes (H (N_to_bytes B t.(expected_xor_K_ipad)) (N_to_bytes t.(ldata) t.(data)))
+      = t.(expected_inner)).
 Proof. vm_compute. reflexivity. Qed.
 *)
 
 Goal (let t := test1 in
-      hmac_sha256 t.(lK) t.(ldata) t.(K) t.(data) = t.(expected_output)).
+      concat_bytes (hmac_sha256 t.(K_bytes) t.(data_bytes)) = t.(expected_output)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Uncomment the below for step-by-step tests of intermediate values for test2
@@ -54,27 +58,30 @@ Proof. vm_compute. reflexivity. Qed.
 (*
 (* Check key padding *)
 Goal (let t := test2 in
-      padded_key t.(lK) t.(K) = t.(expected_padded_key)).
+      concat_bytes (padded_key t.(K_bytes)) = t.(expected_padded_key)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check K ^ ipad *)
 Goal (let t := test2 in
-      N.lxor t.(expected_padded_key) ipad = t.(expected_xor_K_ipad)).
+      concat_bytes (XOR (N_to_bytes B t.(expected_padded_key)) ipad)
+      = t.(expected_xor_K_ipad)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check K ^ opad *)
 Goal (let t := test2 in
-      N.lxor t.(expected_padded_key) opad = t.(expected_xor_K_opad)).
+      concat_bytes (XOR (N_to_bytes B t.(expected_padded_key)) opad)
+      = t.(expected_xor_K_opad)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check inner hash result *)
 Goal (let t := test2 in
-      H B t.(ldata) t.(expected_xor_K_ipad) t.(data) = t.(expected_inner)).
+      concat_bytes (H (N_to_bytes B t.(expected_xor_K_ipad)) (N_to_bytes t.(ldata) t.(data)))
+      = t.(expected_inner)).
 Proof. vm_compute. reflexivity. Qed.
 *)
 
 Goal (let t := test2 in
-      hmac_sha256 t.(lK) t.(ldata) t.(K) t.(data) = t.(expected_output)).
+      concat_bytes (hmac_sha256 t.(K_bytes) t.(data_bytes)) = t.(expected_output)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Uncomment the below for step-by-step tests of intermediate values for test3
@@ -82,25 +89,28 @@ Proof. vm_compute. reflexivity. Qed.
 (*
 (* Check key padding *)
 Goal (let t := test3 in
-      padded_key t.(lK) t.(K) = t.(expected_padded_key)).
+      concat_bytes (padded_key t.(K_bytes)) = t.(expected_padded_key)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check K ^ ipad *)
 Goal (let t := test3 in
-      N.lxor t.(expected_padded_key) ipad = t.(expected_xor_K_ipad)).
+      concat_bytes (XOR (N_to_bytes B t.(expected_padded_key)) ipad)
+      = t.(expected_xor_K_ipad)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check K ^ opad *)
 Goal (let t := test3 in
-      N.lxor t.(expected_padded_key) opad = t.(expected_xor_K_opad)).
+      concat_bytes (XOR (N_to_bytes B t.(expected_padded_key)) opad)
+      = t.(expected_xor_K_opad)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* Check inner hash result *)
 Goal (let t := test3 in
-      H B t.(ldata) t.(expected_xor_K_ipad) t.(data) = t.(expected_inner)).
+      concat_bytes (H (N_to_bytes B t.(expected_xor_K_ipad)) (N_to_bytes t.(ldata) t.(data)))
+      = t.(expected_inner)).
 Proof. vm_compute. reflexivity. Qed.
  *)
 
 Goal (let t := test3 in
-      hmac_sha256 t.(lK) t.(ldata) t.(K) t.(data) = t.(expected_output)).
+      concat_bytes (hmac_sha256 t.(K_bytes) t.(data_bytes)) = t.(expected_output)).
 Proof. vm_compute. reflexivity. Qed.

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
@@ -24,6 +24,7 @@ Local Open Scope N_scope.
 Record sha256_test_vector :=
   { msg : string;
     msg_N := string_to_N msg;
+    msg_bytes := string_to_bytes msg;
     l := N.of_nat (String.length msg * 8);
     expected_digest : N }.
 

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
@@ -16,32 +16,36 @@
 
 Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
+Require Import Cava.Util.BitArithmetic.
 Require Import HmacSpec.SHA256.
 Require Import HmacSpec.Tests.SHA256TestVectors.
-Import ListNotations.
+Import ListNotations BigEndianBytes.
 Local Open Scope N_scope.
 
 (* Tests for SHA-256 spec *)
 
+(* Helper function for evaluating big-endian lists of words *)
+Definition eval_words (x : list N) : N :=
+  fold_left (fun acc => N.lor (N.shiftl acc w)) x 0.
+
 (* Uncomment the below for step-by-step tests of intermediate values for test1
    (useful for debugging) *)
-
 (*
 (* test Nblocks *)
 Goal (let t := test1 in
-      Nblocks t.(l) = N.of_nat (List.length (t.(expected_blocks)))).
+      Nblocks t.(msg_bytes) = N.of_nat (List.length (t.(expected_blocks)))).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test padded_msg *)
 Goal (let t := test1 in
-      padded_msg t.(l) t.(msg_N) = t.(expected_padded_msg)).
+      eval_words (padded_msg t.(msg_bytes)) = t.(expected_padded_msg)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test first 16 blocks of W for round 0 *)
 Goal (let t := test1 in
-      let i := 0 in
-      let expected_W := nth (N.to_nat i) t.(expected_blocks) [] in
-      firstn 16 (W t.(l) t.(msg_N) i) = expected_W).
+      let i := 0%nat in
+      let expected_W := nth i t.(expected_blocks) [] in
+      firstn 16 (W t.(msg_bytes) i) = expected_W).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test round 0 *)
@@ -49,34 +53,34 @@ Goal (let t := test1 in
       let i := 0%nat in
       let old_H := H0 in
       let expected_H := nth i t.(expected_intermediate_digests) [] in
-      sha256_step t.(l) t.(msg_N) old_H i = expected_H).
+      sha256_step t.(msg_bytes) old_H i = expected_H).
 Proof. vm_compute. reflexivity. Qed.
-*)
+ *)
 
 (* test final digest *)
 Goal (let t := test1 in
-      sha256 t.(l) t.(msg_N) = t.(expected_digest)).
+      concat_bytes (sha256 t.(msg_bytes)) = t.(expected_digest)).
 Proof. vm_compute. reflexivity. Qed.
+
 
 (* Uncomment the below for step-by-step tests of intermediate values for test2
    (useful for debugging) *)
-
 (*
 (* test Nblocks *)
 Goal (let t := test2 in
-      Nblocks t.(l) = N.of_nat (List.length (t.(expected_blocks)))).
+      Nblocks t.(msg_bytes) = N.of_nat (List.length (t.(expected_blocks)))).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test padded_msg *)
 Goal (let t := test2 in
-      padded_msg t.(l) t.(msg_N) = t.(expected_padded_msg)).
+      eval_words (padded_msg t.(msg_bytes)) = t.(expected_padded_msg)).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test first 16 blocks of W for round 0 *)
 Goal (let t := test2 in
-      let i := 0 in
-      let expected_W := nth (N.to_nat i) t.(expected_blocks) [] in
-      firstn 16 (W t.(l) t.(msg_N) i) = expected_W).
+      let i := 0%nat in
+      let expected_W := nth i t.(expected_blocks) [] in
+      firstn 16 (W t.(msg_bytes) i) = expected_W).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test round 0 *)
@@ -84,14 +88,14 @@ Goal (let t := test2 in
       let i := 0%nat in
       let old_H := H0 in
       let expected_H := nth i t.(expected_intermediate_digests) [] in
-      sha256_step t.(l) t.(msg_N) old_H i = expected_H).
+      sha256_step t.(msg_bytes) old_H i = expected_H).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test first 16 blocks of W for round 1 *)
 Goal (let t := test2 in
-      let i := 1 in
-      let expected_W := nth (N.to_nat i) t.(expected_blocks) [] in
-      firstn 16 (W t.(l) t.(msg_N) i) = expected_W).
+      let i := 1%nat in
+      let expected_W := nth i t.(expected_blocks) [] in
+      firstn 16 (W t.(msg_bytes) i) = expected_W).
 Proof. vm_compute. reflexivity. Qed.
 
 (* test round 1 *)
@@ -99,11 +103,11 @@ Goal (let t := test2 in
       let i := 1%nat in
       let old_H := nth (i-1) t.(expected_intermediate_digests) [] in
       let expected_H := nth i t.(expected_intermediate_digests) [] in
-      sha256_step t.(l) t.(msg_N) old_H i = expected_H).
+      sha256_step t.(msg_bytes) old_H i = expected_H).
 Proof. vm_compute. reflexivity. Qed.
 *)
 
 (* test final digest *)
 Goal (let t := test2 in
-      sha256 t.(l) t.(msg_N) = t.(expected_digest)).
+      concat_bytes (sha256 t.(msg_bytes)) = t.(expected_digest)).
 Proof. vm_compute. reflexivity. Qed.

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
@@ -31,11 +31,6 @@ Definition eval_words (x : list N) : N :=
 (* Uncomment the below for step-by-step tests of intermediate values for test1
    (useful for debugging) *)
 (*
-(* test Nblocks *)
-Goal (let t := test1 in
-      Nblocks t.(msg_bytes) = N.of_nat (List.length (t.(expected_blocks)))).
-Proof. vm_compute. reflexivity. Qed.
-
 (* test padded_msg *)
 Goal (let t := test1 in
       eval_words (padded_msg t.(msg_bytes)) = t.(expected_padded_msg)).
@@ -66,11 +61,6 @@ Proof. vm_compute. reflexivity. Qed.
 (* Uncomment the below for step-by-step tests of intermediate values for test2
    (useful for debugging) *)
 (*
-(* test Nblocks *)
-Goal (let t := test2 in
-      Nblocks t.(msg_bytes) = N.of_nat (List.length (t.(expected_blocks)))).
-Proof. vm_compute. reflexivity. Qed.
-
 (* test padded_msg *)
 Goal (let t := test2 in
       eval_words (padded_msg t.(msg_bytes)) = t.(expected_padded_msg)).


### PR DESCRIPTION
Implements the change discussed in https://github.com/project-oak/silveroak/pull/872#issuecomment-896059991

This changes the SHA-256 and HMAC specifications so that they take their inputs as lists of bytes (instead of a length parameter and an `N`). SHA-256 internally then converts the input to `N` after padding, which seems to strike a nice balance between doing logically-bytewise operations on bytes and logically-numeric operations on `N`. It should also make the bedrock2 interface smoother.