### PR TITLE
Prove sha256_compress correct

### DIFF
--- a/investigations/cava2/Semantics.v
+++ b/investigations/cava2/Semantics.v
@@ -24,6 +24,8 @@ Require Import Cava.Types.
 Require Import Cava.Expr.
 Require Import Cava.Primitives.
 
+Local Open Scope circuit_type_scope.
+
 Definition split_absorbed_denotation {x y}
   : denote_type (x ++ y) -> denote_type x * denote_type y :=
   match x, y with

--- a/investigations/cava2/Sha256Properties.v
+++ b/investigations/cava2/Sha256Properties.v
@@ -1,0 +1,69 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Init.Byte.
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import Coq.NArith.NArith.
+Require Import Cava.Types.
+Require Import Cava.Expr.
+Require Import Cava.Primitives.
+Require Import Cava.Semantics.
+Require Import Cava.Sha256.
+Require Import Cava.Util.List.
+Require Import Cava.Util.Tactics.
+Require HmacSpec.SHA256.
+Import ListNotations.
+
+(* TODO: move to a more general file *)
+Lemma step_vec_as_tuple_cons {t n} x0 (xs : list (denote_type t)) :
+  step (vec_as_tuple (t:=t) (n:=S n)) tt (x0 :: xs, tt)
+  = (tt, (x0, snd (step (vec_as_tuple (t:=t) (n:=n)) tt (xs, tt)))).
+Proof. reflexivity. Qed.
+Hint Rewrite @step_vec_as_tuple_cons using solve [eauto] : stepsimpl.
+Lemma step_vec_as_tuple_one {t} (x : denote_type t):
+  step (vec_as_tuple (t:=t) (n:=0)) tt ([x], tt) = (tt, x).
+Proof. reflexivity. Qed.
+Hint Rewrite @step_vec_as_tuple_one using solve [eauto] : stepsimpl.
+Ltac stepsimpl :=
+  repeat first [ progress
+                   cbn [fst snd step denote_type absorb_any
+                            split_absorbed_denotation combine_absorbed_denotation
+                            unary_semantics binary_semantics ]
+               | progress autorewrite with stepsimpl ].
+
+Lemma step_rotr n (x : denote_type sha_word) :
+  step (rotr n) tt (x,tt) = (tt, SHA256.ROTR (N.of_nat n) x).
+Proof.
+  cbv [rotr]. stepsimpl.
+  cbv [SHA256.ROTR SHA256.truncating_shiftl SHA256.w].
+  repeat (f_equal; try lia).
+Qed.
+Hint Rewrite @step_rotr using solve [eauto] : stepsimpl.
+
+Lemma step_sha256_compress
+      (H : denote_type sha_digest)
+      (k w : denote_type sha_word) (t i : nat) (msg : list byte) :
+  length H = 8 ->
+  k = nth t SHA256.K 0%N ->
+  w = nth t (SHA256.W msg i) 0%N ->
+  step sha256_compress tt (H,(k,(w,tt)))
+  = (tt, SHA256.sha256_compress msg i H t).
+Proof.
+  intros. subst; destruct_lists_by_length.
+  cbv [sha256_compress]. stepsimpl. reflexivity.
+Qed.
+Hint Rewrite @step_sha256_compress using solve [eauto] : stepsimpl.

--- a/investigations/cava2/TLUL.v
+++ b/investigations/cava2/TLUL.v
@@ -53,7 +53,7 @@ Definition TL_SZW := 2. (* $clog2($clog2(TL_DBW)+1). *)
 (* (1*   logic                         d_ready; *1)   1 *)
 (* (1* } tl_h2d_t; *1)
 =102 *)
-Definition tl_h2d_t :=
+Definition tl_h2d_t : type :=
   Bit **
   BitVec 3 **
   BitVec 3 **
@@ -78,7 +78,7 @@ Definition tl_h2d_t :=
 (*   logic                         a_ready; *)
 (* } tl_d2h_t; *)
 
-Definition tl_d2h_t :=
+Definition tl_d2h_t : type :=
   Bit **
   BitVec 3 **
   BitVec 3 **
@@ -114,7 +114,7 @@ Section Var.
   Definition AccessAck     := Constant tl_d_op_e 0.
   Definition AccessAckData := Constant tl_d_op_e 1.
 
-  Definition io_req :=
+  Definition io_req : type :=
     Bit **          (* write *)
     BitVec TL_AW ** (* address *)
     BitVec TL_DW ** (* write_data *)

--- a/investigations/cava2/Types.v
+++ b/investigations/cava2/Types.v
@@ -88,10 +88,9 @@ Fixpoint vector_as_tuple n t {struct n}
 
 Declare Scope circuit_type_scope.
 Delimit Scope circuit_type_scope with circuit_type.
-Open Scope circuit_type_scope.
+Bind Scope circuit_type_scope with type.
 Notation "[ ]" := Unit (format "[ ]") : circuit_type_scope.
 Notation "[ x ]" := (Pair x Unit) : circuit_type_scope.
 Notation "[ x ; y ; .. ; z ]" := (Pair x (Pair y .. (Pair z Unit) ..)) : circuit_type_scope.
 Notation "x ** y" := (Pair x y)(at level 60, right associativity) : circuit_type_scope.
 Notation "x ++ y" := (absorb_any x y) (at level 60, right associativity): circuit_type_scope.
-

--- a/investigations/cava2/_CoqProject
+++ b/investigations/cava2/_CoqProject
@@ -3,6 +3,7 @@ INSTALLDEFAULTROOT = ./
 -R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
 -R . Cava
 -R ../../cava/Cava Cava
+-R ../../silveroak-opentitan/hmac/Spec HmacSpec
 
 Types.v
 Expr.v


### PR DESCRIPTION
As the first major circuit proofs using cava2, this also involved making some infrastructure improvements:
- Circuit type notations were globally `Open`ed in the `Types.v` file, meaning that anyone importing that file (even transitively) couldn't disable them. They directly conflict with list notations, so this was problematic. Instead, I've used `Bind Scope` to make Coq automatically interpret things it knows are `type`s in `circuit_type_scope`. The previous behavior can be recreated using `Local Open Scope circuit_type_scope`, but in practice the `Bind Scope` was enough in most places.
- Moved the various primitive circuits out of `PrimitiveNotations` so that it's possible to not import `PrimitiveNotations` (in proofs, I find circuit notations are unhelpful because I just translate it all into Gallina immediately anyway) and not have everything prefixed by `PrimitiveNotations.`