### PR TITLE
Fix bug in SHA-256 spec

### DIFF
--- a/cava/Cava/Util/String.v
+++ b/cava/Cava/Util/String.v
@@ -25,3 +25,10 @@ Definition string_to_bytes (s : string) : list Byte.byte :=
 
 Definition string_to_N (s : string) : N :=
   BigEndianBytes.concat_bytes (string_to_bytes s).
+
+Definition bytes_to_string (bs : list Byte.byte) : string :=
+  string_of_list_ascii (map ascii_of_byte bs).
+
+(* n is the number of bytes expected *)
+Definition N_to_string (n : nat) (s : N) : string :=
+  bytes_to_string (BigEndianBytes.N_to_bytes n s).

--- a/silveroak-opentitan/hmac/Spec/SHA256.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256.v
@@ -219,7 +219,7 @@ Section WithMessage.
     (* steps 2-3 : compression loop *)
     let H' := fold_left (sha256_compress i) (seq 0 64) H in
     (* step 4 : get ith intermediate hash value by adding each element *)
-    map2 N.add H' H.
+    map2 add_mod H H'.
 
   (* Concatenate the w-bit words of the hash value to get the full digest *)
   Definition concat_digest (H : list N) :=

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
@@ -134,3 +134,9 @@ Definition test2 : sha256_step_by_step_test :=
          ; 0xF6ECEDD4
          ; 0x19DB06C1 ] ];
   |}.
+
+(* Regression test : corresponds to the inner hash from HMAC test vector 1 from
+      https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/HMAC_SHA256.pdf  *)
+Definition test3 : sha256_test_vector :=
+  {| msg := N_to_string (64+34) 0x36373435323330313E3F3C3D3A3B383926272425222320212E2F2C2D2A2B282916171415121310111E1F1C1D1A1B181906070405020300010E0F0C0D0A0B080953616D706C65206D65737361676520666F72206B65796C656E3D626C6F636B6C656E;
+     expected_digest := 0xC0918E14C43562B910DB4B8101CF8812C3DA2783C670BFF34D88B3B88E731716 |}.

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
@@ -101,3 +101,8 @@ Proof. vm_compute. reflexivity. Qed.
 Goal (let t := test2 in
       concat_bytes (sha256 t.(msg_bytes)) = t.(expected_digest)).
 Proof. vm_compute. reflexivity. Qed.
+
+(* test final digest *)
+Goal (let t := test3 in
+      concat_bytes (sha256 t.(msg_bytes)) = t.(expected_digest)).
+Proof. vm_compute. reflexivity. Qed.


### PR DESCRIPTION
#890 introduced a bug (`N.add` instead of `add_mod`). It wasn't caught by the SHA-256 test vectors (I guess none of them had an overflow there) but was caught by the HMAC tests, so I've added an extra test case to the SHA-256 tests that tests with the particular input that triggered the bug so we catch it earlier.

This wasn't caught by CI because it appears CI is not actually running the things under `silveroak-opentitan/hmac`. We should fix that. Thanks to Ben for pointing out to me that the HMAC tests were failing!