### PR TITLE
Fix subtraction underflow bug

### DIFF
--- a/cava2/Primitives.v
+++ b/cava2/Primitives.v
@@ -89,7 +89,7 @@ Definition binary_semantics {x y r} (prim: BinaryPrim x y r)
   | @BinBitVecXor n => N.lxor
   | @BinBitVecAnd n => N.land
   | @BinBitVecAddU n => fun x y => ((x + y) mod (2 ^ (N.of_nat n)))%N
-  | @BinBitVecSubU n => fun x y => ((x - y + 2 ^ N.of_nat n) mod (2 ^ (N.of_nat n)))%N
+  | @BinBitVecSubU n => fun x y => ((x + 2 ^ N.of_nat n - y) mod (2 ^ (N.of_nat n)))%N
   | @BinVecIndex t len i => fun x n => nth (N.to_nat n) (resize default len x) default
   | BinVecCons => fun x y => x :: y
   | BinVecConcat => fun x y => x ++ y


### PR DESCRIPTION
Noticed this as I was browsing the code. Basically, Coq's addition and subtraction for `N` is left-associative, so the current implementation doesn't protect from underflow since it groups as `((x - y) + 2 ^ n) mod 2 ^ n`.

Specific example of the problem (`n=3`):
```coq
Compute ((2 - 3 + 8) mod 8)%N. (* 0 *)
Compute ((2 + 8 - 3) mod 8)%N. (* 7 *)
```