### PR TITLE
Re-add Bit type and adapt proofs/circuits

### DIFF
--- a/cava2/Expr.v
+++ b/cava2/Expr.v
@@ -135,8 +135,8 @@ End ExprNotations.
 Section Var.
   Context {var : tvar}.
 
-  Definition True := Constant Bit 1.
-  Definition False := Constant Bit 0.
+  Definition True := Constant Bit true.
+  Definition False := Constant Bit false.
   Definition K {sz}(x: N) := Constant (BitVec sz) x.
 
 End Var.
@@ -200,14 +200,21 @@ Module PrimitiveNotations.
   Notation "~ x" := (
     Let x (fun v1 => UnaryOp UnBitVecNot v1)
   ) (in custom expr at level 19, no associativity) : expr_scope.
-  (* ! is identical to ~ but only works on 1-bit bit vectors (i.e. booleans) *)
   Notation "! x" := (
-    Let x (fun v1 => UnaryOp (@UnBitVecNot 1) v1)
+    Let x (fun v1 => UnaryOp UnBitNot v1)
   ) (in custom expr at level 19, no associativity) : expr_scope.
   Notation "x == y" := (
     Let x (fun v1 => Let y (fun v2 =>
       BinaryOp BinEq v1 v2
   ))) (in custom expr at level 19, no associativity) : expr_scope.
+  Notation "x || y" := (
+    Let x (fun v1 => Let y (fun v2 =>
+      BinaryOp BinBitOr v1 v2
+  ))) (in custom expr at level 20, left associativity) : expr_scope.
+  Notation "x && y" := (
+    Let x (fun v1 => Let y (fun v2 =>
+      BinaryOp BinBitAnd v1 v2
+  ))) (in custom expr at level 20, left associativity) : expr_scope.
   Notation "x | y" := (
     Let x (fun v1 => Let y (fun v2 =>
       BinaryOp BinBitVecOr v1 v2

--- a/cava2/Fifo.v
+++ b/cava2/Fifo.v
@@ -43,8 +43,8 @@ Section Var.
     let/delay '(fifo; current_length) :=
 
       ( if data_valid then data +>> fifo else fifo
-      , if data_valid & !out_ready then current_length + `K 1`
-        else if !data_valid & out_ready & current_length >= `K 1` then (current_length - `K 1`)
+      , if data_valid && !out_ready then current_length + `K 1`
+        else if (!data_valid) && out_ready && current_length >= `K 1` then (current_length - `K 1`)
         else current_length
       )
 
@@ -64,7 +64,7 @@ Require Import Cava.Util.Tactics.
 Require Import coqutil.Tactics.Tactics.
 
 Definition no_io_predicate (x: denote_type (Bit**BitVec 32**Bit**Unit))
-  := fst x = 0 /\ fst (snd (snd x)) = 0.
+  := fst x = false /\ fst (snd (snd x)) = false.
 
 Lemma fifo_no_change :
   forall sz st input, no_io_predicate input ->
@@ -74,7 +74,7 @@ Proof.
   cbn [step fifo absorb_any split_absorbed_denotation combine_absorbed_denotation
     denote_type binary_semantics unary_semantics K
       ]. unfold no_io_predicate in *.
-  cbn [fst snd] in *. logical_simplify; subst.
+  cbn [fst snd] in *. logical_simplify; subst. boolsimpl.
   repeat lazymatch goal with u : unit |- _ => destruct u end.
   repeat (destruct_pair_let; cbn [fst snd]).
   reflexivity.

--- a/cava2/Semantics.v
+++ b/cava2/Semantics.v
@@ -76,7 +76,7 @@ Fixpoint step {i s o} (c : Circuit s i o)
     let '(sf, sg) := split_absorbed_denotation s in
     let '(nsf, fo) := step f sf tt in
     let '(nsg, go) := step g sg tt in
-    (combine_absorbed_denotation nsf nsg, if (bv =? 0)%N then go else fo)
+    (combine_absorbed_denotation nsf nsg, if bv then fo else go)
 
   | MakePair f g => fun s _ =>
     let '(sf, sg) := split_absorbed_denotation s in

--- a/cava2/TLUL.v
+++ b/cava2/TLUL.v
@@ -148,12 +148,12 @@ Section Var.
 
     let/delay '(reqid, reqsz, rspop, error, outstanding, we_o; re_o) :=
 
-      let a_ack := a_valid & !outstanding in
-      let d_ack := outstanding & d_ready in
+      let a_ack := a_valid && !outstanding in
+      let d_ack := outstanding && d_ready in
 
-      let rd_req := a_ack & a_opcode == `Get` in
-      let wr_req := a_ack &
-        (a_opcode == `PutFullData` | a_opcode == `PutPartialData`) in
+      let rd_req := a_ack && a_opcode == `Get` in
+      let wr_req := a_ack &&
+        (a_opcode == `PutFullData` || a_opcode == `PutPartialData`) in
 
       (* TODO(blaxill): skipping malformed tl packet detection *)
       let err_internal := `False` in
@@ -164,18 +164,18 @@ Section Var.
           ( a_source
           , a_size
           , if rd_req then `AccessAckData` else `AccessAck`
-          , error_i | err_internal
+          , error_i || err_internal
           , `False`
           )
         else
           (reqid, reqsz, rspop, error, if d_ack then `False` else outstanding)
       in
 
-      let we_o := wr_req & !err_internal in
-      let re_o := rd_req & !err_internal in
+      let we_o := wr_req && !err_internal in
+      let re_o := rd_req && !err_internal in
 
       (reqid, reqsz, rspop, error, outstanding, we_o, re_o)
-      initially (0,(0,(0,(0,(0,(0,0))))))
+      initially (0,(0,(0,(false,(false,(false,false))))))
         : denote_type (BitVec _ ** BitVec _ ** BitVec _ ** Bit ** Bit ** Bit ** Bit)
     in
 

--- a/cava2/Types.v
+++ b/cava2/Types.v
@@ -26,12 +26,11 @@ Require Import Cava.Util.Vector.
 
 Inductive type :=
 | Unit : type
+| Bit : type
 | BitVec  : nat -> type
 | Vec  : type -> nat -> type
 | Pair : type -> type -> type
 .
-
-Notation Bit := (BitVec 1).
 
 Definition eq_dec_type (x y: type): {x = y} + {x <> y}.
 Proof.
@@ -42,6 +41,7 @@ Defined.
 Fixpoint denote_type (t: type) :=
   match t with
   | Unit => unit
+  | Bit => bool
   | BitVec n => N
   | Vec t n =>list (denote_type t)
   | Pair x y => (denote_type x * denote_type y)%type
@@ -50,7 +50,8 @@ Fixpoint denote_type (t: type) :=
 Fixpoint eqb {t}: denote_type t -> denote_type t -> bool :=
   match t return denote_type t -> denote_type t -> bool with
   | Unit => fun _ _ => true
-  | BitVec n => fun x y => N.eqb x y
+  | Bit => Bool.eqb
+  | BitVec n => N.eqb
   | Vec t n =>
     fun x y =>
       fold_right andb true (map (fun '(x,y) => eqb x y) (combine x y))
@@ -73,6 +74,7 @@ Fixpoint ntuple t n : type :=
 Fixpoint default {t: type} : denote_type t :=
   match t return denote_type t with
   | Unit => tt
+  | Bit => false
   | BitVec n => 0%N
   | Vec t1 n => List.repeat default n
   | Pair x y => (@default x, @default y)

--- a/silveroak-opentitan/hmac/hw/Hmac.v
+++ b/silveroak-opentitan/hmac/hw/Hmac.v
@@ -53,20 +53,20 @@ Section Var.
       (* TODO(blaxill): ignore/mask writes to CMD etc ? *)
       (* TODO(blaxill): apply mask to register writes*)
       let nregisters :=
-        if write_en & !fifo_write
+        if write_en && !fifo_write
         then `replace (n:=hmac_register_count)` registers aligned_address write_data
         else registers
       in
 
       (* cmd_start is set when host writes to hmac.CMD.hash_start *)
       (* and signifies the start of a new message *)
-      let cmd_start := write_en & aligned_address == `REG_CMD` & write_data == `K 1` & !fifo_write in
+      let cmd_start := write_en && aligned_address == `REG_CMD` && write_data == `K 1` && !fifo_write in
       (* cmd_process is set when host writes to hmac.CMD.hash_process *)
       (* and signifies the end of a message *)
-      let cmd_process := write_en & aligned_address == `REG_CMD` & write_data == `K 2` & !fifo_write in
+      let cmd_process := write_en && aligned_address == `REG_CMD` && write_data == `K 2` && !fifo_write in
 
       let '(packer_valid; packer_data)
-        := `tlul_pack` (write_en & fifo_write) write_data write_mask cmd_process in
+        := `tlul_pack` (write_en && fifo_write) write_data write_mask cmd_process in
 
       (* TODO(blaxill): FIX ME *)
       (* let '(_, padded_block; padded_valid) := `sha256_padder` packer_valid packer_data cmd_process `circuit_hole` cmd_start in *)


### PR DESCRIPTION
See discussion https://github.com/project-oak/silveroak/pull/904#discussion_r690325205

Earlier I removed `Bit` and replaced it with `BitVec 1`, with the rationale that this would make our core type system simpler. It does, but it also makes individual proofs harder because you end up doing case analysis on an `N` which really you only expect to be a 0 or 1. I tried out adding `Bit` back as a separate type that is denoted as `bool`, and I think overall the wins for simplicity of invariants etc are worth it, so I suggest we add it back!