### PR TITLE
Rename True and False constant circuits to One and Zero

### DIFF
--- a/cava2/Expr.v
+++ b/cava2/Expr.v
@@ -129,14 +129,13 @@ Module ExprNotations.
 
   Notation "'if' i 'then' t 'else' e" := ((ElimBool i t e))
     (in custom expr at level 5, left associativity) : expr_scope.
-
 End ExprNotations.
 
 Section Var.
   Context {var : tvar}.
 
-  Definition True := Constant Bit true.
-  Definition False := Constant Bit false.
+  Definition One := Constant Bit true.
+  Definition Zero := Constant Bit false.
   Definition K {sz}(x: N) := Constant (BitVec sz) x.
 
 End Var.

--- a/cava2/TLUL.v
+++ b/cava2/TLUL.v
@@ -156,8 +156,8 @@ Section Var.
         (a_opcode == `PutFullData` || a_opcode == `PutPartialData`) in
 
       (* TODO(blaxill): skipping malformed tl packet detection *)
-      let err_internal := `False` in
-      let error_i := `False` in
+      let err_internal := `Zero` in
+      let error_i := `Zero` in
 
       let '(reqid, reqsz, rspop, error; outstanding) :=
         if a_ack then
@@ -165,10 +165,10 @@ Section Var.
           , a_size
           , if rd_req then `AccessAckData` else `AccessAck`
           , error_i || err_internal
-          , `True`
+          , `One`
           )
         else
-          (reqid, reqsz, rspop, error, if d_ack then `False` else outstanding)
+          (reqid, reqsz, rspop, error, if d_ack then `Zero` else outstanding)
       in
 
       let we_o := wr_req && !err_internal in

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -44,14 +44,14 @@ Section Var.
 
         let/delay '(idle, busy, done; value) :=
            if busy == `K 1` then
-             (`False`, `K 2`, `False`, value)
+             (`Zero`, `K 2`, `Zero`, value)
            else if busy == `K 2` then
-                  (`False`, `K 0`, `True`, value + `K 1`)
+                  (`Zero`, `K 0`, `One`, value + `K 1`)
                 else if done then
                        (is_value_read_req, `K 0`, !is_value_read_req, value)
                      else (* idle *)
                        let busy' := if is_value_write_req then `K 1` else `K 0` in
-                       (!is_value_write_req, busy', `False`, req_value)
+                       (!is_value_write_req, busy', `Zero`, req_value)
            initially (false, (0, (false ,0))) : denote_type (Bit ** BitVec 2 ** Bit ** BitVec 32)
         in
 

--- a/silveroak-opentitan/hmac/hw/Hmac.v
+++ b/silveroak-opentitan/hmac/hw/Hmac.v
@@ -97,19 +97,19 @@ Section Var.
       let digest_word := `index` digest ptr in
 
       let '(sha_stream_valid, sha_stream, sha_stream_final; sha_stream_final_length) :=
-             if state == `K 1` then (`True`, key ^ `K 0x36363636`, `False`, `K 0`)
+             if state == `K 1` then (`One`, key ^ `K 0x36363636`, `Zero`, `K 0`)
         else if state == `K 2` then (fifo_valid, fifo_data, fifo_final, fifo_length)
         (* else if state' == `K 3` *)
-        else if state == `K 4` then (`True`, key ^ `K 0x5c5c5c5c`, `False`, `K 0`)
-        else if state == `K 5` then (`True`, digest_word, (ptr == `K 7` ) , `K 4`)
-        else (`False`, `K 0`, `False`, `K 0`)
+        else if state == `K 4` then (`One`, key ^ `K 0x5c5c5c5c`, `Zero`, `K 0`)
+        else if state == `K 5` then (`One`, digest_word, (ptr == `K 7` ) , `K 4`)
+        else (`Zero`, `K 0`, `Zero`, `K 0`)
 
       in
 
       (* I don't think we need to explicitly flush-
          if we are left in a bad state we might need to flush after the last state
       *)
-      let sha_stream_flush := `False` in
+      let sha_stream_flush := `Zero` in
 
       let '(sha_done, sha_digest; sha_ready)
         := `sha256` sha_stream_valid sha_stream sha_stream_final sha_stream_final_length sha_stream_flush in
@@ -139,7 +139,7 @@ Section Var.
       let waiting_for_digest :=
         if (state' == `K 3`) || (state' == `K 6`)
         then ! sha_done
-        else `False` in
+        else `Zero` in
 
       (next_registers, waiting_for_digest, is_consuming, ptr', state', next_digest, sha_ready)
 

--- a/silveroak-opentitan/hmac/hw/Sha256Properties.v
+++ b/silveroak-opentitan/hmac/hw/Sha256Properties.v
@@ -96,7 +96,7 @@ Definition sha256_inner_invariant
            msg (H : list N) (i : nat) : Prop :=
   let '(current_digest, (message_schedule, (done, round))) := state in
   if done
-  then Logic.True (* idle; no guarantees about other state elements *)
+  then True (* idle; no guarantees about other state elements *)
   else
     (* the round is < 64 *)
     (round < 64)%N
@@ -112,14 +112,14 @@ Definition sha256_inner_pre
            msg (i : nat) : Prop :=
   let '(block_valid, (block, (initial_digest, (clear,_)))) := input in
   (* if clear is true, then the message ghost variable is empty *)
-  (if clear then msg = repeat x00 16 /\ i = 0%nat else Logic.True)
+  (if clear then msg = repeat x00 16 /\ i = 0%nat else True)
   (* ...and the initial digest is the digest from the previous i *)
   /\ initial_digest = fold_left (SHA256.sha256_step msg) (seq 0 i) SHA256.H0
   (* ...and if the block is valid, the block is the expected slice of the
      message *)
   /\ (if block_valid
      then block = List.slice 0%N (SHA256.W msg i) 0 16
-     else Logic.True).
+     else True).
 
 Definition sha256_inner_spec
            (input : denote_type [Bit; sha_block; sha_digest; Bit])


### PR DESCRIPTION
Currently, the `True` and `False` constant circuits defined in `Expr.v` mask the definitions of `True` and `False` in Coq's core logic, meaning that if `Expr.v` is imported then you have to write `Logic.True` and `Logic.False`. It's a bit annoying and makes specifications/invariants/proof states less readable. (Some Coq IDE setups, including mine, display `True` and `False` as unicode logical symbols, which makes circuits less readable as well.)

Are these names a suitable alternative?