### PR TITLE
Fix bug in SHA-256 padder

### DIFF
--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256TestVectors.v
@@ -140,3 +140,9 @@ Definition test2 : sha256_step_by_step_test :=
 Definition test3 : sha256_test_vector :=
   {| msg := N_to_string (64+34) 0x36373435323330313E3F3C3D3A3B383926272425222320212E2F2C2D2A2B282916171415121310111E1F1C1D1A1B181906070405020300010E0F0C0D0A0B080953616D706C65206D65737361676520666F72206B65796C656E3D626C6F636B6C656E;
      expected_digest := 0xC0918E14C43562B910DB4B8101CF8812C3DA2783C670BFF34D88B3B88E731716 |}.
+
+(* Regression test : checks that padder correctly handles the case where there
+   is exactly one word between message and length (52 characters)  *)
+Definition test4 : sha256_test_vector :=
+  {| msg := "abcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwxyz";
+     expected_digest := 0x8794B1A351873E838EE68D51098C279E9F50ABF5D8B8CBABE97EA3BEA57C6EC7 |}.

--- a/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
+++ b/silveroak-opentitan/hmac/Spec/Tests/SHA256Tests.v
@@ -106,3 +106,8 @@ Proof. vm_compute. reflexivity. Qed.
 Goal (let t := test3 in
       concat_bytes (sha256 t.(msg_bytes)) = t.(expected_digest)).
 Proof. vm_compute. reflexivity. Qed.
+
+(* test final digest *)
+Goal (let t := test4 in
+      concat_bytes (sha256 t.(msg_bytes)) = t.(expected_digest)).
+Proof. vm_compute. reflexivity. Qed.

--- a/silveroak-opentitan/hmac/hw/Sha256.v
+++ b/silveroak-opentitan/hmac/hw/Sha256.v
@@ -81,7 +81,11 @@ Section Var.
           (* - Writing padding 0's *)
           else `padder_flushing`
         else if state == `padder_emit_bit` then
-          `padder_flushing`
+          (* If we are at offset 13, switch to writing length as there is space
+             this block for the length *)
+          if current_offset == `K 13`
+          then `padder_writing_length`
+          else `padder_flushing`
         else if state == `padder_flushing` then
           (* If we are at offset 13, switch to writing length as there is space
              this block for the length *)

--- a/silveroak-opentitan/hmac/hw/Sha256Tests.v
+++ b/silveroak-opentitan/hmac/hw/Sha256Tests.v
@@ -155,3 +155,7 @@ Proof. vm_compute. reflexivity. Qed.
 Goal (let t := test3 in
       from_sha256_output (simulate sha256 (to_sha256_input t)) = t.(expected_digest)).
 Proof. vm_compute. reflexivity. Qed.
+
+Goal (let t := test4 in
+      from_sha256_output (simulate sha256 (to_sha256_input t)) = t.(expected_digest)).
+Proof. vm_compute. reflexivity. Qed.


### PR DESCRIPTION
While trying to prove the circuit correct, I found that there was a bug in the case where the circuit needs to switch from the "emit_bit" state directory to "writing_length" (occurs if there's exactly one word between the message and length). This PR fixes the bug and adds a regression test.