### PR TITLE
Partial padder output correctness proof

### DIFF
--- a/cava/Cava/Util/BitArithmetic.v
+++ b/cava/Cava/Util/BitArithmetic.v
@@ -190,7 +190,7 @@ Module BigEndianBytes.
   (* convert a big-endian list of bytes to a list of n-byte words (length of list
    must be a multiple of n) *)
   Definition bytes_to_Ns n (x : list byte) : list N :=
-    List.map (fun i => concat_bytes (firstn n (skipn (n*i) x))) (seq 0 (length x / 4)).
+    List.map (fun i => concat_bytes (firstn n (skipn (n*i) x))) (seq 0 (length x / n)).
 End BigEndianBytes.
 
 Definition byte_xor (x y : byte) : byte := N_to_byte (N.lxor (Byte.to_N x) (Byte.to_N y)).

--- a/silveroak-opentitan/hmac/hw/Sha256Properties.v
+++ b/silveroak-opentitan/hmac/hw/Sha256Properties.v
@@ -1021,7 +1021,6 @@ Local Ltac testbit_crush :=
          | _ => first [ progress (push_Ntestbit; boolsimpl) | reflexivity ]
          end.
 
-Check step_sha256_inner.
 Lemma step_sha256_padder input state msg msg_complete padder_done index :
   sha256_padder_pre input msg msg_complete padder_done index ->
   sha256_padder_invariant state msg msg_complete padder_done index ->


### PR DESCRIPTION
Another update on the padder proofs:
- All the scariest admits from the invariant-preservation proof are now proven
- Half of the padder output-correctness proof is sketched out with a few admits

Everything seems to be on track so far, although the bit-fiddling is annoying in the `is_final` case. Mostly automated now, but we could go farther.