### PR TITLE
Complete padder proofs

### DIFF
--- a/silveroak-opentitan/hmac/hw/Sha256.v
+++ b/silveroak-opentitan/hmac/hw/Sha256.v
@@ -127,8 +127,8 @@ Section Var.
           `Constant (BitVec 32) 0x80000000`
         else if state == `padder_writing_length` then
           if current_offset == `K 14`
-          then `bvslice 32 32` (length << 3)
-          else `bvslice 0 32` (length << 3)
+          then `bvslice 32 32` (`bvresize 64` length << 3)
+          else `bvslice 0 32` (`bvresize 64` length << 3)
 
         else `K 0`
       in


### PR DESCRIPTION
On top of #925 (will be marked draft until #925 is merged).

Padder proofs are now done except for a few lemmas that are not padder-specific (they're only about `N`, `bytes`, `nat`, etc). The full output from `Print Assumptions` is:
```coq
nth_firstn
  : forall (A : Type) (i n : nat) (d : A) (l : list A),
    nth i (firstn n l) d = (if i <? n then nth i l d else d)
nth_bytes_to_Ns
  : forall (i n : nat) (bs : list byte),
    nth i (BigEndianBytes.bytes_to_Ns n bs) 0%N =
    BigEndianBytes.concat_bytes (List.map (fun j : nat => nth (i * n + j) bs "000"%byte) (seq 0 n))
ceiling_range : forall a b : nat, 0 < b -> 0 < a -> Nat.ceiling a b * b - b < a <= Nat.ceiling a b * b
ceiling_add_same
  : forall a b c : nat, 1 < c < b - 1 -> a mod b <= b - c -> Nat.ceiling (a + c) b = Nat.ceiling (a + 1) b
ceiling_add_le_mono : forall a b c : nat, Nat.ceiling a b <= Nat.ceiling (a + c) b
ceiling_add_diff
  : forall a b c : nat, 0 < b -> 0 < c < b -> b - c < a mod b -> Nat.ceiling (a + c) b = Nat.ceiling a b + 1
N_to_byte_to_N : forall x : N, Byte.to_N (N_to_byte x) = (x mod 256)%N
```
I'm pretty confident that all these lemmas are true and not too terrible to prove. 