### PR TITLE
Move some lemmas to cava2/ExprProperties.v

### DIFF
--- a/cava2/ExprProperties.v
+++ b/cava2/ExprProperties.v
@@ -18,6 +18,7 @@ Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
 Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Util.List.
+Require Import Cava.Util.Nat.
 Require Import Cava.Util.Tactics.
 Require Import Cava.Expr.
 Require Import Cava.Primitives.
@@ -76,3 +77,27 @@ Proof.
   rewrite !resize_succ. reflexivity.
 Qed.
 Hint Rewrite @step_map2 using solve [eauto] : stepsimpl.
+
+Lemma step_bvresize {n m} (x : denote_type (BitVec n)) :
+  step (bvresize (n:=n) m) tt (x, tt) = (tt, N.land x (N.ones (N.of_nat m))).
+Proof. reflexivity. Qed.
+Hint Rewrite @step_bvresize using solve [eauto] : stepsimpl.
+
+Lemma step_bvconcat {n m} (x : denote_type (BitVec n)) (y : denote_type (BitVec m)) :
+  step (bvconcat (n:=n) (m:=m)) tt (x, (y, tt))
+  = (tt, N.lor (N.shiftl (N.land x (N.ones (N.of_nat n))) (N.of_nat m))
+               (N.land y (N.ones (N.of_nat (n + m))))).
+Proof.
+  cbv [bvconcat]. stepsimpl. f_equal.
+  apply N.bits_inj; intro i. push_Ntestbit.
+  rewrite Nat2N.inj_add.
+  destruct_one_match; push_Ntestbit; boolsimpl; [ | reflexivity ].
+  destr (i <? N.of_nat m)%N; push_Ntestbit; boolsimpl; reflexivity.
+Qed.
+Hint Rewrite @step_bvconcat using solve [eauto] : stepsimpl.
+
+Lemma step_bvslice {n start len} (x : denote_type (BitVec n)) :
+  step (bvslice (n:=n) start len) tt (x, tt)
+  = (tt, N.land (N.shiftr x (N.of_nat start)) (N.ones (N.of_nat len))).
+Proof. reflexivity. Qed.
+Hint Rewrite @step_bvslice using solve [eauto] : stepsimpl.

--- a/silveroak-opentitan/hmac/hw/Sha256Properties.v
+++ b/silveroak-opentitan/hmac/hw/Sha256Properties.v
@@ -383,33 +383,6 @@ Definition sha256_padder_pre
        is_final = false
     ).
 
-
-(* TODO: move *)
-Lemma step_bvresize {n m} (x : denote_type (BitVec n)) :
-  step (bvresize (n:=n) m) tt (x, tt) = (tt, N.land x (N.ones (N.of_nat m))).
-Proof. reflexivity. Qed.
-Hint Rewrite @step_bvresize using solve [eauto] : stepsimpl.
-
-(* TODO: move *)
-Lemma step_bvconcat {n m} (x : denote_type (BitVec n)) (y : denote_type (BitVec m)) :
-  step (bvconcat (n:=n) (m:=m)) tt (x, (y, tt))
-  = (tt, N.lor (N.shiftl (N.land x (N.ones (N.of_nat n))) (N.of_nat m))
-               (N.land y (N.ones (N.of_nat (n + m))))).
-Proof.
-  cbv [bvconcat]. stepsimpl. f_equal.
-  apply N.bits_inj; intro i. push_Ntestbit.
-  rewrite Nat2N.inj_add.
-  destruct_one_match; push_Ntestbit; boolsimpl; [ | reflexivity ].
-  destr (i <? N.of_nat m)%N; push_Ntestbit; boolsimpl; reflexivity.
-Qed.
-Hint Rewrite @step_bvconcat using solve [eauto] : stepsimpl.
-
-(* TODO: move *)
-Lemma step_bvslice {n start len} (x : denote_type (BitVec n)) :
-  step (bvslice (n:=n) start len) tt (x, tt)
-  = (tt, N.land (N.shiftr x (N.of_nat start)) (N.ones (N.of_nat len))).
-Proof. reflexivity. Qed.
-Hint Rewrite @step_bvslice using solve [eauto] : stepsimpl.
 (* TODO: move *)
 Lemma length_N_to_bytes n bs :
   length (BigEndianBytes.N_to_bytes n bs) = n.


### PR DESCRIPTION
Cleanup after #926, just moving some general-purpose lemmas about bitvector primitives into the cava2 main library.