### PR TITLE
Make use of tvar typeclass

### DIFF
--- a/cava2/Expr.v
+++ b/cava2/Expr.v
@@ -24,9 +24,6 @@ Require Import Cava.Primitives.
 
 Local Open Scope N.
 
-Definition tvar : Type := type -> Type.
-Existing Class tvar.
-
 Section Vars.
   Inductive Circuit {var: tvar}: type -> type -> type -> Type :=
   | Var : forall {x},     var x -> Circuit [] [] x
@@ -284,7 +281,8 @@ Definition bvslice {var n} (start length: nat): Circuit (var:=var) [] [BitVec n]
   {{ fun vec => `bvresize length` (vec >> start) }}.
 Definition bvconcat {var n m}: Circuit (var:=var) [] [BitVec n; BitVec m] (BitVec (n + m)) :=
   {{ fun v1 v2 => (((`bvresize (n+m)` v1) << m) | (`bvresize (n+m)` v2)) }}.
-Fixpoint map {var t u n} (f: Circuit [] [t] u): Circuit (var:=var) [] [Vec t n] (Vec u n) :=
+Fixpoint map {var : tvar} {t u n} (f: Circuit [] [t] u)
+  : Circuit (var:=var) [] [Vec t n] (Vec u n) :=
   match n with
   | O => {{ fun _ => [] }}
   | S n' => {{ fun vec =>
@@ -292,7 +290,8 @@ Fixpoint map {var t u n} (f: Circuit [] [t] u): Circuit (var:=var) [] [Vec t n] 
                 `f` hd :> `map f` tl
            }}
   end.
-Fixpoint map2 {var t u v n} (f: Circuit [] [t; u] v): Circuit (var:=var) [] [Vec t n; Vec u n] (Vec v n) :=
+Fixpoint map2 {var : tvar} {t u v n} (f: Circuit [] [t; u] v)
+  : Circuit (var:=var) [] [Vec t n; Vec u n] (Vec v n) :=
   match n with
   | O => {{ fun _ _ => [] }}
   | S n' => {{ fun vecx vecy =>

--- a/cava2/FifoProperties.v
+++ b/cava2/FifoProperties.v
@@ -75,8 +75,8 @@ Section FifoSpec.
 
   Definition fifo_pre
     (contents: list (denote_type T))
-    (input : denote_type (input_of (fifo (var:=denote_type) (T:=T) fifo_size)))
-    (state: denote_type (state_of (fifo (var:=denote_type) (T:=T) fifo_size)))
+    (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+    (state: denote_type (state_of (fifo (T:=T) fifo_size)))
     :=
     let '(valid, (data, (accepted_output,_))) := input in
     let '(_, (_, (fifo, count))) := state in
@@ -85,7 +85,7 @@ Section FifoSpec.
 
   Definition fifo_invariant
     (contents: list (denote_type T))
-    (state: denote_type (state_of (fifo (var:=denote_type) (T:=T) fifo_size)))
+    (state: denote_type (state_of (fifo (T:=T) fifo_size)))
     :=
     let '(_, (_, (fifo, count))) := state in
     fifo_size = length fifo
@@ -95,7 +95,7 @@ Section FifoSpec.
   .
 
   Definition fifo_contents_update (empty full: bool) contents
-      (input : denote_type (input_of (fifo (var:=denote_type) (T:=T) fifo_size)))
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
       :=
     let '(valid, (data, (accepted_output,_))) := input in
     let contents' := if accepted_output && negb empty then tl contents else contents in
@@ -153,8 +153,8 @@ Section FifoSpec.
 
   Lemma step_fifo_invariant
       contents new_contents
-      (input : denote_type (input_of (fifo (var:=denote_type) (T:=T) fifo_size)))
-      (state : denote_type (state_of (fifo (var:=denote_type) (T:=T) fifo_size))) :
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+      (state : denote_type (state_of (fifo (T:=T) fifo_size))) :
     new_contents = fifo_contents_update (length contents =? 0) (length contents =? fifo_size) contents input ->
     fifo_pre contents input state ->
     fifo_invariant contents state ->
@@ -264,8 +264,8 @@ Section FifoSpec.
   Definition fifo_spec
       (contents: list (denote_type T))
       (new_contents: list (denote_type T))
-      (input : denote_type (input_of (fifo (var:=denote_type) (T:=T) fifo_size)))
-      (state : denote_type (state_of (fifo (var:=denote_type) (T:=T) fifo_size)))
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+      (state : denote_type (state_of (fifo (T:=T) fifo_size)))
       : denote_type (Bit ** T ** Bit ** Bit) :=
     (negb (0 =? length contents)
     , (if 0 =? length contents then default else hd default contents
@@ -274,8 +274,8 @@ Section FifoSpec.
 
   Lemma step_fifo
       contents new_contents
-      (input : denote_type (input_of (fifo (var:=denote_type) (T:=T) fifo_size)))
-      (state : denote_type (state_of (fifo (var:=denote_type) (T:=T) fifo_size))) :
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+      (state : denote_type (state_of (fifo (T:=T) fifo_size))) :
     new_contents = fifo_contents_update (length contents =? 0) (length contents =? fifo_size) contents input ->
     fifo_pre contents input state ->
     fifo_invariant contents state ->

--- a/cava2/Semantics.v
+++ b/cava2/Semantics.v
@@ -89,7 +89,7 @@ Fixpoint step {i s o} (c : Circuit s i o)
   | TernaryOp op x y z => fun _ _ => (tt, ternary_semantics op x y z)
   end.
 
-Fixpoint reset_state {i s o} (c : Circuit (var:=denote_type) s i o) : denote_type s :=
+Fixpoint reset_state {i s o} (c : Circuit s i o) : denote_type s :=
   match c in Circuit s i o return denote_type s with
   | Var _ => tt
   | Abs f => reset_state (f default)
@@ -108,9 +108,9 @@ Fixpoint reset_state {i s o} (c : Circuit (var:=denote_type) s i o) : denote_typ
   | TernaryOp op x y z => tt
   end.
 
-Definition simulate' {s i o} (c : Circuit (var:=denote_type) s i o) (input : list (denote_type i)) (state: denote_type s)
+Definition simulate' {s i o} (c : Circuit s i o) (input : list (denote_type i)) (state: denote_type s)
   : list (denote_type o) * denote_type s :=
     fold_left_accumulate' (step c) nil input state.
 
-Definition simulate {s i o} (c : Circuit (var:=denote_type) s i o) (input : list (denote_type i))
+Definition simulate {s i o} (c : Circuit s i o) (input : list (denote_type i))
   : list (denote_type o) := fst (simulate' c input (reset_state c)).

--- a/cava2/Types.v
+++ b/cava2/Types.v
@@ -37,15 +37,19 @@ Proof.
   decide equality; apply Nat.eq_dec.
 Defined.
 
+Definition tvar : Type := type -> Type.
+Existing Class tvar.
+
 (* simple_denote_type denotes 'BitVec's as N *)
-Fixpoint denote_type (t: type) :=
-  match t with
-  | Unit => unit
-  | Bit => bool
-  | BitVec n => N
-  | Vec t n =>list (denote_type t)
-  | Pair x y => (denote_type x * denote_type y)%type
-  end.
+Instance denote_type : tvar :=
+  fix denote_type (t: type) :=
+    match t with
+    | Unit => unit
+    | Bit => bool
+    | BitVec n => N
+    | Vec t n =>list (denote_type t)
+    | Pair x y => (denote_type x * denote_type y)%type
+    end.
 
 Fixpoint eqb {t}: denote_type t -> denote_type t -> bool :=
   match t return denote_type t -> denote_type t -> bool with
@@ -96,3 +100,4 @@ Notation "[ x ]" := (Pair x Unit) : circuit_type_scope.
 Notation "[ x ; y ; .. ; z ]" := (Pair x (Pair y .. (Pair z Unit) ..)) : circuit_type_scope.
 Notation "x ** y" := (Pair x y)(at level 60, right associativity) : circuit_type_scope.
 Notation "x ++ y" := (absorb_any x y) (at level 60, right associativity): circuit_type_scope.
+Arguments denote_type _%circuit_type.

--- a/silveroak-opentitan/hmac/hw/Hmac.v
+++ b/silveroak-opentitan/hmac/hw/Hmac.v
@@ -211,8 +211,6 @@ Section SanityCheck.
   Definition is_done (v : denote_type (Vec (BitVec 32) hmac_register_count)) :=
     nth 0 (v) 0.
 
-  Definition state_of {s i o} (_: Circuit (var:=denote_type) s i o) := s.
-
   Definition get_regs (v: denote_type (state_of hmac))
     : denote_type (Vec (BitVec 32) hmac_register_count) .
     cbv [state_of hmac absorb_any] in v.

--- a/silveroak-opentitan/hmac/hw/Sha256Tests.v
+++ b/silveroak-opentitan/hmac/hw/Sha256Tests.v
@@ -35,7 +35,7 @@ Definition extra_cycles : nat := 80.
 
 (* convert test vector data into circuit input signals *)
 Definition to_sha256_input (t : sha256_test_vector)
-  : list (denote_type (input_of (var:=denote_type) sha256)) :=
+  : list (denote_type (input_of sha256)) :=
   (* input must be divided into into 32-bit words *)
   let l := N.to_nat t.(l) in
   let nwords := l / 32 + (if l mod 32 =? 0 then 0 else 1) in
@@ -82,14 +82,14 @@ Definition to_sha256_input (t : sha256_test_vector)
 
 (* extract test result from circuit output signals *)
 Definition from_sha256_output
-           (out : list (denote_type (output_of (var:=denote_type) sha256)))
+           (out : list (denote_type (output_of sha256)))
   : N :=
   let '(done, (digest, accept_input)) := last out default in
   BigEndianBytes.concat_bytes (concat_digest digest).
 
 (* convert test vector data into input signals for padder *)
 Definition to_sha256_padder_input (t : sha256_test_vector)
-  : list (denote_type (input_of (var:=denote_type) sha256_padder)) :=
+  : list (denote_type (input_of sha256_padder)) :=
   (* For padder tests, we assume the consumer is always ready *)
   List.map
     (fun '(fifo_data_valid,(fifo_data,(is_final,(final_length,(clear,_))))) =>
@@ -102,7 +102,7 @@ Definition concat_words (n : nat) (ws : list N) : N :=
 
 (* extract test result from padder output signals *)
 Definition from_sha256_padder_output
-           (out : list (denote_type (output_of (var:=denote_type) sha256_padder)))
+           (out : list (denote_type (output_of sha256_padder)))
   : N :=
   (* remove invalid output signals entirely, and extract data from signals *)
   let valid_out :=
@@ -113,7 +113,7 @@ Definition from_sha256_padder_output
 
 (* extract all intermediate digests from circuit output signals *)
 Definition intermediate_digests_from_sha256_output
-           (out : list (denote_type (output_of (var:=denote_type) sha256)))
+           (out : list (denote_type (output_of sha256)))
   : list (list N) :=
   let digests := List.map (fun '(done, (digest, accept_input)) => digest) out in
   (* remove repetitions of the same digest *)


### PR DESCRIPTION
Currently, we have a `tvar` typeclass that should help us infer type denotation definitions, but no instances of the typeclass are ever constructed (although they do exist inside sections). Making `denote_type` an instance of `tvar` means we can remove a lot of `(var:=denote_type)` clauses, which seems like an improvement.