### PR TITLE
More structured invariant-reasoning infrastructure with examples

### DIFF
--- a/cava2/ExprProperties.v
+++ b/cava2/ExprProperties.v
@@ -38,7 +38,7 @@ Hint Rewrite @step_vec_as_tuple_one using solve [eauto] : stepsimpl.
 
 Ltac stepsimpl :=
   repeat first [ progress
-                   cbn [fst snd step denote_type absorb_any
+                   cbn [fst snd step denote_type absorb_any One Zero K
                             split_absorbed_denotation combine_absorbed_denotation
                             unary_semantics binary_semantics eqb ]
                | progress autorewrite with stepsimpl ].

--- a/cava2/Invariant.v
+++ b/cava2/Invariant.v
@@ -1,0 +1,314 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.NArith.NArith.
+Require Import Cava.Types.
+Require Import Cava.Expr.
+Require Import Cava.Semantics.
+Local Open Scope N_scope.
+
+Require Import Coq.micromega.Lia.
+Require Import coqutil.Tactics.Tactics.
+Require Import Cava.Util.Nat.
+Require Import Cava.Util.Tactics.
+Require Import Cava.ExprProperties.
+
+Module N.
+  Lemma mod_mod_mul_l a b c : b <> 0 -> c <> 0 -> (a mod (b * c)) mod c = a mod c.
+  Proof.
+    intros. rewrite (N.mul_comm b c).
+    rewrite N.mod_mul_r, N.add_mod, N.mod_mul_l, N.add_0_r by lia.
+    rewrite !N.mod_mod by lia. reflexivity.
+  Qed.
+  Lemma div_floor a b : b <> 0 -> (a - a mod b) / b = a / b.
+  Proof.
+    intros. rewrite (N.div_mod a b) at 1 by lia.
+    rewrite N.add_sub, N.div_mul_l; lia.
+  Qed.
+  Lemma mod_mul_div_r a b c :
+    b <> 0 -> c <> 0 -> a mod (b * c) / c = (a / c) mod b.
+  Proof.
+    intros.
+    rewrite (N.mul_comm b c), N.mod_mul_r by lia.
+    rewrite (N.mul_comm c (_ mod b)), N.div_add by lia.
+    rewrite (N.div_small (_ mod c) c) by (apply N.mod_bound_pos; lia).
+    lia.
+  Qed.
+End N.
+
+(**** Example using invariant logic ****)
+Module Example.
+  Section CircuitDefinitions.
+    Context {var : tvar}.
+    Import ExprNotations.
+    Import PrimitiveNotations.
+
+    (* Circuit which takes a bit indicating whether to increment or not, and if
+       the bit is true increments an n-bit counter by 1 each cycle. The counter
+       truncates on overflow and returns the counter value along with a bit
+       indicating whether the counter overflowed. *)
+    Definition counter (n : nat) : Circuit (BitVec n ** Bit) [Bit] (BitVec n ** Bit) :=
+      {{ fun enable =>
+           let/delay '(data; overflow) :=
+              (if !enable
+               then (data,`Zero`)
+               else
+                 let new_overflow := data == `K (N.ones (N.of_nat n))` in
+                 let new_data := data + `K 1` in
+                 (new_data, new_overflow))
+                initially
+                ((0,false) : denote_type (BitVec n ** Bit)) in
+           (data,overflow)
+      }}.
+
+    (* Creates a 2n-bit counter out of two n-bit counters *)
+    Definition double_counter (n : nat) : Circuit _ [Bit] (BitVec (2 * n) ** Bit) :=
+      {{ fun enable =>
+           let '(low; low_overflow) := `counter n` enable in
+           let '(high; high_overflow) := `counter n` low_overflow in
+           (`bvresize _` (`bvconcat` high low), high_overflow) }}.
+  End CircuitDefinitions.
+
+  Section Specifications.
+    (* Ghost state : counter value *)
+    Definition counter_ghost_state : Type := N.
+
+    (* Invariant: the counter value must be < 2 ^ n. *)
+    Definition counter_invariant {n}
+               (state : denote_type (state_of (var:=denote_type) (counter n)))
+               (* Ghost variable tracking counter value *)
+               (ghost_state : counter_ghost_state)
+    : Prop :=
+      let '(data, _) := state in
+      let value := ghost_state in
+      (* value is exactly equivalent to [data] *)
+      data = value
+      (* ...and value < 2 ^ n *)
+      /\ (value < 2 ^ N.of_nat n)%N.
+
+    (* No input preconditions *)
+    Definition counter_pre {n}
+               (input : denote_type (input_of (var:=denote_type) (counter n)))
+               (ghost_state : counter_ghost_state)
+      : Prop := True.
+
+    Definition counter_spec {n}
+               (input : denote_type (input_of (var:=denote_type) (counter n)))
+               (ghost_state : counter_ghost_state)
+      : denote_type (output_of (var:=denote_type) (counter n)) :=
+      let '(enable,_) := input in
+      let value := ghost_state in
+      let new_val := if enable then (value + 1)%N else value in
+      (new_val mod (2 ^ N.of_nat n), (2 ^ N.of_nat n <=? new_val))%N.
+
+    Definition counter_update_ghost_state {n}
+               (input : denote_type (input_of (counter (var:=denote_type) n)))
+               (ghost_state : counter_ghost_state) : counter_ghost_state :=
+      let '(enable,_) := input in
+      let value := ghost_state in
+      if enable
+      then ((value + 1) mod (2 ^ N.of_nat n))%N
+      else value.
+
+    (* Double counter ghost state is also just a value *)
+    Definition double_counter_ghost_state := counter_ghost_state.
+
+    Definition double_counter_invariant {n}
+               (state : denote_type (state_of (double_counter (var:=denote_type) n)))
+               (* Ghost variable tracking double_counter value *)
+               (ghost_state : double_counter_ghost_state)
+    : Prop :=
+      let '(counter1_state, counter2_state) := state in
+      let value := ghost_state in
+      (* counter1_state matches the low part of the counter value *)
+      counter_invariant (n:=n) counter1_state (value mod 2 ^ N.of_nat n)%N
+      (* ...and counter2_state matches the high part of the counter value *)
+      /\ counter_invariant (n:=n) counter2_state (value / 2 ^ N.of_nat n)%N
+      (* ...and the value is < 2 ^ 2n (this is implied by the other two but
+         convenient to have without unfolding [counter_invariant]) *)
+      /\ value < 2 ^ (N.of_nat (2 * n)).
+
+    (* No input preconditions *)
+    Definition double_counter_pre {n}
+               (input : denote_type (input_of (double_counter (var:=denote_type) n)))
+               (ghost_state : double_counter_ghost_state)
+      : Prop := True.
+
+    (* Spec is the same as a double-size counter *)
+    Definition double_counter_spec {n}
+               (input : denote_type (input_of (double_counter (var:=denote_type) n)))
+               (ghost_state : double_counter_ghost_state)
+      : denote_type (output_of (double_counter (var:=denote_type) n)) :=
+      counter_spec (n:=2*n) input ghost_state.
+
+    Definition double_counter_update_ghost_state {n}
+               (input : denote_type (input_of (double_counter (var:=denote_type) n)))
+               (ghost_state : double_counter_ghost_state) : double_counter_ghost_state :=
+      counter_update_ghost_state (n:=2*n) input ghost_state.
+  End Specifications.
+
+  Section Proofs.
+
+
+    (* TODO: move *)
+    Lemma step_bvresize {n m} (x : denote_type (BitVec n)) :
+      step (bvresize (n:=n) m) tt (x, tt) = (tt, N.land x (N.ones (N.of_nat m))).
+    Proof. reflexivity. Qed.
+    Hint Rewrite @step_bvresize using solve [eauto] : stepsimpl.
+    (* TODO: move *)
+    Lemma step_bvconcat {n m} (x : denote_type (BitVec n)) (y : denote_type (BitVec m)) :
+      step (bvconcat (n:=n) (m:=m)) tt (x, (y, tt))
+      = (tt, N.lor (N.shiftl (N.land x (N.ones (N.of_nat n))) (N.of_nat m))
+                   (N.land y (N.ones (N.of_nat (n + m))))).
+    Proof.
+      cbv [bvconcat]. stepsimpl. f_equal.
+      apply N.bits_inj; intro i. push_Ntestbit.
+      rewrite Nat2N.inj_add.
+      destruct_one_match; push_Ntestbit; boolsimpl; [ | reflexivity ].
+      destr (i <? N.of_nat m)%N; push_Ntestbit; boolsimpl; reflexivity.
+    Qed.
+    Hint Rewrite @step_bvconcat using solve [eauto] : stepsimpl.
+
+    Lemma step_counter_invariant n state ghost_state new_ghost_state input :
+      counter_invariant (n:=n) state ghost_state ->
+      counter_pre (n:=n) input ghost_state ->
+      new_ghost_state = counter_update_ghost_state input ghost_state ->
+      counter_invariant (fst (step (counter n) state input))
+                        new_ghost_state.
+    Admitted.
+
+    Lemma step_counter n state ghost_state input :
+      counter_invariant (n:=n) state ghost_state ->
+      counter_pre (n:=n) input ghost_state ->
+      snd (step (counter n) state input)
+      = counter_spec input ghost_state.
+    Admitted.
+
+    Lemma step_double_counter_invariant n state ghost_state new_ghost_state input :
+      double_counter_invariant (n:=n) state ghost_state ->
+      double_counter_pre (n:=n) input ghost_state ->
+      new_ghost_state = double_counter_update_ghost_state input ghost_state ->
+      double_counter_invariant (fst (step (double_counter n) state input))
+                               new_ghost_state.
+    Proof.
+      destruct state as (data, ?). rename ghost_state into value.
+      destruct input as (enable,[]).
+      cbv [double_counter_invariant double_counter_pre]; intros; subst.
+      cbv [double_counter]. stepsimpl.
+      logical_simplify; subst. natsimpl.
+      lazymatch goal with
+      | |- context [match step (counter ?n) ?s ?i with pair _ _ => _ end] =>
+        rewrite (surjective_pairing (step (counter n) s i))
+      end.
+      erewrite step_counter by eauto.
+      cbv [counter_spec].
+      stepsimpl.
+      lazymatch goal with
+      | |- context [match step (counter ?n) ?s ?i with pair _ _ => _ end] =>
+        rewrite (surjective_pairing (step (counter n) s i))
+      end.
+      erewrite step_counter by eauto.
+      cbv [counter_spec].
+      stepsimpl.
+      (* helpful assertions *)
+      assert (2 ^ N.of_nat n <> 0) by (apply N.pow_nonzero; lia).
+      pose proof N.mod_bound_pos value (2 ^ N.of_nat n) ltac:(lia) ltac:(lia).
+      cbv [double_counter_update_ghost_state counter_update_ghost_state].
+      ssplit.
+      { eapply step_counter_invariant; [ solve [eauto] .. | ].
+        cbv [counter_update_ghost_state].
+        destruct enable; [ | reflexivity ].
+        rewrite N.add_mod_idemp_l, Nat2N.inj_mul by lia.
+        replace (N.of_nat 2 * N.of_nat n) with (N.of_nat n * 2) by lia.
+        rewrite N.pow_mul_r, N.pow_2_r.
+        rewrite N.mod_mod_mul_l by lia.
+        reflexivity. }
+      { eapply step_counter_invariant; [ solve [eauto] .. | ].
+        cbv [counter_update_ghost_state].
+        repeat (destruct_one_match; try lia).
+        { (* this is the case in which the low counter overflows -- adding 1 and
+             then taking the high part is therefore the same as taking the high
+             part and adding 1 *)
+          replace (N.of_nat (2 * n)) with (N.of_nat n * 2) by lia.
+          rewrite N.pow_mul_r, N.pow_2_r by lia.
+          rewrite N.mod_mul_div_r by lia.
+          (* remember high part so as not to change it with the N.div_mod rewrite *)
+          remember (value / 2 ^ N.of_nat n) as X.
+          rewrite (N.div_mod value (2 ^ N.of_nat n)) by lia.
+          subst X.
+          lazymatch goal with
+          | H : ?x <= ?y mod ?x + 1 |- _ =>
+            replace (y mod x) with (x - 1) in * by lia
+          | _ => idtac
+          end.
+          lazymatch goal with
+          | |- context [?x + (?y - ?z) + ?z] =>
+            replace (x + (y - z) + z) with (x + y) by lia
+          end.
+          rewrite (N.mul_comm (2 ^ N.of_nat n) (_ / _)).
+          rewrite N.div_add_l, N.div_same by lia.
+          reflexivity. }
+        { (* more ugly modular-arithmetic reasoning *)
+          replace (N.of_nat (2 * n)) with (N.of_nat n * 2) in * by lia.
+          rewrite N.pow_mul_r, N.pow_2_r in * by lia.
+          rewrite N.mod_mul_div_r by lia.
+          rewrite (N.div_mod value (2 ^ N.of_nat n)) at 1 by lia.
+          rewrite (N.mul_comm (2 ^ _) (_ / _)), <-N.add_assoc.
+          rewrite N.div_add_l by lia.
+          rewrite (N.div_small (_ + 1) _), N.add_0_r by lia.
+          apply N.mod_small, N.div_lt_upper_bound; lia. } }
+      { destruct enable; [ | lia ].
+        apply N.mod_bound_pos; lia. }
+    Qed.
+
+    Lemma step_double_counter n state ghost_state input :
+      double_counter_invariant (n:=n) state ghost_state ->
+      double_counter_pre (n:=n) input ghost_state ->
+      snd (step (double_counter n) state input)
+      = double_counter_spec input ghost_state.
+    Proof.
+      destruct state as (data, ?). rename ghost_state into value.
+      destruct input as (enable,[]).
+      cbv [double_counter_invariant double_counter_pre]; intros; subst.
+      cbv [double_counter double_counter_spec]. stepsimpl.
+      logical_simplify; subst. natsimpl.
+      lazymatch goal with
+      | |- context [match step (counter ?n) ?s ?i with pair _ _ => _ end] =>
+        rewrite (surjective_pairing (step (counter n) s i))
+      end.
+      erewrite step_counter by eauto.
+      cbv [counter_spec].
+      stepsimpl.
+      lazymatch goal with
+      | |- context [match step (counter ?n) ?s ?i with pair _ _ => _ end] =>
+        rewrite (surjective_pairing (step (counter n) s i))
+      end.
+      erewrite step_counter by eauto.
+      cbv [counter_spec].
+      stepsimpl.
+      f_equal.
+      { (* counter values match *)
+        (* TODO: consider making moduli constants so that nice automation works *)
+        rewrite <-!N.shiftr_div_pow2.
+        rewrite <-!N.land_ones.
+        destr enable.
+    Qed.
+  End Proofs.
+End Example.
+
+
+
+

--- a/cava2/Invariant.v
+++ b/cava2/Invariant.v
@@ -29,56 +29,72 @@ Require Import Cava.Util.Nat.
 Require Import Cava.Util.Tactics.
 Require Import Cava.ExprProperties.
 
-Class invariant_logic_for {s i o} (c : Circuit (var:=denote_type) s i o)
-      (hl_state : Type) :=
-  { reset_hl_state : hl_state;
-    update_hl_state : denote_type i -> hl_state -> hl_state;
-    invariant_for : denote_type s -> hl_state -> Prop;
-    precondition_for : denote_type i -> hl_state -> Prop;
-    spec_for : denote_type i -> hl_state -> denote_type o;
+
+(* When using an abstract circuit, I want to parameterize over the state
+invariant but know the specification concretely. I also want to parameterize
+over proofs that the invariant works to prove the spec.
+*)
+
+Definition invariant_for {s i o} (c : Circuit (var:=denote_type) s i o)
+           (repr : Type) : Type := denote_type s -> repr -> Prop.
+Existing Class invariant_for.
+
+Class specification_for {s i o} (c : Circuit (var:=denote_type) s i o)
+      (repr : Type) :=
+  { reset_repr : repr;
+    update_repr : denote_type i -> repr -> repr;
+    precondition : denote_type i -> repr -> Prop;
+    postcondition : denote_type i -> repr -> denote_type o -> Prop;
   }.
-Global Arguments invariant_for {_ _ _} _ {_ _}.
-Global Arguments precondition_for {_ _ _} _ {_ _}.
-Global Arguments spec_for {_ _ _} _ {_ _}.
+Global Arguments precondition {_ _ _} _ {_ _}.
+Global Arguments postcondition {_ _ _} _ {_ _}.
 
 Definition invariant_at_reset {s i o} (c : Circuit s i o)
-           {hl_state} {invariant_logic : invariant_logic_for c hl_state} : Prop :=
-  invariant_for c (reset_state c) reset_hl_state.
+           {repr} {invariant : invariant_for c repr}
+           {spec : specification_for c repr} : Prop :=
+  invariant (reset_state c) reset_repr.
 Existing Class invariant_at_reset.
 
 Definition invariant_preserved {s i o} (c : Circuit s i o)
-           {hl_state} {invariant_logic : invariant_logic_for c hl_state} : Prop :=
-  forall input state hl_state new_hl_state,
-    new_hl_state = update_hl_state input hl_state ->
-    invariant_for c state hl_state ->
-    precondition_for c input hl_state ->
-    invariant_for c (fst (step c state input)) new_hl_state.
+           {repr} {invariant : invariant_for c repr}
+           {spec : specification_for c repr} : Prop :=
+  forall input state r new_r,
+    new_r = update_repr input r ->
+    invariant state r ->
+    precondition c input r ->
+    invariant (fst (step c state input)) new_r.
 Existing Class invariant_preserved.
 
 Definition output_correct {s i o} (c : Circuit s i o)
-           {hl_state} {invariant_logic : invariant_logic_for c hl_state} : Prop :=
-  forall input state hl_state,
-    invariant_for c state hl_state ->
-    precondition_for c input hl_state ->
-    snd (step c state input) = spec_for c input hl_state.
+           {repr} {invariant : invariant_for c repr}
+           {spec : specification_for c repr} : Prop :=
+  forall input state r,
+    invariant state r ->
+    precondition c input r ->
+    postcondition c input r (snd (step c state input)).
 Existing Class output_correct.
 
 Class correctness_for {s i o} (c : Circuit s i o)
-      {hl_state} {invariant_logic : invariant_logic_for c hl_state} :=
+           {repr} {invariant : invariant_for c repr}
+           {spec : specification_for c repr} : Prop :=
   { invariant_at_reset_pf : invariant_at_reset c;
     invariant_preserved_pf : invariant_preserved c;
     output_correct_pf : output_correct c }.
 
 (* Switch between higher-level representations *)
-Definition invariant_logic_isomorphism {s i o} {c : Circuit s i o}
+Definition invariant_by_isomorphism {s i o} {c : Circuit s i o}
            {s1 s2} (phi : s1 -> s2) (inv : s2 -> s1)
-           (invariant_logic : invariant_logic_for c s1)
-  : invariant_logic_for c s2 :=
-  {| reset_hl_state := phi reset_hl_state;
-     update_hl_state := fun input x => phi (update_hl_state input (inv x));
-     invariant_for := fun (state : denote_type s) x => invariant_for c state (inv x);
-     precondition_for := fun input x => precondition_for c input (inv x);
-     spec_for := fun input x => spec_for c input (inv x)
+           {invariant : invariant_for c s1}
+  : invariant_for c s2 :=
+  fun (state : denote_type s) x => invariant state (inv x).
+Definition specification_by_isomorphism {s i o} {c : Circuit s i o}
+           {s1 s2} (phi : s1 -> s2) (inv : s2 -> s1)
+           {spec : specification_for c s1}
+  : specification_for c s2 :=
+  {| reset_repr := phi (reset_repr);
+     update_repr := fun i x => phi (update_repr i (inv x));
+     precondition := fun i x => precondition c i (inv x);
+     postcondition := fun i x => postcondition c i (inv x);
   |}.
 
 (* Succeeds if an instance is found for circuit correctness *)
@@ -86,52 +102,61 @@ Ltac find_correctness c :=
   let x := constr:(_:correctness_for c) in
   idtac.
 
-Ltac simplify_invariant_logic c :=
-  let x := constr:(_:invariant_logic_for c _) in
+Ltac simplify_invariant c :=
+  cbv [invariant_at_reset invariant_preserved output_correct];
+  let x := constr:(_:invariant_for c _) in
   match x with
-  | ?x => cbn [x update_hl_state invariant_for precondition_for
-                spec_for invariant_at_reset invariant_preserved
-                output_correct reset_hl_state] in *
+  | ?x => cbv [x] in *
   end.
 Ltac simplify_spec c :=
-  let x := constr:(_:invariant_logic_for c _) in
+  let x := constr:(_:specification_for c _) in
   match x with
-  | ?x => cbn [spec_for x] in *
+  | ?x => cbn [x update_repr precondition postcondition] in *
   end.
 
 (* if a subcircuit is found that has an invariant-based correctness proof, use
    the correctness proof to replace the circuit step function with the
    spec. Uses [eauto] to solve the side conditions of the output-correctness
    proof. *)
+Ltac use_correctness' c :=
+  lazymatch goal with
+  | |- context [snd (step c ?s ?i)] =>
+    find_correctness c;
+    pose proof (output_correct_pf (c:=c) i s _ ltac:(eauto) ltac:(eauto));
+    generalize dependent (snd (step c s i)); intros;
+    try simplify_spec c; logical_simplify; subst
+  end.
 Ltac use_correctness :=
   match goal with
   | |- context [match step ?c ?s ?i with pair _ _ => _ end] =>
     find_correctness c;
     rewrite (surjective_pairing (step c s i));
-    erewrite (output_correct_pf (c:=c)) by eauto;
-    simplify_spec c
+    use_correctness' c
   end.
 
 Section StateLogicProofs.
   Context {s i o} (c : Circuit (var:=denote_type) s i o).
-  Context {hl_state} {invariant_logic : invariant_logic_for c hl_state}.
-  Context {correctness : correctness_for c}.
+  Context {repr} {invariant : invariant_for c repr}
+          {spec : specification_for c repr}
+          {correctness : correctness_for c}.
 
-  Lemma simulate_invariant_logic input :
+  Lemma simulate_invariant_logic input output_func :
     (* TODO: refine this. The precondition has to hold at each step; for now,
        just say that each of the inputs satisfies the precondition for all
        states *)
-    Forall (fun i => forall s, precondition_for c i s) input ->
+    Forall (fun i => forall s, precondition c i s) input ->
+    (* the postcondition fully specifies the output *)
+    (forall i s x, postcondition c i s x -> x = output_func i s) ->
     simulate c input = fold_left_accumulate
-                         (fun s i => (update_hl_state i s, spec_for _ i s))
-                         input reset_hl_state.
+                         (fun s i => (update_repr i s, output_func i s))
+                         input reset_repr.
   Proof.
     intros.
     change (simulate c input) with
         (fold_left_accumulate (step c) input (reset_state c)).
     eapply fold_left_accumulate_double_invariant_In
       with (I:=fun s1 s2 acc1 acc2 =>
-                 invariant_for c s1 s2 /\ acc1 = acc2).
+                 invariant s1 s2 /\ acc1 = acc2).
     { ssplit; [ | reflexivity ].
       apply invariant_at_reset_pf. }
     { intros; logical_simplify; subst.
@@ -141,22 +166,24 @@ Section StateLogicProofs.
       ssplit.
       { eapply invariant_preserved_pf; [ | solve [eauto] .. ].
         reflexivity. }
-      { rewrite output_correct_pf; [ | solve [eauto] .. ].
-        reflexivity. } }
+      { use_correctness' c. cbn [fst snd].
+        repeat (f_equal; eauto). } }
     { intros; logical_simplify; subst. reflexivity. }
   Qed.
 
   (* if there's an isomorphism between two higher-level states, then invariant
      logic and correctness proofs can be ported between them. *)
   Lemma invariant_logic_isomorphism_correct
-        (hl_state' : Type) (phi : hl_state -> hl_state') (inv : hl_state' -> hl_state) :
+        (repr' : Type) (phi : repr -> repr') (inv : repr' -> repr) :
     (forall x, inv (phi x) = x) ->
-    correctness_for (invariant_logic:=invariant_logic_isomorphism phi inv _) c.
+    correctness_for (invariant:=invariant_by_isomorphism phi inv)
+                    (spec:=specification_by_isomorphism phi inv) c.
   Proof.
     intros Hphi.
     constructor; cbv [invariant_at_reset invariant_preserved output_correct
-                                         invariant_logic_isomorphism].
-    all:cbn [reset_hl_state invariant_for precondition_for spec_for].
+                                         specification_by_isomorphism
+                                         invariant_by_isomorphism].
+    all:cbn [reset_repr precondition postcondition].
     all:rewrite ?Hphi; intros; subst.
     all:eauto using invariant_preserved_pf, output_correct_pf.
     all:eapply invariant_at_reset_pf.
@@ -199,86 +226,90 @@ Module DoubleCounterExample.
 
   Section Specifications.
 
-    Global Instance counter_invariant_logic
-      : invariant_logic_for counter N :=
-      {| reset_hl_state := 0;
-         update_hl_state :=
+    Global Instance counter_specification
+      : specification_for counter N :=
+      {| reset_repr := 0;
+         update_repr :=
            fun (input : denote_type [Bit]) value =>
              let '(enable,_) := input in
-             (* if enabled, add 1 mod 2^8, else do nothing *)
+             (* if enabled, add 1 mod 2^n, else do nothing *)
              if enable
              then ((value + 1) mod (2 ^ 8))%N
              else value;
-         invariant_for :=
-           fun (state : denote_type (BitVec 8 ** _)) value =>
-             let '(data,_) := state in
-             (* value is exactly equivalent to [data] *)
-             data = value
-             (* ...and value < 2 ^ 8 *)
-             /\ value < 2 ^ 8;
-         precondition_for := fun _ _ => True;
-         spec_for :=
-           fun input value =>
+         precondition := fun _ _ => True;
+         postcondition :=
+           fun input value (output : denote_type (BitVec 8 ** Bit)) =>
              let '(enable,_) := input in
              let new_val := if enable then (value + 1)%N else value in
-             ((new_val mod (2 ^ 8), 2 ^ 8 <=? new_val)
-              : denote_type (BitVec 8 ** Bit))
+             output = (new_val mod (2 ^ 8), 2 ^ 8 <=? new_val)
       |}.
 
-    Global Instance double_counter_invariant_logic
-      : invariant_logic_for double_counter N :=
-      {| reset_hl_state := 0;
-         update_hl_state :=
+    Global Instance counter_invariant : invariant_for counter N :=
+      fun (state : denote_type (BitVec 8 ** _)) value =>
+        let '(data,_) := state in
+        (* value is exactly equivalent to [data] *)
+        data = value
+        (* ...and value < 2 ^ 8 *)
+        /\ value < 2 ^ 8.
+
+    (* Almost identical to the counter specification *)
+    Global Instance double_counter_specification
+      : specification_for double_counter N :=
+      {| reset_repr := 0;
+         update_repr :=
            fun (input : denote_type [Bit]) value =>
              let '(enable,_) := input in
-             (* if enabled, add 1 mod 2^16, else do nothing *)
+             (* if enabled, add 1 mod 2^n, else do nothing *)
              if enable
              then ((value + 1) mod (2 ^ 16))%N
              else value;
-         invariant_for :=
-           fun (state : denote_type (state_of (var:=denote_type) counter
-                                            ** state_of (var:=denote_type) counter)) value =>
-             let '(counter1_state, counter2_state) := state in
-             (* counter1_state matches the low part of the counter value *)
-             invariant_for counter counter1_state (value mod 2 ^ 8)%N
-             (* ...and counter2_state matches the high part of the counter value *)
-             /\ invariant_for counter counter2_state (value / 2 ^ 8)%N
-             (* ...and the value is < 2 ^ 16 (this is implied by the other two but
-                convenient to have without unfolding [counter_invariant]) *)
-             /\ value < 2 ^ 16;
-         precondition_for := fun _ _ => True;
-         spec_for :=
-           fun input value =>
+         precondition := fun _ _ => True;
+         postcondition :=
+           fun input value (output : denote_type (BitVec 16 ** Bit)) =>
              let '(enable,_) := input in
              let new_val := if enable then (value + 1)%N else value in
-             ((new_val mod (2 ^ 16), 2 ^ 16 <=? new_val)
-              : denote_type (BitVec 16 ** Bit))
+             output = (new_val mod (2 ^ 16), 2 ^ 16 <=? new_val)
       |}.
+
+    Global Instance double_counter_invariant_logic
+      : invariant_for double_counter N :=
+      fun (state : denote_type (state_of counter
+                                       ** state_of counter)) value =>
+        let '(counter1_state, counter2_state) := state in
+        (* counter1_state matches the low part of the counter value *)
+        counter_invariant counter1_state (value mod 2 ^ 8)%N
+        (* ...and counter2_state matches the high part of the counter value *)
+        /\ counter_invariant counter2_state (value / 2 ^ 8)%N
+        (* ...and the value is < 2 ^ 16 (this is implied by the other two but
+           convenient to have without unfolding [counter_invariant]) *)
+        /\ value < 2 ^ 16.
   End Specifications.
 
   Section Proofs.
     Lemma counter_invariant_at_reset : invariant_at_reset counter.
     Proof.
-      simplify_invariant_logic counter.
-      cbv [counter]. cbn [reset_state]. stepsimpl.
+      simplify_invariant counter.
+      cbv [counter]. cbn [reset_state]; stepsimpl.
+      simplify_invariant counter.
       ssplit; [ reflexivity | ]. cbn; lia.
     Qed.
 
     Lemma counter_invariant_preserved : invariant_preserved counter.
     Proof.
       intros (enable,[]) (data, ?) value. intros; subst.
-      simplify_invariant_logic counter.
+      simplify_invariant counter. simplify_spec counter.
       cbv [counter]. stepsimpl. logical_simplify; subst.
       destruct enable; cbn [negb fst snd].
       all:ssplit; first [ lia | reflexivity
-                        | apply N.mod_bound_pos; lia ].
+                          | apply N.mod_bound_pos; lia ].
     Qed.
 
     Lemma counter_output_correct : output_correct counter.
     Proof.
       intros (enable,[]) (data, ?) value.
-      simplify_invariant_logic counter.
+      simplify_invariant counter.
       intros; logical_simplify; subst.
+      simplify_spec counter.
       cbv [counter]. stepsimpl. compute_expr (N.of_nat 8).
       change (2 ^ 8) with 256 in *.
       change (N.ones 8) with 255 in *.
@@ -298,7 +329,7 @@ Module DoubleCounterExample.
 
     Lemma double_counter_invariant_at_reset : invariant_at_reset double_counter.
     Proof.
-      simplify_invariant_logic double_counter.
+      simplify_invariant double_counter.
       cbn [double_counter reset_state].
       stepsimpl. rewrite N.mod_0_l, N.div_0_l by (cbn; lia).
       ssplit; [ eapply counter_invariant_at_reset .. | ].
@@ -308,19 +339,20 @@ Module DoubleCounterExample.
     Lemma double_counter_invariant_preserved : invariant_preserved double_counter.
     Proof.
       cbv [invariant_preserved]. intros (enable,[]) (data,?) value.
-      intros; subst. simplify_invariant_logic double_counter.
+      intros; subst. simplify_invariant double_counter.
       cbv [double_counter]. stepsimpl. logical_simplify; subst.
       repeat use_correctness. stepsimpl.
+      simplify_spec double_counter.
       ssplit.
       { eapply (invariant_preserved_pf (c:=counter));
           [ | solve [eauto] .. ].
-        cbn [update_hl_state counter_invariant_logic].
+        simplify_spec counter.
         destruct enable; [ | reflexivity ].
         change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
         Zify.zify. Z.to_euclidean_division_equations. lia. }
-      {eapply (invariant_preserved_pf (c:=counter));
-          [ | solve [eauto] .. ].
-        cbn [update_hl_state counter_invariant_logic].
+      { eapply (invariant_preserved_pf (c:=counter));
+        [ | solve [eauto] .. ].
+        simplify_spec counter.
         change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
         repeat (destruct_one_match; try lia).
         (* extra step to help lia out, otherwise hangs *)
@@ -333,7 +365,8 @@ Module DoubleCounterExample.
     Lemma double_counter_output_correct : output_correct double_counter.
     Proof.
       cbv [output_correct]. intros (enable,[]) (data, ?) value.
-      simplify_invariant_logic double_counter.
+      simplify_invariant double_counter.
+      simplify_spec double_counter.
       intros; logical_simplify; subst.
       cbv [double_counter]. stepsimpl.
       repeat use_correctness. stepsimpl.
@@ -372,192 +405,201 @@ Module AbstractSubcircuitExample.
     Import ExprNotations.
     Import PrimitiveNotations.
 
-    (* Somewhat contrived circuit that takes in a stream of inputs of unknown
-       type, and always returns the smallest input seen so far (according to a
-       comparator subcircuit). The [cmp] subcircuit retuns true if the first
-       argument is <= the second, and false otherwise. *)
-    Definition minimum {cmp_state T} (cmp : Circuit cmp_state [T;T] Bit)
-      : Circuit _ [T] T :=
-      {{ fun input =>
-           let/delay min :=
-              (let input_le_min := `cmp` input min in
-               if input_le_min then input else min)
-                initially default in
-           min
-      }}.
+    (* Somewhat contrived circuit that takes in two streams of inputs of some
+       type, and always returns the smallest input seen so far.
 
-    Check Vec.
-    Definition double_minimum {cmp_state T} (cmp : Circuit cmp_state [T;T] Bit)
+       * The [cmp] subcircuit retuns true if the first argument is <= the
+         second, and false otherwise.
+       * The [minimum] subcircuit has the same idea but with a single stream of
+         inputs; its output is the smallest input seen so far.
+     *)
+    Definition double_minimum
+               {T minimum_state} (cmp : Circuit [] [T;T] Bit)
+               (minimum : Circuit minimum_state [T] T)
       : Circuit _ [T;T] T :=
       {{ fun input1 input2 =>
-           let min1 := `minimum cmp` input1 in
-           let min2 := `minimum cmp` input2 in
+           let min1 := `minimum` input1 in
+           let min2 := `minimum` input2 in
            let min1_le_min2 := `cmp` min1 min2 in
            if min1_le_min2 then min1 else min2
       }}.
   End CircuitDefinitions.
 
-  Section Specifications.
-    Context {T : type} (minT : denote_type T -> denote_type T -> denote_type T).
-    Context {cmp_state} (cmp : Circuit cmp_state [T;T] Bit).
+  Section SpecificationsAndProofs.
+    Context {T : type}
+            (* some order exists on type T *)
+            (rankT : denote_type T -> N).
+    Context (cmp : Circuit [] [T;T] Bit)
+            {minimum_state} (minimum : Circuit minimum_state [T] T)
+            {minimum_invariant : invariant_for minimum (list (denote_type T))}.
 
-    (* higher-level state here will be the list of inputs recieved so far *)
-    Global Instance minimum_invariant_logic
-      : invariant_logic_for (minimum cmp) (list (denote_type T)) :=
-      {| reset_hl_state := List.nil;
-         update_hl_state :=
+    (* high-level representation here is also the list of inputs so far *)
+    Global Instance minimum_specification
+      : specification_for minimum (list (denote_type T)) :=
+      {| reset_repr := List.nil;
+         update_repr :=
            fun (input : denote_type [T]) (acc : list (denote_type T)) =>
              let '(x,_) := input in
-             (x :: acc : list (denote_type T));
-         invariant_for :=
-           fun (state : denote_type T) acc =>
-             (* min is the minimum of the inputs received so far *)
-             state = fold_right minT default acc;
-         precondition_for := fun _ _ => True;
-         spec_for :=
-           fun input value =>
-             let '(enable,_) := input in
-             let new_val := if enable then (value + 1)%N else value in
-             ((new_val mod (2 ^ 8), 2 ^ 8 <=? new_val)
-              : denote_type (BitVec 8 ** Bit))
+             x :: acc;
+         precondition := fun _ _ => True;
+         postcondition :=
+           fun input acc out =>
+             let '(x,_) := input in
+             Forall (fun y => rankT out <= rankT y) (x :: acc);
       |}.
 
-    Global Instance double_counter_invariant_logic
-      : invariant_logic_for double_counter N :=
-      {| reset_hl_state := 0;
-         update_hl_state :=
-           fun (input : denote_type [Bit]) value =>
-             let '(enable,_) := input in
-             (* if enabled, add 1 mod 2^16, else do nothing *)
-             if enable
-             then ((value + 1) mod (2 ^ 16))%N
-             else value;
-         invariant_for :=
-           fun (state : denote_type (state_of (var:=denote_type) counter
-                                            ** state_of (var:=denote_type) counter)) value =>
-             let '(counter1_state, counter2_state) := state in
-             (* counter1_state matches the low part of the counter value *)
-             invariant_for counter counter1_state (value mod 2 ^ 8)%N
-             (* ...and counter2_state matches the high part of the counter value *)
-             /\ invariant_for counter counter2_state (value / 2 ^ 8)%N
-             (* ...and the value is < 2 ^ 16 (this is implied by the other two but
-                convenient to have without unfolding [counter_invariant]) *)
-             /\ value < 2 ^ 16;
-         precondition_for := fun _ _ => True;
-         spec_for :=
-           fun input value =>
-             let '(enable,_) := input in
-             let new_val := if enable then (value + 1)%N else value in
-             ((new_val mod (2 ^ 16), 2 ^ 16 <=? new_val)
-              : denote_type (BitVec 16 ** Bit))
+    (* Almost the same as minimum_specification *)
+    Instance double_minimum_specification
+      : specification_for (double_minimum cmp minimum) (list (denote_type T)) :=
+      {| reset_repr := List.nil;
+         update_repr :=
+           fun (input : denote_type [T;T]) (acc : list (denote_type T)) =>
+             let '(x,(y,_)) := input in
+             x :: y :: acc;
+         precondition := fun _ _ => True;
+         postcondition :=
+           fun input acc out =>
+             let '(x,(y,_)) := input in
+             Forall (fun y => rankT out <= rankT y) (x :: y :: acc);
       |}.
-  End Specifications.
 
-  Section Proofs.
-    Lemma counter_invariant_at_reset : invariant_at_reset counter.
-    Proof.
-      simplify_invariant_logic counter.
-      cbv [counter]. cbn [reset_state]. stepsimpl.
-      ssplit; [ reflexivity | ]. cbn; lia.
-    Qed.
+    Instance double_minimum_invariant
+      : invariant_for (double_minimum cmp minimum) (list (denote_type T)) :=
+      fun (state : denote_type (minimum_state ++ minimum_state ++ []))
+        (acc : list (denote_type T)) =>
+        let '(state1, state) := split_absorbed_denotation state in
+        let '(state2, _) := split_absorbed_denotation state in
+        exists acc1 acc2,
+          minimum_invariant state1 acc1
+          /\ minimum_invariant state2 acc2
+          (* acc1 ++ acc2 is a permutation of acc *)
+          /\ (forall x, In x (acc1 ++ acc2) -> In x acc)
+          /\ (forall x, In x acc -> In x (acc1 ++ acc2)).
 
-    Lemma counter_invariant_preserved : invariant_preserved counter.
-    Proof.
-      intros (enable,[]) (data, ?) value. intros; subst.
-      simplify_invariant_logic counter.
-      cbv [counter]. stepsimpl. logical_simplify; subst.
-      destruct enable; cbn [negb fst snd].
-      all:ssplit; first [ lia | reflexivity
-                        | apply N.mod_bound_pos; lia ].
-    Qed.
+    Section Proofs.
+      Context (cmp_correct :
+                 forall x y, step cmp tt (x,(y,tt)) = (tt, rankT x <? rankT y))
+              (minimum_correctness : correctness_for minimum).
+      Hint Rewrite cmp_correct : stepsimpl.
 
-    Lemma counter_output_correct : output_correct counter.
-    Proof.
-      intros (enable,[]) (data, ?) value.
-      simplify_invariant_logic counter.
-      intros; logical_simplify; subst.
-      cbv [counter]. stepsimpl. compute_expr (N.of_nat 8).
-      change (2 ^ 8) with 256 in *.
-      change (N.ones 8) with 255 in *.
-      destruct enable; cbn [negb fst snd].
-      all:repeat lazymatch goal with
-                 | |- context [N.eqb ?x ?y] => destr (N.eqb x y); subst
-                 | |- context [N.leb ?x ?y] => destr (N.leb x y)
-                 | _ => lia || reflexivity
-                 end.
-      all:rewrite N.mod_small by lia; reflexivity.
-    Qed.
+      Lemma split_combine_denotation
+            {t1 t2} (x : denote_type t1) (y : denote_type t2) :
+        split_absorbed_denotation (combine_absorbed_denotation x y) = (x,y).
+      Proof.
+        induction t1; destruct t2.
+        all:cbn [split_absorbed_denotation combine_absorbed_denotation denote_type] in *.
+        all:logical_simplify; subst.
+        all:repeat lazymatch goal with x : unit |- _ => destruct x end.
+        all:reflexivity.
+      Qed.
+      Lemma combine_split_denotation
+            {t1 t2} (xy : denote_type (t1 ++ t2)) :
+        combine_absorbed_denotation
+          (fst (split_absorbed_denotation xy))
+          (snd (split_absorbed_denotation xy)) = xy.
+      Proof.
+        induction t1; destruct t2.
+        all:cbn [split_absorbed_denotation combine_absorbed_denotation
+                                           denote_type absorb_any fst snd] in *.
+        all:logical_simplify; subst.
+        all:repeat lazymatch goal with x : unit |- _ => destruct x end.
+        all:rewrite <-?surjective_pairing.
+        all:reflexivity.
+      Qed.
 
-    Existing Instances counter_invariant_at_reset counter_invariant_preserved
-             counter_output_correct.
-    Global Instance counter_correctness : correctness_for counter.
-    Proof. constructor; typeclasses eauto. Defined.
+      Lemma double_minimum_invariant_at_reset
+        : invariant_at_reset (double_minimum cmp minimum).
+      Proof.
+        simplify_invariant (double_minimum cmp minimum).
+        cbn [double_minimum reset_state]. stepsimpl.
+        rewrite !split_combine_denotation.
+        exists nil, nil.
+        ssplit.
+        { exact (invariant_at_reset_pf (c:=minimum)). }
+        { exact (invariant_at_reset_pf (c:=minimum)). }
+        { cbn [app In]; tauto. }
+        { cbn [reset_repr double_minimum_specification app In].
+          tauto. }
+      Qed.
 
-    Lemma double_counter_invariant_at_reset : invariant_at_reset double_counter.
-    Proof.
-      simplify_invariant_logic double_counter.
-      cbn [double_counter reset_state].
-      stepsimpl. rewrite N.mod_0_l, N.div_0_l by (cbn; lia).
-      ssplit; [ eapply counter_invariant_at_reset .. | ].
-      cbn; lia.
-    Qed.
+      Lemma double_minimum_invariant_preserved : invariant_preserved (double_minimum cmp minimum).
+      Proof.
+        cbv [invariant_preserved]. cbn [absorb_any].
+        intros [i1 [i2 []]].
+        intros; subst. simplify_invariant (double_minimum cmp minimum).
+        repeat destruct_pair_let.
+        repeat lazymatch goal with
+               | H : context [match ?p with pair _ _ => _ end] |- _ =>
+                 rewrite (surjective_pairing p) in H
+               end.
+        cbv [double_minimum]. stepsimpl. logical_simplify; subst.
+        repeat (destruct_pair_let; cbn [fst snd]). stepsimpl.
+        repeat (rewrite split_combine_denotation; cbn [fst snd]).
+        simplify_spec (double_minimum cmp minimum).
+        do 2 eexists. ssplit.
+        { eapply (invariant_preserved_pf (c:=minimum));
+            [ | solve [eauto] .. ].
+          simplify_spec minimum. reflexivity. }
+        { eapply (invariant_preserved_pf (c:=minimum));
+            [ | solve [eauto] .. ].
+          simplify_spec minimum. reflexivity. }
+        { cbn [app In]. intros.
+          repeat match goal with
+                 | _ => progress cbn [In] in *
+                 | H : _ \/ _ |- _ => destruct H; subst
+                 | H : In _ (_ ++ _) |- _ => eapply in_app_or in H
+                 | H1 : (forall x, In x (_ ++ _) -> ?P), H2 : In ?x _ |- _ =>
+                   assert ((fun x => P) x) by (apply H1; apply in_app_iff; tauto);
+                     tauto
+                 | _ => tauto
+                 end. }
+        { cbn [app In]. intros.
+          rewrite in_app_iff. cbn [In].
+          repeat match goal with
+                 | _ => progress cbn [In] in *
+                 | H : _ \/ _ |- _ => destruct H; subst
+                 | H : In _ (_ ++ _) |- _ => eapply in_app_or in H
+                 | H1 : (forall x, In x ?l -> ?P), H2 : In ?x ?l |- _ =>
+                   specialize (H1 x H2)
+                 | _ => tauto
+                 end. }
+      Qed.
 
-    Lemma double_counter_invariant_preserved : invariant_preserved double_counter.
-    Proof.
-      cbv [invariant_preserved]. intros (enable,[]) (data,?) value.
-      intros; subst. simplify_invariant_logic double_counter.
-      cbv [double_counter]. stepsimpl. logical_simplify; subst.
-      repeat use_correctness. stepsimpl.
-      ssplit.
-      { eapply (invariant_preserved_pf (c:=counter));
-          [ | solve [eauto] .. ].
-        cbn [update_hl_state counter_invariant_logic].
-        destruct enable; [ | reflexivity ].
-        change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
-        Zify.zify. Z.to_euclidean_division_equations. lia. }
-      {eapply (invariant_preserved_pf (c:=counter));
-          [ | solve [eauto] .. ].
-        cbn [update_hl_state counter_invariant_logic].
-        change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
-        repeat (destruct_one_match; try lia).
-        (* extra step to help lia out, otherwise hangs *)
-        all:try rewrite N.mod_mul_div_r with (b:=256) (c:=256) by lia.
-        all:Zify.zify; Z.to_euclidean_division_equations; lia. }
-      { destruct enable; [ | lia ].
-        apply N.mod_bound_pos; lia. }
-    Qed.
+      Lemma double_minimum_output_correct : output_correct (double_minimum cmp minimum).
+      Proof.
+        cbv [output_correct]. cbn [absorb_any].
+        intros (i1,(i2,[])). intros.
+        simplify_invariant (double_minimum cmp minimum).
+        simplify_spec (double_minimum cmp minimum).
+        repeat lazymatch goal with
+               | H : context [match ?p with pair _ _ => _ end] |- _ =>
+                 rewrite (surjective_pairing p) in H
+               end.
+        cbv [double_minimum]. stepsimpl. logical_simplify; subst.
+        repeat (destruct_pair_let; cbn [fst snd]). stepsimpl.
+        repeat use_correctness' minimum.
+        rewrite !Forall_forall in *. intros.
+        repeat match goal with
+               | _ => progress cbn [In] in *
+               | H : _ \/ _ |- _ => destruct H; subst
+               | H : In _ (_ ++ _) |- _ => eapply in_app_or in H
+               | H : forall x, ?y = x \/ _ -> _ |- _ <= rankT ?y =>
+                 specialize (H y ltac:(eauto))
+               | H : (forall x, (_ \/ In x ?l) -> _), H2 : In ?x ?l |- _ =>
+                 specialize (H x ltac:(eauto))
+               | H1 : (forall x, In x ?l -> ?P), H2 : In ?x ?l |- _ =>
+                 specialize (H1 x H2)
+               | _ => tauto
+               | _ => lia
+               | _ => solve [eauto using N.le_trans]
+               | _ => destruct_one_match
+               end.
+      Qed.
 
-    Lemma double_counter_output_correct : output_correct double_counter.
-    Proof.
-      cbv [output_correct]. intros (enable,[]) (data, ?) value.
-      simplify_invariant_logic double_counter.
-      intros; logical_simplify; subst.
-      cbv [double_counter]. stepsimpl.
-      repeat use_correctness. stepsimpl.
-      f_equal.
-      { (* counter values match *)
-        compute_expr (N.of_nat 8). compute_expr (8 + 8)%nat.
-        compute_expr (N.of_nat 16).
-        rewrite !N.shiftl_mul_pow2, !N.land_ones.
-        change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
-        rewrite !(N.mod_small (_ mod 256) 65536)
-          by (eapply N.lt_le_trans; [ apply N.mod_bound_pos | ]; lia).
-        rewrite N.lor_high_low_add with (b:=8). change (2 ^ 8) with 256 in *.
-        repeat destruct_one_match.
-        (* the below rewrite improves performance of lia *)
-        all:rewrite ?N.mod_mod by lia.
-        all:Zify.zify; Z.to_euclidean_division_equations; lia. }
-      { change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
-        repeat destruct_one_match.
-        all:repeat lazymatch goal with |- context [N.leb ?x ?y] =>
-                                       destr (N.leb x y) end.
-        all:try reflexivity.
-        all:Zify.zify; Z.to_euclidean_division_equations; lia. }
-    Qed.
-
-    Existing Instances double_counter_invariant_at_reset double_counter_invariant_preserved
-             double_counter_output_correct.
-    Global Instance double_counter_correctness : correctness_for double_counter.
-    Proof. constructor; typeclasses eauto. Defined.
-  End Proofs.
-End DoubleCounterExample.
+      Existing Instances double_minimum_invariant_at_reset double_minimum_invariant_preserved
+               double_minimum_output_correct.
+      Global Instance double_minimum_correctness : correctness_for (double_minimum cmp minimum).
+      Proof. constructor; typeclasses eauto. Defined.
+    End Proofs.
+  End SpecificationsAndProofs.
+End AbstractSubcircuitExample.

--- a/cava2/Invariant.v
+++ b/cava2/Invariant.v
@@ -15,6 +15,7 @@
 (****************************************************************************)
 
 Require Import Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
 Require Import Cava.Types.
 Require Import Cava.Expr.
 Require Import Cava.Semantics.
@@ -57,107 +58,114 @@ Module Example.
     Import PrimitiveNotations.
 
     (* Circuit which takes a bit indicating whether to increment or not, and if
-       the bit is true increments an n-bit counter by 1 each cycle. The counter
+       the bit is true increments an 8-bit counter by 1 each cycle. The counter
        truncates on overflow and returns the counter value along with a bit
        indicating whether the counter overflowed. *)
-    Definition counter (n : nat) : Circuit (BitVec n ** Bit) [Bit] (BitVec n ** Bit) :=
+    Definition counter : Circuit (BitVec 8 ** Bit) [Bit] (BitVec 8 ** Bit) :=
       {{ fun enable =>
            let/delay '(data; overflow) :=
               (if !enable
                then (data,`Zero`)
                else
-                 let new_overflow := data == `K (N.ones (N.of_nat n))` in
+                 let new_overflow := data == `K (N.ones 8)` in
                  let new_data := data + `K 1` in
                  (new_data, new_overflow))
                 initially
-                ((0,false) : denote_type (BitVec n ** Bit)) in
+                ((0,false) : denote_type (BitVec 8 ** Bit)) in
            (data,overflow)
       }}.
 
-    (* Creates a 2n-bit counter out of two n-bit counters *)
-    Definition double_counter (n : nat) : Circuit _ [Bit] (BitVec (2 * n) ** Bit) :=
+    (* Creates a 16-bit counter out of two 8-bit counters *)
+    Definition double_counter : Circuit _ [Bit] (BitVec 16 ** Bit) :=
       {{ fun enable =>
-           let '(low; low_overflow) := `counter n` enable in
-           let '(high; high_overflow) := `counter n` low_overflow in
+           let '(low; low_overflow) := `counter` enable in
+           let '(high; high_overflow) := `counter` low_overflow in
            (`bvresize _` (`bvconcat` high low), high_overflow) }}.
   End CircuitDefinitions.
 
   Section Specifications.
     (* Ghost state : counter value *)
-    Definition counter_ghost_state : Type := N.
+    Definition counter_hl_state : Type := N.
 
-    (* Invariant: the counter value must be < 2 ^ n. *)
-    Definition counter_invariant {n}
-               (state : denote_type (state_of (var:=denote_type) (counter n)))
+    (* Invariant: the counter value must be < 2 ^ 8. *)
+    Definition counter_invariant
+               (state : denote_type (state_of (var:=denote_type) counter))
                (* Ghost variable tracking counter value *)
-               (ghost_state : counter_ghost_state)
+               (hl_state : counter_hl_state)
     : Prop :=
       let '(data, _) := state in
-      let value := ghost_state in
+      let value := hl_state in
       (* value is exactly equivalent to [data] *)
       data = value
-      (* ...and value < 2 ^ n *)
-      /\ (value < 2 ^ N.of_nat n)%N.
+      (* ...and value < 2 ^ 8 *)
+      /\ value < 2 ^ 8.
 
     (* No input preconditions *)
-    Definition counter_pre {n}
-               (input : denote_type (input_of (var:=denote_type) (counter n)))
-               (ghost_state : counter_ghost_state)
+    Definition counter_pre
+               (input : denote_type (input_of (var:=denote_type) counter))
+               (hl_state : counter_hl_state)
       : Prop := True.
 
-    Definition counter_spec {n}
-               (input : denote_type (input_of (var:=denote_type) (counter n)))
-               (ghost_state : counter_ghost_state)
-      : denote_type (output_of (var:=denote_type) (counter n)) :=
+    Definition counter_spec
+               (input : denote_type (input_of (var:=denote_type) counter))
+               (hl_state : counter_hl_state)
+      : denote_type (output_of (var:=denote_type) counter) :=
       let '(enable,_) := input in
-      let value := ghost_state in
+      let value := hl_state in
       let new_val := if enable then (value + 1)%N else value in
-      (new_val mod (2 ^ N.of_nat n), (2 ^ N.of_nat n <=? new_val))%N.
+      (new_val mod (2 ^ 8), 2 ^ 8 <=? new_val).
 
-    Definition counter_update_ghost_state {n}
-               (input : denote_type (input_of (counter (var:=denote_type) n)))
-               (ghost_state : counter_ghost_state) : counter_ghost_state :=
+    Definition counter_update_hl_state
+               (input : denote_type (input_of (counter (var:=denote_type))))
+               (hl_state : counter_hl_state) : counter_hl_state :=
       let '(enable,_) := input in
-      let value := ghost_state in
+      let value := hl_state in
       if enable
-      then ((value + 1) mod (2 ^ N.of_nat n))%N
+      then ((value + 1) mod (2 ^ 8))%N
       else value.
 
-    (* Double counter ghost state is also just a value *)
-    Definition double_counter_ghost_state := counter_ghost_state.
+    (* Double counter high-level state is also just a value *)
+    Definition double_counter_hl_state := counter_hl_state.
 
-    Definition double_counter_invariant {n}
-               (state : denote_type (state_of (double_counter (var:=denote_type) n)))
-               (* Ghost variable tracking double_counter value *)
-               (ghost_state : double_counter_ghost_state)
+    Definition double_counter_invariant
+               (state : denote_type (state_of (double_counter (var:=denote_type))))
+               (* High-level state variable tracking double_counter value *)
+               (hl_state : double_counter_hl_state)
     : Prop :=
       let '(counter1_state, counter2_state) := state in
-      let value := ghost_state in
+      let value := hl_state in
       (* counter1_state matches the low part of the counter value *)
-      counter_invariant (n:=n) counter1_state (value mod 2 ^ N.of_nat n)%N
+      counter_invariant counter1_state (value mod 2 ^ 8)%N
       (* ...and counter2_state matches the high part of the counter value *)
-      /\ counter_invariant (n:=n) counter2_state (value / 2 ^ N.of_nat n)%N
-      (* ...and the value is < 2 ^ 2n (this is implied by the other two but
+      /\ counter_invariant counter2_state (value / 2 ^ 8)%N
+      (* ...and the value is < 2 ^ 16 (this is implied by the other two but
          convenient to have without unfolding [counter_invariant]) *)
-      /\ value < 2 ^ (N.of_nat (2 * n)).
+      /\ value < 2 ^ 16.
 
     (* No input preconditions *)
-    Definition double_counter_pre {n}
-               (input : denote_type (input_of (double_counter (var:=denote_type) n)))
-               (ghost_state : double_counter_ghost_state)
+    Definition double_counter_pre
+               (input : denote_type (input_of (double_counter (var:=denote_type))))
+               (hl_state : double_counter_hl_state)
       : Prop := True.
 
     (* Spec is the same as a double-size counter *)
-    Definition double_counter_spec {n}
-               (input : denote_type (input_of (double_counter (var:=denote_type) n)))
-               (ghost_state : double_counter_ghost_state)
-      : denote_type (output_of (double_counter (var:=denote_type) n)) :=
-      counter_spec (n:=2*n) input ghost_state.
+    Definition double_counter_spec
+               (input : denote_type (input_of (double_counter (var:=denote_type))))
+               (hl_state : double_counter_hl_state)
+      : denote_type (output_of (double_counter (var:=denote_type))) :=
+      let '(enable,_) := input in
+      let value := hl_state in
+      let new_val := if enable then (value + 1)%N else value in
+      (new_val mod (2 ^ 16), 2 ^ 16 <=? new_val).
 
-    Definition double_counter_update_ghost_state {n}
-               (input : denote_type (input_of (double_counter (var:=denote_type) n)))
-               (ghost_state : double_counter_ghost_state) : double_counter_ghost_state :=
-      counter_update_ghost_state (n:=2*n) input ghost_state.
+    Definition double_counter_update_hl_state
+               (input : denote_type (input_of (double_counter (var:=denote_type))))
+               (hl_state : double_counter_hl_state) : double_counter_hl_state :=
+      let '(enable,_) := input in
+      let value := hl_state in
+      if enable
+      then ((value + 1) mod (2 ^ 16))%N
+      else value.
   End Specifications.
 
   Section Proofs.
@@ -182,54 +190,83 @@ Module Example.
     Qed.
     Hint Rewrite @step_bvconcat using solve [eauto] : stepsimpl.
 
-    Lemma step_counter_invariant n state ghost_state new_ghost_state input :
-      counter_invariant (n:=n) state ghost_state ->
-      counter_pre (n:=n) input ghost_state ->
-      new_ghost_state = counter_update_ghost_state input ghost_state ->
-      counter_invariant (fst (step (counter n) state input))
-                        new_ghost_state.
+    Lemma step_counter_invariant state hl_state new_hl_state input :
+      counter_invariant state hl_state ->
+      counter_pre input hl_state ->
+      new_hl_state = counter_update_hl_state input hl_state ->
+      counter_invariant (fst (step counter state input))
+                        new_hl_state.
     Admitted.
 
-    Lemma step_counter n state ghost_state input :
-      counter_invariant (n:=n) state ghost_state ->
-      counter_pre (n:=n) input ghost_state ->
-      snd (step (counter n) state input)
-      = counter_spec input ghost_state.
+    Lemma step_counter state hl_state input :
+      counter_invariant state hl_state ->
+      counter_pre input hl_state ->
+      snd (step counter state input)
+      = counter_spec input hl_state.
     Admitted.
 
-    Lemma step_double_counter_invariant n state ghost_state new_ghost_state input :
-      double_counter_invariant (n:=n) state ghost_state ->
-      double_counter_pre (n:=n) input ghost_state ->
-      new_ghost_state = double_counter_update_ghost_state input ghost_state ->
-      double_counter_invariant (fst (step (double_counter n) state input))
-                               new_ghost_state.
+    Lemma step_double_counter_invariant state hl_state new_hl_state input :
+      double_counter_invariant state hl_state ->
+      double_counter_pre input hl_state ->
+      new_hl_state = double_counter_update_hl_state input hl_state ->
+      double_counter_invariant (fst (step double_counter state input))
+                               new_hl_state.
     Proof.
-      destruct state as (data, ?). rename ghost_state into value.
+      destruct state as (data, ?). rename hl_state into value.
       destruct input as (enable,[]).
       cbv [double_counter_invariant double_counter_pre]; intros; subst.
       cbv [double_counter]. stepsimpl.
       logical_simplify; subst. natsimpl.
       lazymatch goal with
-      | |- context [match step (counter ?n) ?s ?i with pair _ _ => _ end] =>
-        rewrite (surjective_pairing (step (counter n) s i))
+      | |- context [match step counter ?s ?i with pair _ _ => _ end] =>
+        rewrite (surjective_pairing (step counter s i))
       end.
       erewrite step_counter by eauto.
       cbv [counter_spec].
       stepsimpl.
       lazymatch goal with
-      | |- context [match step (counter ?n) ?s ?i with pair _ _ => _ end] =>
-        rewrite (surjective_pairing (step (counter n) s i))
+      | |- context [match step counter ?s ?i with pair _ _ => _ end] =>
+        rewrite (surjective_pairing (step counter s i))
       end.
       erewrite step_counter by eauto.
       cbv [counter_spec].
       stepsimpl.
+      cbv [double_counter_update_hl_state counter_update_hl_state].
+      ssplit.
+      { eapply step_counter_invariant; [ solve [eauto] .. | ].
+        cbv [counter_update_hl_state]. destruct enable; [ | reflexivity ].
+        change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
+        Zify.zify. Z.to_euclidean_division_equations. lia. }
+      { eapply step_counter_invariant; [ solve [eauto] .. | ].
+        cbv [counter_update_hl_state].
+        change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
+        repeat (destruct_one_match; try lia).
+        { Zify.zify;
+          Z.to_euclidean_division_equations;
+          lia. }
+        { Zify.zify.
+          Z.to_euclidean_division_equations.
+          lia. }
+        { rewrite N.div_small by (apply N.mod_bound_pos; lia).
+          assert (value / 256 < 256) by admit.
+          Zify.zify.
+          Search Z.rem Z.modulo.
+          rewrite !Z.rem_mod_nonneg in * by lia.
+          Z.div_mod_to_equations.
+          lia.
+          Z.to_euclidean_division_equations. lia. }
+        
+        all:Zify.zify; Z.to_euclidean_division_equations; try lia. }
+
+
+      
       (* helpful assertions *)
       assert (2 ^ N.of_nat n <> 0) by (apply N.pow_nonzero; lia).
       pose proof N.mod_bound_pos value (2 ^ N.of_nat n) ltac:(lia) ltac:(lia).
-      cbv [double_counter_update_ghost_state counter_update_ghost_state].
+      cbv [double_counter_update_hl_state counter_update_hl_state].
       ssplit.
       { eapply step_counter_invariant; [ solve [eauto] .. | ].
-        cbv [counter_update_ghost_state].
+        cbv [counter_update_hl_state].
         destruct enable; [ | reflexivity ].
         rewrite N.add_mod_idemp_l, Nat2N.inj_mul by lia.
         replace (N.of_nat 2 * N.of_nat n) with (N.of_nat n * 2) by lia.
@@ -237,7 +274,7 @@ Module Example.
         rewrite N.mod_mod_mul_l by lia.
         reflexivity. }
       { eapply step_counter_invariant; [ solve [eauto] .. | ].
-        cbv [counter_update_ghost_state].
+        cbv [counter_update_hl_state].
         repeat (destruct_one_match; try lia).
         { (* this is the case in which the low counter overflows -- adding 1 and
              then taking the high part is therefore the same as taking the high
@@ -274,13 +311,13 @@ Module Example.
         apply N.mod_bound_pos; lia. }
     Qed.
 
-    Lemma step_double_counter n state ghost_state input :
-      double_counter_invariant (n:=n) state ghost_state ->
-      double_counter_pre (n:=n) input ghost_state ->
+    Lemma step_double_counter n state hl_state input :
+      double_counter_invariant state hl_state ->
+      double_counter_pre input hl_state ->
       snd (step (double_counter n) state input)
-      = double_counter_spec input ghost_state.
+      = double_counter_spec input hl_state.
     Proof.
-      destruct state as (data, ?). rename ghost_state into value.
+      destruct state as (data, ?). rename hl_state into value.
       destruct input as (enable,[]).
       cbv [double_counter_invariant double_counter_pre]; intros; subst.
       cbv [double_counter double_counter_spec]. stepsimpl.

--- a/cava2/Invariant.v
+++ b/cava2/Invariant.v
@@ -27,6 +27,38 @@ Require Import Cava.Util.Nat.
 Require Import Cava.Util.Tactics.
 Require Import Cava.ExprProperties.
 
+Class state_logic_for {s i o} (c : Circuit (var:=denote_type) s i o)
+      (hl_state : Type) :=
+  { reset_hl_state : hl_state;
+    update_hl_state : denote_type i -> hl_state -> hl_state;
+    invariant_for : denote_type s -> hl_state -> Prop;
+    precondition_for : denote_type i -> hl_state -> Prop;
+    spec_for : denote_type i -> hl_state -> denote_type o;
+  }.
+Global Arguments invariant_for {_ _ _} _ {_ _}.
+Global Arguments precondition_for {_ _ _} _ {_ _}.
+Global Arguments spec_for {_ _ _} _ {_ _}.
+
+Definition invariant_at_reset {s i o} (c : Circuit s i o)
+           {hl_state} {state_logic : state_logic_for c hl_state} : Prop :=
+  invariant_for c (reset_state c) reset_hl_state.
+
+Definition invariant_preserved {s i o} (c : Circuit s i o)
+           {hl_state} {state_logic : state_logic_for c hl_state} : Prop :=
+  forall input state hl_state new_hl_state,
+    new_hl_state = update_hl_state input hl_state ->
+    invariant_for c state hl_state ->
+    precondition_for c input hl_state ->
+    invariant_for c (fst (step c state input)) new_hl_state.
+
+Definition output_correct {s i o} (c : Circuit s i o)
+           {hl_state} {state_logic : state_logic_for c hl_state} : Prop :=
+  forall input state hl_state,
+    invariant_for c state hl_state ->
+    precondition_for c input hl_state ->
+    snd (step c state input) = spec_for c input hl_state.
+
+
 Module N.
   Lemma mod_mod_mul_l a b c : b <> 0 -> c <> 0 -> (a mod (b * c)) mod c = a mod c.
   Proof.
@@ -107,121 +139,86 @@ Module Example.
   End CircuitDefinitions.
 
   Section Specifications.
-    (* Ghost state : counter value *)
-    Definition counter_hl_state : Type := N.
 
-    (* Invariant: the counter value must be < 2 ^ 8. *)
-    Definition counter_invariant
-               (state : denote_type (state_of (var:=denote_type) counter))
-               (* Ghost variable tracking counter value *)
-               (hl_state : counter_hl_state)
-    : Prop :=
-      let '(data, _) := state in
-      let value := hl_state in
-      (* value is exactly equivalent to [data] *)
-      data = value
-      (* ...and value < 2 ^ 8 *)
-      /\ value < 2 ^ 8.
+    Global Instance counter_state_logic
+      : state_logic_for counter N :=
+      {| reset_hl_state := 0;
+         update_hl_state :=
+           fun (input : denote_type [Bit]) value =>
+             let '(enable,_) := input in
+             (* if enabled, add 1 mod 2^8, else do nothing *)
+             if enable
+             then ((value + 1) mod (2 ^ 8))%N
+             else value;
+         invariant_for :=
+           fun (state : denote_type (BitVec 8 ** _)) value =>
+             let '(data,_) := state in
+             (* value is exactly equivalent to [data] *)
+             data = value
+             (* ...and value < 2 ^ 8 *)
+             /\ value < 2 ^ 8;
+         precondition_for := fun _ _ => True;
+         spec_for :=
+           fun input value =>
+             let '(enable,_) := input in
+             let new_val := if enable then (value + 1)%N else value in
+             ((new_val mod (2 ^ 8), 2 ^ 8 <=? new_val)
+              : denote_type (BitVec 8 ** Bit))
+      |}.
 
-    (* No input preconditions *)
-    Definition counter_pre
-               (input : denote_type (input_of (var:=denote_type) counter))
-               (hl_state : counter_hl_state)
-      : Prop := True.
-
-    Definition counter_spec
-               (input : denote_type (input_of (var:=denote_type) counter))
-               (hl_state : counter_hl_state)
-      : denote_type (output_of (var:=denote_type) counter) :=
-      let '(enable,_) := input in
-      let value := hl_state in
-      let new_val := if enable then (value + 1)%N else value in
-      (new_val mod (2 ^ 8), 2 ^ 8 <=? new_val).
-
-    Definition counter_update_hl_state
-               (input : denote_type (input_of (counter (var:=denote_type))))
-               (hl_state : counter_hl_state) : counter_hl_state :=
-      let '(enable,_) := input in
-      let value := hl_state in
-      if enable
-      then ((value + 1) mod (2 ^ 8))%N
-      else value.
-
-    (* Double counter high-level state is also just a value *)
-    Definition double_counter_hl_state := counter_hl_state.
-
-    Definition double_counter_invariant
-               (state : denote_type (state_of (double_counter (var:=denote_type))))
-               (* High-level state variable tracking double_counter value *)
-               (hl_state : double_counter_hl_state)
-    : Prop :=
-      let '(counter1_state, counter2_state) := state in
-      let value := hl_state in
-      (* counter1_state matches the low part of the counter value *)
-      counter_invariant counter1_state (value mod 2 ^ 8)%N
-      (* ...and counter2_state matches the high part of the counter value *)
-      /\ counter_invariant counter2_state (value / 2 ^ 8)%N
-      (* ...and the value is < 2 ^ 16 (this is implied by the other two but
-         convenient to have without unfolding [counter_invariant]) *)
-      /\ value < 2 ^ 16.
-
-    (* No input preconditions *)
-    Definition double_counter_pre
-               (input : denote_type (input_of (double_counter (var:=denote_type))))
-               (hl_state : double_counter_hl_state)
-      : Prop := True.
-
-    (* Spec is the same as a double-size counter *)
-    Definition double_counter_spec
-               (input : denote_type (input_of (double_counter (var:=denote_type))))
-               (hl_state : double_counter_hl_state)
-      : denote_type (output_of (double_counter (var:=denote_type))) :=
-      let '(enable,_) := input in
-      let value := hl_state in
-      let new_val := if enable then (value + 1)%N else value in
-      (new_val mod (2 ^ 16), 2 ^ 16 <=? new_val).
-
-    Definition double_counter_update_hl_state
-               (input : denote_type (input_of (double_counter (var:=denote_type))))
-               (hl_state : double_counter_hl_state) : double_counter_hl_state :=
-      let '(enable,_) := input in
-      let value := hl_state in
-      if enable
-      then ((value + 1) mod (2 ^ 16))%N
-      else value.
+    Global Instance double_counter_state_logic
+      : state_logic_for double_counter N :=
+      {| reset_hl_state := 0;
+         update_hl_state :=
+           fun (input : denote_type [Bit]) value =>
+             let '(enable,_) := input in
+             (* if enabled, add 1 mod 2^16, else do nothing *)
+             if enable
+             then ((value + 1) mod (2 ^ 16))%N
+             else value;
+         invariant_for :=
+           fun (state : denote_type (state_of (var:=denote_type) counter
+                                            ** state_of (var:=denote_type) counter)) value =>
+             let '(counter1_state, counter2_state) := state in
+             (* counter1_state matches the low part of the counter value *)
+             invariant_for counter counter1_state (value mod 2 ^ 8)%N
+             (* ...and counter2_state matches the high part of the counter value *)
+             /\ invariant_for counter counter2_state (value / 2 ^ 8)%N
+             (* ...and the value is < 2 ^ 16 (this is implied by the other two but
+                convenient to have without unfolding [counter_invariant]) *)
+             /\ value < 2 ^ 16;
+         precondition_for := fun _ _ => True;
+         spec_for :=
+           fun input value =>
+             let '(enable,_) := input in
+             let new_val := if enable then (value + 1)%N else value in
+             ((new_val mod (2 ^ 16), 2 ^ 16 <=? new_val)
+              : denote_type (BitVec 16 ** Bit))
+      |}.
   End Specifications.
 
   Section Proofs.
 
-    Lemma step_counter_invariant state hl_state new_hl_state input :
-      counter_invariant state hl_state ->
-      counter_pre input hl_state ->
-      new_hl_state = counter_update_hl_state input hl_state ->
-      counter_invariant (fst (step counter state input))
-                        new_hl_state.
+    Lemma step_counter_invariant : invariant_preserved counter.
     Proof.
-      destruct state as (data, ?). rename hl_state into value.
-      destruct input as (enable,[]).
-      cbv [counter_invariant counter_pre]; intros; subst.
+      cbv [invariant_preserved]. intros (enable,[]) (data, ?) value.
+      intros; subst.
+      cbn [invariant_for precondition_for update_hl_state
+                         counter_state_logic] in *.
       cbv [counter]. stepsimpl. logical_simplify; subst.
-      cbv [counter_update_hl_state].
       destruct enable; cbn [negb fst snd].
       all:ssplit; first [ lia
                         | reflexivity
                         | apply N.mod_bound_pos; lia ].
     Qed.
 
-    Lemma step_counter state hl_state input :
-      counter_invariant state hl_state ->
-      counter_pre input hl_state ->
-      snd (step counter state input)
-      = counter_spec input hl_state.
+    Lemma step_counter : output_correct counter.
     Proof.
-      destruct state as (data, ?). rename hl_state into value.
-      destruct input as (enable,[]).
-      cbv [counter_invariant counter_pre]; intros; subst.
-      cbv [counter]. stepsimpl. logical_simplify; subst.
-      cbv [counter_spec]. compute_expr (N.of_nat 8).
+      cbv [output_correct]. intros (enable,[]) (data, ?) value.
+      cbn [invariant_for precondition_for spec_for
+                         counter_state_logic] in *.
+      intros; logical_simplify; subst.
+      cbv [counter]. stepsimpl. compute_expr (N.of_nat 8).
       change (2 ^ 8) with 256 in *.
       change (N.ones 8) with 255 in *.
       destruct enable; cbn [negb fst snd].
@@ -233,39 +230,33 @@ Module Example.
       all:rewrite N.mod_small by lia; reflexivity.
     Qed.
 
-    Lemma step_double_counter_invariant state hl_state new_hl_state input :
-      double_counter_invariant state hl_state ->
-      double_counter_pre input hl_state ->
-      new_hl_state = double_counter_update_hl_state input hl_state ->
-      double_counter_invariant (fst (step double_counter state input))
-                               new_hl_state.
+    Lemma step_double_counter_invariant : invariant_preserved double_counter.
     Proof.
-      destruct state as (data, ?). rename hl_state into value.
-      destruct input as (enable,[]).
-      cbv [double_counter_invariant double_counter_pre]; intros; subst.
-      cbv [double_counter]. stepsimpl.
-      logical_simplify; subst. natsimpl.
+      cbv [invariant_preserved]. intros (enable,[]) (data,?) value.
+      intros; subst.
+      cbn [invariant_for precondition_for update_hl_state
+                         double_counter_state_logic] in *.
+      cbv [double_counter]. stepsimpl. logical_simplify; subst.
       lazymatch goal with
       | |- context [match step counter ?s ?i with pair _ _ => _ end] =>
         rewrite (surjective_pairing (step counter s i))
       end.
       erewrite !step_counter by eauto.
-      cbv [counter_spec]. stepsimpl.
+      cbn [spec_for counter_state_logic]. stepsimpl.
       lazymatch goal with
       | |- context [match step counter ?s ?i with pair _ _ => _ end] =>
         rewrite (surjective_pairing (step counter s i))
       end.
       erewrite step_counter by eauto.
-      cbv [counter_spec].
-      stepsimpl.
-      cbv [double_counter_update_hl_state counter_update_hl_state].
+      cbn [spec_for counter_state_logic]. stepsimpl.
       ssplit.
-      { eapply step_counter_invariant; [ solve [eauto] .. | ].
-        cbv [counter_update_hl_state]. destruct enable; [ | reflexivity ].
+      { eapply step_counter_invariant; [ | solve [eauto] .. ].
+        cbn [update_hl_state counter_state_logic].
+        destruct enable; [ | reflexivity ].
         change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
         Zify.zify. Z.to_euclidean_division_equations. lia. }
-      { eapply step_counter_invariant; [ solve [eauto] .. | ].
-        cbv [counter_update_hl_state].
+      { eapply step_counter_invariant; [ | solve [eauto] .. ].
+        cbn [update_hl_state counter_state_logic].
         change (2 ^ 8) with 256 in *. change (2 ^ 16) with 65536 in *.
         repeat (destruct_one_match; try lia).
         (* extra step to help lia out, otherwise hangs *)
@@ -275,31 +266,25 @@ Module Example.
         apply N.mod_bound_pos; lia. }
     Qed.
 
-    Lemma step_double_counter state hl_state input :
-      double_counter_invariant state hl_state ->
-      double_counter_pre input hl_state ->
-      snd (step double_counter state input)
-      = double_counter_spec input hl_state.
+    Lemma step_double_counter : output_correct double_counter.
     Proof.
-      destruct state as (data, ?). rename hl_state into value.
-      destruct input as (enable,[]).
-      cbv [double_counter_invariant double_counter_pre]; intros; subst.
-      cbv [double_counter double_counter_spec]. stepsimpl.
-      logical_simplify; subst. natsimpl.
+      cbv [output_correct]. intros (enable,[]) (data, ?) value.
+      cbn [invariant_for precondition_for spec_for
+                         double_counter_state_logic] in *.
+      intros; logical_simplify; subst.
+      cbv [double_counter]. stepsimpl.
       lazymatch goal with
       | |- context [match step counter ?s ?i with pair _ _ => _ end] =>
         rewrite (surjective_pairing (step counter s i))
       end.
       erewrite step_counter by eauto.
-      cbv [counter_spec].
-      stepsimpl.
+      cbn [spec_for counter_state_logic]; stepsimpl.
       lazymatch goal with
       | |- context [match step counter ?s ?i with pair _ _ => _ end] =>
         rewrite (surjective_pairing (step counter s i))
       end.
       erewrite step_counter by eauto.
-      cbv [counter_spec].
-      stepsimpl.
+      cbn [spec_for counter_state_logic]; stepsimpl.
       f_equal.
       { (* counter values match *)
         compute_expr (N.of_nat 8). compute_expr (8 + 8)%nat.


### PR DESCRIPTION
I've been thinking that we should probably introduce some more structure and ergonomics to the invariant-style reasoning we've been loosely using. So I created some small examples that test the kind of things we want invariant reasoning to be able to do, including handle abstract types and subcircuits.

I've got a certain typeclass-based setup working on the examples, and added some automation. But I think before we commit to this kind of setup, it's worth having a little bit of design discussion about it. The two examples should let us iterate more quickly on ideas in this area.