### PR TITLE
Prove and reorganize all padder helper lemmas

### DIFF
--- a/cava/Cava/Util/BitArithmeticProperties.v
+++ b/cava/Cava/Util/BitArithmeticProperties.v
@@ -18,12 +18,14 @@ Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Bool.Bvector.
 Require Import Coq.Lists.List.
 Require Import Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 Require Import Coq.Vectors.Vector.
 Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Util.Nat.
+Require Import Cava.Util.List.
+Require Import Cava.Util.Tactics.
 Require Import Cava.Util.Vector.
-Require Import Cava.Util.BitArithmetic.
 Import ListNotations.
 Local Open Scope N_scope.
 
@@ -546,4 +548,88 @@ Proof.
     rewrite Bv2N_N2Bv_sized in vec_eq; [ assumption | assumption ].
   }
   { intros. apply f_equal. assumption. }
+Qed.
+
+Lemma N_to_bytes_length n x : length (BigEndianBytes.N_to_bytes n x) = n.
+Proof. cbv [BigEndianBytes.N_to_bytes]. length_hammer. Qed.
+Hint Rewrite @N_to_bytes_length : push_length.
+
+Lemma bytes_to_Ns_length n bs :
+  length (BigEndianBytes.bytes_to_Ns n bs) = length bs / n.
+Proof. cbv [BigEndianBytes.bytes_to_Ns]. length_hammer. Qed.
+Hint Rewrite @bytes_to_Ns_length : push_length.
+
+Lemma N_to_byte_to_N x : Byte.to_N (N_to_byte x) = (x mod 256)%N.
+Proof.
+  cbv [N_to_byte]. change (2 ^ 8)%N with 256%N.
+  pose proof N.mod_bound_pos x 256 ltac:(lia) ltac:(lia).
+  pose proof proj1 (Byte.of_N_None_iff (x mod 256)).
+  apply Byte.to_of_N.
+  destruct (Byte.of_N (x mod 256)); [ reflexivity | ].
+  lazymatch goal with H : None = None -> _ |- _ =>
+                      specialize (H ltac:(reflexivity)) end.
+  lia.
+Qed.
+
+Lemma nth_bytes_to_Ns i n bs :
+  length bs mod n = 0 ->
+  n <> 0 ->
+  List.nth i (BigEndianBytes.bytes_to_Ns n bs) 0%N
+  = BigEndianBytes.concat_bytes
+      (List.map
+         (fun j => List.nth (i*n + j) bs Byte.x00)
+         (seq 0 n)).
+Proof.
+  cbv [BigEndianBytes.bytes_to_Ns]. intros.
+  destruct (Compare_dec.lt_dec i (length bs / n)).
+  { erewrite map_nth_inbounds with (d2:=0%nat) by length_hammer.
+    cbv [BigEndianBytes.concat_bytes]. f_equal; [ ].
+    push_nth. natsimpl.
+    erewrite firstn_map_nth with (d:=Byte.x00).
+    { eapply List.map_ext_in; intros *.
+      rewrite in_seq; natsimpl; intros.
+      push_nth. f_equal; lia. }
+    { push_length.
+      Zify.zify.
+      (* extra step because zify fails to zify Nat.modulo and Nat.div *)
+      rewrite ?mod_Zmod, ?div_Zdiv in * by lia.
+      Zify.zify; Z.to_euclidean_division_equations.
+      (* N.B. this needs nia instead of lia *)
+      nia. } }
+  { push_nth. cbv [BigEndianBytes.concat_bytes].
+    assert (length bs <= i * n).
+    { Zify.zify.
+      (* extra step because zify fails to zify Nat.modulo and Nat.div *)
+      rewrite ?mod_Zmod, ?div_Zdiv in * by lia.
+      Zify.zify; Z.to_euclidean_division_equations.
+      (* N.B. this needs nia instead of lia *)
+      nia. }
+    apply fold_left_invariant with (I:= eq 0%N); [ reflexivity | | tauto ].
+    intros *; rewrite in_map_iff.
+    intros; logical_simplify; subst.
+    match goal with H : _ |- _ => apply in_seq in H end.
+    push_nth. reflexivity. }
+Qed.
+
+Lemma N_to_byte_equiv x y :
+  (x mod 256 = y mod 256)%N -> N_to_byte x = N_to_byte y.
+Proof.
+  intro Heq. cbv [N_to_byte]. compute_expr (2 ^ 8)%N.
+  rewrite Heq. reflexivity.
+Qed.
+
+Lemma nth_N_to_bytes i n x :
+  i < n ->
+  List.nth i (BigEndianBytes.N_to_bytes n x) Byte.x00
+  = N_to_byte (N.shiftr (N.land x (N.ones (8 * N.of_nat n)))
+                        (N.of_nat (n - 1 - i) * 8)).
+Proof.
+  intros. cbv [BigEndianBytes.N_to_bytes].
+  push_nth; natsimpl. apply N_to_byte_equiv.
+  change 256%N with (2 ^ 8)%N.
+  apply N.bits_inj; intro j.
+  push_Ntestbit; boolsimpl.
+  case_eq (j <? 8)%N; intros; N.bool_to_prop; [ | reflexivity ].
+  push_Ntestbit. boolsimpl.
+  f_equal; lia.
 Qed.


### PR DESCRIPTION
I needed some of the same helper lemmas to adjust some of the other proofs and start with the outer `sha256` circuit, so it made sense to just prove them and move them to the appropriate files. Padder proofs are now closed under the global context :tada: 