### PR TITLE
Adjust sha256_inner proofs

### DIFF
--- a/silveroak-opentitan/hmac/Spec/SHA256.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256.v
@@ -187,7 +187,7 @@ Section WithMessage.
               (seq 0 64) [].
 
   (* See steps in section 6.2.2. *)
-  Definition sha256_compress (i : nat) (H : list N) (t : nat) : list N :=
+  Definition sha256_compress (W : list N) (H : list N) (t : nat) : list N :=
     (* initialize working variables *)
     let a := nth 0 H 0 in
     let b := nth 1 H 0 in
@@ -200,7 +200,7 @@ Section WithMessage.
 
     (* step 3 in section 6.2.2 *)
     let Kt := nth t K 0 in
-    let Wt := nth t (W i) 0 in
+    let Wt := nth t W 0 in
     let T1 := h + (Sigma1 e) + (Ch e f g) + Kt + Wt in
     let T2 := (Sigma0 a) + (Maj a b c) in
     let h := g in
@@ -217,7 +217,7 @@ Section WithMessage.
   Definition sha256_step
              (H : list N) (i : nat) : list N :=
     (* steps 2-3 : compression loop *)
-    let H' := fold_left (sha256_compress i) (seq 0 64) H in
+    let H' := fold_left (sha256_compress (W i)) (seq 0 64) H in
     (* step 4 : get ith intermediate hash value by adding each element *)
     map2 add_mod H H'.
 

--- a/silveroak-opentitan/hmac/Spec/SHA256Properties.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256Properties.v
@@ -45,63 +45,18 @@ Proof. t. Qed.
 Lemma k_smallest msg n : (l msg + 1 + n) mod 512 = 448 -> n >= k msg.
 Proof. t. Qed.
 
-(* Formula for the nth element of W (n > 15) *)
-Lemma nth_W msg (i t : nat) :
-  (t < 64)%nat ->
-  nth t (SHA256.W msg i) 0 =
-  if (t <? 16)%nat
-  then SHA256.M msg t i
-  else
-    let W_tm2 := nth (t - 2) (SHA256.W msg i) 0 in
-    let W_tm7 := nth (t - 7) (SHA256.W msg i) 0 in
-    let W_tm15 := nth (t - 15) (SHA256.W msg i) 0 in
-    let W_tm16 := nth (t - 16) (SHA256.W msg i) 0 in
-    SHA256.add_mod
-      (SHA256.add_mod
-         (SHA256.add_mod
-            (SHA256.sigma1 W_tm2) W_tm7) (SHA256.sigma0 W_tm15))
-      W_tm16.
-Proof.
-  intros.
-  (* extract the formula for an element of W and remember it *)
-  lazymatch goal with
-    | |- nth t ?W ?d = ?rhs =>
-      let f := lazymatch (eval pattern t in rhs) with
-               | ?f _ => f end in
-      let f := lazymatch (eval pattern W in f) with
-               | ?f _ => f end in
-      set (W_formula:=f);
-        change (nth t W d = W_formula W t)
-  end.
-  (* use an invariant *)
-  apply fold_left_invariant_seq
-    with (I:= fun n W =>
-                length W = n /\
-                forall t, (t < n)%nat -> nth t W 0 = W_formula W t)
-         (P:=fun W => nth t W 0 = W_formula W t);
-    [ intros; ssplit; length_hammer
-    | | intros; ssplit; logical_simplify; solve [auto] ].
-  intros. autorewrite with natsimpl push_nth in *.
-  logical_simplify. ssplit; [ length_hammer | ]. intros.
-  lazymatch goal with H : (?t < S ?n)%nat |- context [nth ?t] =>
-                      destr (t <? n)%nat; [ | replace t with n in * by lia ]
-  end; subst W_formula; cbn beta zeta; push_nth; natsimpl;
-    [ solve [auto] | ].
-  destruct_one_match; push_nth; reflexivity.
-Qed.
-
 Lemma H0_length : length H0 = 8%nat.
 Proof. reflexivity. Qed.
 Hint Rewrite @H0_length using solve [eauto] : push_length.
 
-Lemma sha256_compress_length msg i H t :
-  length (sha256_compress msg i H t) = 8%nat.
+Lemma sha256_compress_length W H t :
+  length (sha256_compress W H t) = 8%nat.
 Proof. reflexivity. Qed.
 Hint Rewrite @sha256_compress_length : push_length.
 
-Lemma fold_left_sha256_compress_length msg i H ts :
+Lemma fold_left_sha256_compress_length W H ts :
   length H = 8%nat ->
-  length (fold_left (sha256_compress msg i) ts H) = 8%nat.
+  length (fold_left (sha256_compress W) ts H) = 8%nat.
 Proof.
   intros. apply fold_left_invariant with (I:=fun H => length H = 8%nat); auto.
 Qed.
@@ -226,4 +181,190 @@ Lemma nth_padding_nonzero msg i :
 Proof.
   destruct i; [ lia | ]. intros.
   apply nth_padding_succ.
+Qed.
+
+(* Alternate definitions that work with padded_msg as an argument instead of msg *)
+Module SHA256Alt.
+  Section WithPaddedMessage.
+    Context (padded_msg : list N).
+
+    Definition M (j i : nat) : N := nth (i*16 + j) padded_msg 0.
+
+    Definition W (i : nat) : list N :=
+      fold_left (fun (W : list N) t =>
+                   let wt :=
+                       if (t <? 16)%nat
+                       then M t i
+                       else
+                         let W_tm2 := nth (t-2) W 0 in
+                         let W_tm7 := nth (t-7) W 0 in
+                         let W_tm15 := nth (t-15) W 0 in
+                         let W_tm16 := nth (t-16) W 0 in
+                         add_mod
+                           (add_mod
+                              (add_mod (sigma1 W_tm2) W_tm7)
+                              (sigma0 W_tm15))
+                           W_tm16 in
+                   W ++ [wt])
+                (seq 0 64) [].
+
+    (* See steps in section 6.2.2. *)
+    Definition sha256_step
+               (H : list N) (i : nat) : list N :=
+      (* steps 2-3 : compression loop *)
+      let H' := fold_left (sha256_compress (W i)) (seq 0 64) H in
+      (* step 4 : get ith intermediate hash value by adding each element *)
+      map2 add_mod H H'.
+
+    (* Full SHA-256 computation: loop of sha256_step *)
+    Definition sha256 :=
+      let nblocks := (length padded_msg / (512 / N.to_nat w))%nat in
+      let H := fold_left sha256_step (seq 0 nblocks) H0 in
+      concat_digest H.
+  End WithPaddedMessage.
+End SHA256Alt.
+
+Lemma M_alt_equiv msg : SHA256Alt.M (padded_msg msg) = M msg.
+Proof. reflexivity. Qed.
+
+Lemma W_alt_equiv msg i : SHA256Alt.W (padded_msg msg) i = W msg i.
+Proof. cbv [W SHA256Alt.W]. rewrite M_alt_equiv. reflexivity. Qed.
+
+Lemma sha256_step_alt_equiv msg H i :
+  SHA256Alt.sha256_step (padded_msg msg) H i = sha256_step msg H i.
+Proof.
+  cbv [SHA256Alt.sha256_step sha256_step].
+  rewrite W_alt_equiv. reflexivity.
+Qed.
+
+Lemma sha256_alt_equiv msg :
+  SHA256Alt.sha256 (padded_msg msg) = sha256 msg.
+Proof.
+  cbv [SHA256Alt.sha256 sha256].
+  apply f_equal. apply fold_left_ext; intros.
+  rewrite sha256_step_alt_equiv. reflexivity.
+Qed.
+
+Lemma sha256_step_alt_length msg H i :
+  length H = 8%nat -> length (SHA256Alt.sha256_step msg H i) = 8%nat.
+Proof.
+  intro Hlen; cbv [SHA256Alt.sha256_step]. push_length.
+  repeat (push_length || rewrite Hlen || rewrite fold_left_sha256_compress_length); lia.
+Qed.
+#[export] Hint Resolve sha256_step_alt_length : length.
+
+Lemma fold_left_sha256_step_alt_length msg H idxs :
+  length H = 8%nat -> length (fold_left (SHA256Alt.sha256_step msg) idxs H) = 8%nat.
+Proof.
+  intros. apply fold_left_invariant with (I:=fun H => length H = 8%nat); auto.
+  intros; length_hammer.
+Qed.
+#[export] Hint Resolve fold_left_sha256_step_alt_length : length.
+
+(* Formula for the nth element of W (n > 15) *)
+Lemma nth_W_alt msg (i t : nat) :
+  (t < 64)%nat ->
+  nth t (SHA256Alt.W msg i) 0 =
+  if (t <? 16)%nat
+  then SHA256Alt.M msg t i
+  else
+    let W_tm2 := nth (t - 2) (SHA256Alt.W msg i) 0 in
+    let W_tm7 := nth (t - 7) (SHA256Alt.W msg i) 0 in
+    let W_tm15 := nth (t - 15) (SHA256Alt.W msg i) 0 in
+    let W_tm16 := nth (t - 16) (SHA256Alt.W msg i) 0 in
+    SHA256.add_mod
+      (SHA256.add_mod
+         (SHA256.add_mod
+            (SHA256.sigma1 W_tm2) W_tm7) (SHA256.sigma0 W_tm15))
+      W_tm16.
+Proof.
+  intros.
+  (* extract the formula for an element of W and remember it *)
+  lazymatch goal with
+    | |- nth t ?W ?d = ?rhs =>
+      let f := lazymatch (eval pattern t in rhs) with
+               | ?f _ => f end in
+      let f := lazymatch (eval pattern W in f) with
+               | ?f _ => f end in
+      set (W_formula:=f);
+        change (nth t W d = W_formula W t)
+  end.
+  (* use an invariant *)
+  apply fold_left_invariant_seq
+    with (I:= fun n W =>
+                length W = n /\
+                forall t, (t < n)%nat -> nth t W 0 = W_formula W t)
+         (P:=fun W => nth t W 0 = W_formula W t);
+    [ intros; ssplit; length_hammer
+    | | intros; ssplit; logical_simplify; solve [auto] ].
+  intros. autorewrite with natsimpl push_nth in *.
+  logical_simplify. ssplit; [ length_hammer | ]. intros.
+  lazymatch goal with H : (?t < S ?n)%nat |- context [nth ?t] =>
+                      destr (t <? n)%nat; [ | replace t with n in * by lia ]
+  end; subst W_formula; cbn beta zeta; push_nth; natsimpl;
+    [ solve [auto] | ].
+  destruct_one_match; push_nth; reflexivity.
+Qed.
+
+Lemma nth_W msg (i t : nat) :
+  (t < 64)%nat ->
+  nth t (SHA256.W msg i) 0 =
+  if (t <? 16)%nat
+  then SHA256.M msg t i
+  else
+    let W_tm2 := nth (t - 2) (SHA256.W msg i) 0 in
+    let W_tm7 := nth (t - 7) (SHA256.W msg i) 0 in
+    let W_tm15 := nth (t - 15) (SHA256.W msg i) 0 in
+    let W_tm16 := nth (t - 16) (SHA256.W msg i) 0 in
+    SHA256.add_mod
+      (SHA256.add_mod
+         (SHA256.add_mod
+            (SHA256.sigma1 W_tm2) W_tm7) (SHA256.sigma0 W_tm15))
+      W_tm16.
+Proof.
+  intros. rewrite <-W_alt_equiv, <-M_alt_equiv.
+  auto using nth_W_alt.
+Qed.
+
+(* M returns the same result regardless of blocks above the current block
+   index *)
+Lemma sha256_M_alt_truncate msg1 msg2 j i :
+  (S i * 16 <= length msg1)%nat -> (j < 16)%nat ->
+  SHA256Alt.M (msg1 ++ msg2) j i = SHA256Alt.M msg1 j i.
+Proof. cbv [SHA256Alt.M]. intros. apply app_nth1. lia. Qed.
+
+(* W returns the same result regardless of blocks above the current block
+   index *)
+Lemma sha256_W_alt_truncate msg1 msg2 i :
+  (S i * 16 <= length msg1)%nat -> SHA256Alt.W (msg1 ++ msg2) i = SHA256Alt.W msg1 i.
+Proof.
+  cbv [SHA256Alt.W]. intros.
+  eapply fold_left_ext_In. intros *; rewrite in_seq; natsimpl; intros.
+  destruct_one_match; [ | reflexivity ].
+  rewrite sha256_M_alt_truncate by lia.
+  reflexivity.
+Qed.
+
+(* sha256_step returns the same result regardless of blocks above the current index *)
+Lemma sha256_step_alt_truncate msg1 msg2 i H :
+  (S i * 16 <= length msg1)%nat ->
+  SHA256Alt.sha256_step (msg1 ++ msg2) H i = SHA256Alt.sha256_step msg1 H i.
+Proof.
+  cbv [SHA256Alt.sha256_step]. intros. apply f_equal2; [ reflexivity | ].
+  apply fold_left_ext_In; intros *. rewrite in_seq; natsimpl; intros.
+  rewrite sha256_W_alt_truncate by lia. reflexivity.
+Qed.
+
+Lemma slice0_W_alt msg block i :
+  (i * 16 = length msg)%nat -> length block = 16%nat ->
+  List.slice 0%N (SHA256Alt.W (msg ++ block) i) 0 16 = block.
+Proof.
+  intros.
+  etransitivity;
+    [ | apply resize_noop with (d:=0%N) (n:=16%nat); lia ].
+  rewrite resize_map_nth. rewrite slice_map_nth.
+  apply map_ext_in; intros *; rewrite in_seq; intros.
+  rewrite nth_W_alt by lia. destruct_one_match; try lia; [ ].
+  cbv [SHA256Alt.M]. rewrite app_nth2 by length_hammer.
+  f_equal; lia.
 Qed.


### PR DESCRIPTION
In preparation for proving `sha256`, I realized it would be helpful to change the phrasing of `sha256_inner`'s specification. In particular:
1. The abstract state should reference the message _seen so far_, not the whole message, because `sha256` won't know the whole message if it's only gotten part of the data
2. The postcondition should be in terms of `sha256_step`, not `sha256_compress`, just to make the logic a little smoother

Change (2) was pretty straightforward, but change (1) was more complicated. Basically, the `sha256_inner` circuit really should only reason about the _padded_ message, which is its input, not whatever original message the padded message came from. But this was problematic because the specs require the original message; I couldn't describe what `sha256_step` should return without passing it the original bytes of the message, which were complicated to derive from the circuit input.

To resolve this problem, I created some shadow definitions for some of the spec functions (`M`, `W`, `sha256_step`, and `sha256`) that take the padded message as their argument instead of the original message, and proved they're equivalent to the originals. Then I could prove that `sha256_inner` matches this alternate representation with respect to the padded-message input it gets, without actually requiring that it's a valid padded message. In `sha256`, when I have the context to know that what I'm passing `sha256_inner` is indeed a valid padded message, I can use the equivalence lemma to rewrite back to the original spec.