### PR TITLE
Add realign_fifo spec and proof

### DIFF
--- a/cava2/Components/Fifo.v
+++ b/cava2/Components/Fifo.v
@@ -1,0 +1,67 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Strings.String.
+Require Import Coq.Strings.HexString.
+Require Import Coq.Lists.List.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Arith.PeanoNat.
+Require Import Cava.Util.List.
+
+Require Import Cava.Types.
+Require Import Cava.Expr.
+Require Import Cava.Primitives.
+
+Import ListNotations.
+Import PrimitiveNotations.
+
+Local Open Scope string_scope.
+Local Open Scope N.
+
+Section Var.
+  Import ExprNotations.
+
+  Context {var : tvar}.
+
+  Definition fifo {T} fifo_size: Circuit _ [Bit; T; Bit]
+    (* out_valid, out, full *)
+    (Bit ** T ** Bit ** Bit) :=
+    let fifo_bits := BitVec (Nat.log2_up (fifo_size + 1)) in
+    {{
+    fun data_valid data accepted_output =>
+
+    let/delay '(valid, output, fifo; count) :=
+      let decrement := accepted_output && count >= `K 1` in
+
+      ( count >= `K 1`
+      , `index` fifo (count - `K 1`)
+
+      , if data_valid then data +>> fifo else fifo
+      , if data_valid && !decrement then count + `K 1`
+        else if !data_valid && decrement then (count - `K 1`)
+        else count
+      )
+
+      initially (false,(default,(@default (Vec T fifo_size), 0)))
+      : denote_type (Bit ** T ** Vec T fifo_size ** fifo_bits) in
+
+    ( valid, if valid then output else `Constant T default`
+    (* Will be empty if accepted_output is asserted next cycle *)
+    , (count == `Constant fifo_bits 0` )
+    (* We are full, does not assume output this cycle has been accepted yet *)
+    , (count == `Constant fifo_bits (N.of_nat fifo_size)` ) )
+  }}.
+End Var.

--- a/cava2/Components/FifoProperties.v
+++ b/cava2/Components/FifoProperties.v
@@ -1,0 +1,402 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.micromega.Lia.
+Require Import Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Lists.List.
+
+Require Import coqutil.Tactics.Tactics.
+
+Require Import Cava.Util.List.
+Require Import Cava.Util.Nat.
+Require Import Cava.Util.Byte.
+Require Import Cava.Util.Tactics.
+Require Import Cava.Util.If.
+
+Require Import Cava.Types.
+Require Import Cava.Expr.
+Require Import Cava.ExprProperties.
+Require Import Cava.Primitives.
+Require Import Cava.Semantics.
+Require Import Cava.Components.Fifo.
+
+Import ListNotations.
+
+Local Open Scope bool.
+Local Open Scope nat.
+Local Open Scope list.
+
+Lemma nz_s_1_a_1: forall x:nat, (x <> 0 -> x - 1 + 1 = x)%nat.
+Proof. lia. Qed.
+
+Lemma lt_nat_log2_simpl: forall x y,
+  (y < 2 ^ (Nat.log2_up x ))%nat ->
+  (N.of_nat y < 2 ^ N.of_nat (Nat.log2_up x))%N.
+Proof.
+  intros.
+  change 2%N with (N.of_nat (S (S 0))).
+  rewrite Nat2N.inj_pow.
+  lia.
+Qed.
+
+Lemma inj_le: forall x, (1 <=? x)%N = negb (N.to_nat x =? 0)%nat.
+Proof.
+  intros.
+  rewrite <- (N2Nat.id x).
+  rewrite (Nat2N.id (N.to_nat x)).
+  destruct (N.to_nat x); cbn.
+  { reflexivity. }
+  rewrite N.leb_le.
+  lia.
+Qed.
+
+Lemma eqb_inj: forall x y, ( N.of_nat x =? N.of_nat y )%N = ( x =? y ).
+Proof. intros.
+  destruct (Nat.eqb_spec x y ).
+  { rewrite e. rewrite N.eqb_refl. reflexivity. }
+  { rewrite N.eqb_neq. lia. }
+Qed.
+
+Section FifoSpec.
+  Context (T: type).
+  Context (fifo_size: nat).
+  Context (Hfifo_nz: (1 < fifo_size)%nat).
+
+  Definition fifo_bits_size := Nat.log2_up (fifo_size + 1).
+
+  Definition fifo_pre
+    (contents: list (denote_type T))
+    (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+    (state: denote_type (state_of (fifo (T:=T) fifo_size)))
+    :=
+    let '(valid, (data, (accepted_output,_))) := input in
+    let '(_, (_, (fifo, count))) := state in
+    (* if count is fifo_size we are full and we shouldn't be receiving  *)
+    (if valid then N.to_nat count < fifo_size else True).
+
+  Definition fifo_invariant
+    (contents: list (denote_type T))
+    (state: denote_type (state_of (fifo (T:=T) fifo_size)))
+    :=
+    let '(_, (_, (fifo, count))) := state in
+    fifo_size = length fifo
+    /\ N.to_nat count <= fifo_size
+    /\ N.to_nat count = length contents
+    /\ contents = rev (firstn (length contents) fifo)
+  .
+
+  Definition fifo_contents_update (empty full: bool) contents
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+      :=
+    let '(valid, (data, (accepted_output,_))) := input in
+    let contents' := if accepted_output && negb empty then tl contents else contents in
+    contents' ++ if valid && negb full then [data] else [].
+
+  Ltac N2nat_lt_2lg_solve x :=
+    apply lt_nat_log2_simpl;
+    apply (Nat.lt_le_trans _ (length x + 1)); [lia|];
+    apply Nat.log2_up_spec; lia.
+
+  (* Reduces the mod equations that arise here that aren't solved by e.g.
+     Z.to_euclidean_division_equations, likely due to the non-constants modulus *)
+  Local Ltac reduce_mod_eqs fifo contents :=
+      match goal with
+      | |- context [ N.modulo ?X ?Y ] =>
+        let H := fresh in
+        assert (X mod Y = X)%N as H;
+        [ apply N.mod_small;
+          N2nat_lt_2lg_solve fifo
+        |]; rewrite H; clear H
+      | |- context [ N.modulo ( ?X + ?Y - 1 ) ?Y ] =>
+        let H := fresh in
+        assert (( X + Y - 1 ) mod Y = X - 1)%N as H;
+        let H1 := fresh in
+        assert (forall x, 0 < x -> x <> 0)%N as H1 by lia;
+        let H2 := fresh in
+        assert (2 ^ N.of_nat (Nat.log2_up (Datatypes.length fifo + 1)) <> 0)%N as H2 by
+          (
+            apply H1;
+            change 0%N with (N.of_nat 0)%nat;
+            N2nat_lt_2lg_solve fifo
+          );
+
+        rewrite N.add_sub_swap by lia;
+        rewrite <- N.add_mod_idemp_r by apply H2;
+
+        rewrite N.mod_same by apply H2;
+        rewrite N.add_0_r;
+
+        rewrite N.mod_small;
+
+        replace (N.of_nat (length contents) - 1)%N with (N.of_nat (length contents - 1))%N
+          by apply Nat2N.inj_sub;
+
+        [| N2nat_lt_2lg_solve fifo]
+
+      | |- context [ N.modulo ( ?X + 1 ) ?Y ] =>
+        let H := fresh in
+        assert ( (X + 1)  mod Y = (X + 1) )%N as H;
+        [ replace (N.of_nat( length contents ) + 1)%N with (N.of_nat (length contents  + 1)) by lia;
+          apply N.mod_small;
+          N2nat_lt_2lg_solve fifo
+        |] ; rewrite H; clear H
+      end.
+
+  Lemma step_fifo_invariant
+      contents new_contents
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+      (state : denote_type (state_of (fifo (T:=T) fifo_size))) :
+    new_contents = fifo_contents_update (length contents =? 0) (length contents =? fifo_size) contents input ->
+    fifo_pre contents input state ->
+    fifo_invariant contents state ->
+    fifo_invariant new_contents (fst (step (fifo fifo_size) state input)).
+  Proof.
+    destruct input as (input_valid, (input_data, (accepted_output, []))).
+    destruct state as (s_valid, (s_data, (fifo, count))).
+    intros Hcontents Hpre Hinv.
+    destruct Hinv as [Hfifo_len [Hcount_bound [Hcontents_len Hcontents_rev_fifo ]]].
+    cbv [fifo_pre fifo_invariant fifo_contents_update] in *.
+    cbn in fifo.
+
+    split.
+    { destruct input_valid; stepsimpl; try rewrite length_removelast_cons; apply Hfifo_len. }
+
+    (* *)
+    assert (fifo <> []) as Hfifon_empty by
+      (apply length_pos_nonnil; setoid_rewrite <- Hfifo_len; lia).
+
+    stepsimpl.
+
+    fold denote_type in *. (* denote_type is previously unfolded in some implicits *)
+
+    rewrite inj_le.
+    rewrite Hcontents_len.
+    rewrite <- Nat2N.id in Hcontents_len.
+    apply N2Nat.inj in Hcontents_len.
+    subst.
+
+    destruct (Nat.eqb_spec (@Datatypes.length (denote_type T) contents) 0)
+      as [Hcontents_len_z | Hcontents_len_nz];
+      destruct input_valid, accepted_output;
+      stepsimpl;
+      boolsimpl.
+
+    (* Clean up terms *)
+    all:
+      try rewrite app_nil_r;
+      try rewrite Hcontents_len_z;
+      try change (N.of_nat 0 + 1)%N with (N.of_nat 1)%N;
+      try replace (N.of_nat (length contents) + 1)%N with (N.of_nat (length contents + 1))%N by
+        apply Nat2N.inj_add;
+      try rewrite Nat2N.id.
+
+    (* Simplify mod equations *)
+    all: try reduce_mod_eqs fifo contents.
+
+    all:
+      try apply length_zero_iff_nil in Hcontents_len_z;
+      try rewrite Nat2N.id in *;
+      repeat ssplit.
+    all: try (tauto || lia).
+
+    all: subst; try rewrite app_nil_l.
+
+    all: try (destruct fifo; tauto).
+
+    5: {
+      rewrite tl_length.
+      lia.
+    }
+    5: {
+      rewrite Hcontents_rev_fifo at 1.
+      rewrite tl_rev.
+      replace (length contents) with (S (length contents - 1)) by lia.
+      rewrite removelast_firstn by lia.
+      rewrite tl_length.
+      reflexivity.
+    }
+
+    all:
+      assert (Datatypes.length (contents) <> Datatypes.length fifo) by lia;
+      destruct (Nat.eqb_spec (Datatypes.length (contents)) (Datatypes.length fifo)); try tauto;
+      try rewrite app_length;
+      try rewrite tl_length;
+      try now (cbn; lia).
+
+    all:
+      rewrite Hcontents_rev_fifo at 1;
+      try rewrite tl_rev;
+      try (
+        replace (length contents) with (S (length contents - 1)) by lia;
+        rewrite removelast_firstn by lia);
+      boolsimpl.
+
+    {
+      rewrite removelast_cons1 by tauto.
+      cbn [length].
+      rewrite nz_s_1_a_1 by lia.
+      rewrite firstn_cons.
+      cbn.
+      rewrite firstn_removelast by lia.
+      reflexivity.
+    }
+
+    {
+      rewrite removelast_cons1 by tauto.
+      cbn [length].
+      rewrite Nat.add_1_r.
+      rewrite firstn_cons.
+      cbn.
+      rewrite firstn_removelast by lia.
+      reflexivity.
+    }
+  Qed.
+
+  Definition fifo_spec
+      (contents: list (denote_type T))
+      (new_contents: list (denote_type T))
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+      : denote_type (Bit ** T ** Bit ** Bit) :=
+    (negb (0 =? length contents)
+    , (if 0 =? length contents then default else hd default contents
+    , (length new_contents =? 0
+    , length new_contents =? fifo_size)))%nat.
+
+  Lemma step_fifo
+      contents new_contents
+      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
+      (state : denote_type (state_of (fifo (T:=T) fifo_size))) :
+    new_contents = fifo_contents_update (length contents =? 0) (length contents =? fifo_size) contents input ->
+    fifo_pre contents input state ->
+    fifo_invariant contents state ->
+    snd (step (fifo fifo_size) state input) = fifo_spec contents new_contents input.
+  Proof.
+    destruct input as (input_valid, (input_data, (accepted_output, []))).
+    destruct state as (s_valid, (s_data, (fifo, count))).
+    intros Hcontents Hpre Hinv.
+    destruct Hinv as [Hfifo_len [Hcount_bound [Hcontents_len Hcontents_rev_fifo]]].
+    cbv [Fifo.fifo fifo_spec fifo_pre fifo_invariant fifo_contents_update K] in *.
+    cbn in fifo.
+
+    (* *)
+    assert (fifo <> []) as Hfifon_empty by
+      (apply length_pos_nonnil; setoid_rewrite <- Hfifo_len; lia).
+
+    stepsimpl.
+    repeat (destruct_pair_let; cbn [fst snd]).
+
+    fold denote_type in *. (* denote_type is previously unfolded in some implicits *)
+
+    logical_simplify.
+
+    fold denote_type in *.
+
+    rewrite inj_le.
+    rewrite Hcontents_len.
+    rewrite <- Nat2N.id in Hcontents_len.
+    apply N2Nat.inj in Hcontents_len.
+    rewrite (Nat.eqb_sym 0 (length contents)).
+    subst.
+
+    f_equal.
+    f_equal.
+
+    {
+      destruct (Nat.eqb_spec (@Datatypes.length (denote_type T) contents) 0)
+        as [Hcontents_len_z | Hcontents_len_nz];
+        stepsimpl;
+        boolsimpl.
+        { reflexivity. }
+        { try reduce_mod_eqs fifo contents.
+          { reflexivity. }
+          rewrite Nat2N.id.
+          rewrite resize_noop by reflexivity.
+          rewrite Hcontents_rev_fifo.
+          rewrite rev_length.
+          rewrite firstn_length.
+          rewrite hd_rev.
+          replace (Init.Nat.min (length contents) (length fifo))
+            with (length contents) by (rewrite Nat.min_l; lia).
+          rewrite <- (firstn_skipn (length contents) fifo) at 1.
+          rewrite app_nth1 .
+          2:{ cbn.
+            rewrite firstn_length.
+            replace (Init.Nat.min (length contents) (length fifo))
+            with (length contents).
+            2:{ rewrite Nat.min_l. {lia. }
+              rewrite Nat2N.id in Hcount_bound.
+              lia.
+            }
+            lia.
+          }
+        rewrite nth_last.
+        { reflexivity. }
+        rewrite firstn_length.
+        replace (Init.Nat.min (length contents) (length fifo))
+          with (length contents) by (rewrite Nat.min_l; lia).
+        reflexivity.
+        }
+    }
+
+    destruct (Nat.eqb_spec (@Datatypes.length (denote_type T) contents) 0)
+      as [Hcontents_len_z | Hcontents_len_nz];
+    destruct input_valid, accepted_output;
+      stepsimpl;
+      boolsimpl;
+      fold denote_type in *;
+      try reduce_mod_eqs fifo contents;
+      try rewrite app_nil_r;
+      try reflexivity;
+      try rewrite app_length; cbn.
+
+    all: destr (length contents =? length fifo); try lia; cbn.
+    all: repeat match goal with
+         | |- context [ ?X ] =>
+            lazymatch X with
+            | ( N.of_nat ?Y =? N.of_nat ?Z )%N => fail
+            | ( N.of_nat ?Y + ?Z =? _ )%N =>
+              replace ( N.of_nat Y + Z )%N
+              with ( N.of_nat (Y + (N.to_nat Z) ) )%N by now (rewrite Nat2N.inj_add; rewrite N2Nat.id)
+            | ( N.of_nat ?Y =? ?Z )%N =>
+              replace ( N.of_nat Y =? Z )%N
+                with ( N.of_nat Y =? N.of_nat (N.to_nat Z) )%N by now rewrite N2Nat.id
+            end
+         end.
+    all: repeat rewrite eqb_inj.
+    all: repeat match goal with
+         | |- context [ ?X ] =>
+            match X with
+            | _ =? _  => destr X; try lia
+            end
+         end.
+    all: try reflexivity.
+    all: repeat match goal with
+                | H: length (tl ?X) + 1 = _ |- _ =>
+                  rewrite tl_length in H; try rewrite nz_s_1_a_1 in H by lia
+                | H: length (tl ?X) + 1 <> _ |- _ =>
+                  rewrite tl_length in H; try rewrite nz_s_1_a_1 in H by lia
+                | H: length (tl ?X) = _ |- _ =>
+                  rewrite tl_length in H
+                | H: length (tl ?X) <> _ |- _ =>
+                  rewrite tl_length in H
+                end.
+    all: lia.
+  Qed.
+
+End FifoSpec.
+

--- a/cava2/Components/RealignFifo.v
+++ b/cava2/Components/RealignFifo.v
@@ -1,0 +1,68 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Strings.String.
+Require Import Coq.Strings.HexString.
+Require Import Coq.Lists.List.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Arith.PeanoNat.
+Require Import Cava.Util.List.
+
+Require Import Cava.Types.
+Require Import Cava.Expr.
+Require Import Cava.Primitives.
+Require Import Cava.Components.Fifo.
+Require Import Cava.Components.Realigner.
+
+Import ListNotations.
+Import PrimitiveNotations.
+
+Local Open Scope string_scope.
+Local Open Scope N.
+
+Section Var.
+  Import ExprNotations.
+
+  Context {var : tvar}.
+
+  Definition realign_fifo fifo_size: Circuit _ [Bit; BitVec 32; BitVec 4; Bit; Bit]
+    (* *)
+    (Bit ** BitVec 32 ** BitVec 4 ** Bit ** Bit ) := {{
+    fun data_valid data data_mask drain consumer_ready =>
+
+    let/delay '(is_last, out_valid, out_data, out_length, fifo_empty; fifo_full) :=
+      let '(realigned_valid, realigned_data; realigned_length) :=
+        `realign` data_valid data data_mask (drain && fifo_empty && consumer_ready) (!fifo_full) in
+
+      let '(fifo_valid, fifo_data, fifo_empty; fifo_full) :=
+        `fifo fifo_size` (realigned_valid && (! drain) && (!fifo_full) ) realigned_data consumer_ready in
+
+      let valid :=
+        if drain then fifo_valid || realigned_valid else fifo_valid in
+      let data :=
+        if drain && !fifo_valid then realigned_data
+        else fifo_data in
+      let length :=
+        if drain && !fifo_valid then realigned_length
+        else `K 4` in
+
+      (drain && !fifo_valid && valid, valid, data, length, fifo_empty, fifo_full)
+      initially default
+    in
+    (out_valid, out_data, out_length, is_last, fifo_full)
+  }}.
+
+End Var.

--- a/cava2/Components/RealignFifoProperties.v
+++ b/cava2/Components/RealignFifoProperties.v
@@ -1,0 +1,419 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.micromega.Lia.
+Require Import Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Lists.List.
+
+Require Import coqutil.Tactics.Tactics.
+
+Require Import Cava.Util.List.
+Require Import Cava.Util.Nat.
+Require Import Cava.Util.Byte.
+Require Import Cava.Util.Tactics.
+Require Import Cava.Util.If.
+
+Require Import Cava.Types.
+Require Import Cava.Expr.
+Require Import Cava.ExprProperties.
+Require Import Cava.Primitives.
+Require Import Cava.Semantics.
+Require Import Cava.Components.Fifo.
+Require Import Cava.Components.Realigner.
+Require Import Cava.Components.RealignFifo.
+Require Import Cava.Components.FifoProperties.
+Require Import Cava.Components.RealignerProperties.
+
+Import ListNotations.
+
+Local Open Scope bool.
+Local Open Scope nat.
+Local Open Scope list.
+
+Section RealignFifo.
+  Context (fifo_size: nat).
+  Context (Hfifo_nz: (1 < fifo_size)%nat).
+
+  (* Specification for the 'realign_fifo' component defined in terms of
+   * 'fifo_spec' and 'realign_spec'. *)
+  Definition realign_fifo_spec
+    fifo_contents
+    realign_state
+    (input : denote_type (input_of (var:=denote_type) (realign_fifo fifo_size))) :=
+    let '(data_valid, (data, (data_mask, (drain, (consumer_ready, tt))))) := input in
+
+    let fifo_empty := (length fifo_contents =? 0) in
+    let fifo_full := (length fifo_contents =? fifo_size) in
+
+    let realign_input := (data_valid, (data, (data_mask, ((drain && fifo_empty && consumer_ready), (negb fifo_full, tt))))) in
+
+    let '(realigned_valid, (realigned_data, realigned_length)) :=
+      realign_spec
+        (fst (fst realign_state)) (snd (fst realign_state)) (snd realign_state)
+        realign_input
+    in
+
+    let fifo_input := ( (realigned_valid && (negb drain) && (negb fifo_full)), (realigned_data, (consumer_ready, tt))) in
+
+    let new_contents :=
+      fifo_contents_update (BitVec 32) fifo_size
+        fifo_empty fifo_full fifo_contents fifo_input
+    in
+
+    let '(fifo_valid, (fifo_data, (fifo_empty, fifo_full))) :=
+      fifo_spec (BitVec 32) fifo_size
+        fifo_contents new_contents fifo_input in
+
+    let valid :=
+      if drain then fifo_valid || realigned_valid else fifo_valid in
+    let data :=
+      if drain && negb fifo_valid then realigned_data
+      else fifo_data in
+    let length :=
+      if drain && negb fifo_valid then realigned_length
+      else 4%N in
+
+    (valid, (data, (length, (drain && negb fifo_valid && valid, fifo_full)))).
+
+  (* Invariant for the 'realign_fifo' component. *)
+  Definition realign_fifo_invariant
+    fifo_contents realign_contents
+    (state : denote_type (state_of (var:=denote_type) (realign_fifo fifo_size))) :=
+
+    let '(top_state, (realign_state, fifo_state)) := state in
+    let '(is_last, (out_valid, (out_data, (out_length, (fifo_empty, fifo_full))))) := top_state in
+
+    fifo_invariant (BitVec 32) fifo_size fifo_contents fifo_state
+    /\ realign_invariant (fst (fst realign_contents)) (snd (fst realign_contents)) (snd realign_contents) realign_state
+    (* the only additional invariant we preserve is that we respect fifo_full &
+     * fifo_empty *)
+    /\ (if fifo_full then fifo_size = length fifo_contents else length fifo_contents < fifo_size)
+    /\ (if fifo_empty then length fifo_contents = 0 else length fifo_contents <> 0).
+
+
+  (* Precondition for the 'realign_fifo' component. *)
+  Definition realign_fifo_pre
+    (input : denote_type (input_of (realign_fifo fifo_size)))
+    (state: denote_type (state_of (realign_fifo fifo_size)))
+    :=
+    let '(valid, (data, _)) := input in
+    let '(_, (realign_state, fifo_state)) := state in
+    let '(_, (_, (_, count))) := fifo_state in
+    (if valid then N.to_nat count < fifo_size else True)
+    /\ (data < 2 ^ 32)%N.
+
+  (* "fifo" state update, not intended to be readable,
+     discovered mechanically during the proof below. *)
+  Definition realign_fifo_update_fifo_contents
+    fifo_contents
+    (input : denote_type (input_of (realign_fifo fifo_size)))
+    (state : denote_type (state_of (realign_fifo fifo_size))):=
+    fifo_contents_update (BitVec 32) fifo_size (length fifo_contents =? 0)
+      (length fifo_contents =? fifo_size) fifo_contents
+      (fst
+         (snd
+            (step realign (fst (snd state))
+               (fst input,
+               (fst (snd input),
+               (fst (snd (snd input)),
+               (fst (snd (snd (snd input))) &&
+                fst (snd (snd (snd (snd (fst state))))) &&
+                fst (snd (snd (snd (snd input)))),
+               (negb (snd (snd (snd (snd (snd (fst state)))))), tt))))))) &&
+       negb (fst (snd (snd (snd input)))) &&
+       negb (snd (snd (snd (snd (snd (fst state)))))),
+      (fst
+         (snd
+            (snd
+               (step realign (fst (snd state))
+                  (fst input,
+                  (fst (snd input),
+                  (fst (snd (snd input)),
+                  (fst (snd (snd (snd input))) &&
+                   fst (snd (snd (snd (snd (fst state))))) &&
+                   fst (snd (snd (snd (snd input)))),
+                  (negb (snd (snd (snd (snd (snd (fst state)))))), tt)))))))),
+      (fst (snd (snd (snd (snd input)))), tt))).
+
+  (* "realign" state update, not intended to be readable,
+     discovered mechanically during the proof below. *)
+  Definition realign_fifo_update_realign_contents
+    realign_contents
+    (input : denote_type (input_of (realign_fifo fifo_size)))
+    (state : denote_type (state_of (realign_fifo fifo_size))) :=
+    let '(top_state, _) := state in
+    let '(is_last, (out_valid, (out_data, (out_length, (fifo_empty, fifo_full))))) := top_state in
+    ( (
+      realign_update_latched_valid (fst (fst realign_contents)) (snd realign_contents)
+        (fst input,
+        (fst (snd input),
+        (fst (snd (snd input)),
+        (fst (snd (snd (snd input))) && fifo_empty &&
+         fst (snd (snd (snd (snd input)))), (negb fifo_full, tt))))),
+      realign_update_latched_bytes (snd (fst realign_contents)) (snd realign_contents)
+        (fst input,
+        (fst (snd input),
+        (fst (snd (snd input)),
+        (fst (snd (snd (snd input))) && fifo_empty &&
+         fst (snd (snd (snd (snd input)))), (negb fifo_full, tt)))))
+      ),
+      realign_update_state (snd realign_contents)
+        (fst input,
+        (fst (snd input),
+        (fst (snd (snd input)),
+        (fst (snd (snd (snd input))) && fifo_empty &&
+         fst (snd (snd (snd (snd input)))), (negb fifo_full, tt)))))
+    ).
+
+
+  Lemma step_realign_fifo_invariant
+      fifo_contents
+      realign_contents
+      new_fifo_contents
+      new_realign_contents
+      (input : denote_type (input_of (realign_fifo fifo_size)))
+      (state : denote_type (state_of (realign_fifo fifo_size))):
+
+    new_fifo_contents = realign_fifo_update_fifo_contents fifo_contents input state ->
+    new_realign_contents = realign_fifo_update_realign_contents realign_contents input state ->
+
+    realign_fifo_pre input state ->
+    realign_fifo_invariant fifo_contents realign_contents state ->
+    realign_fifo_invariant new_fifo_contents new_realign_contents (fst (step (realign_fifo fifo_size) state input)).
+  Proof.
+    cbv [realign_fifo_invariant realign_fifo].
+    destruct state as (top_state, (realign_state, fifo_state)).
+    destruct realign_state as (x0,(x1,(x2,(x3,x4)))).
+    destruct top_state as (is_last, (out_valid, (out_data, (out_length, (fifo_empty, fifo_full))))).
+
+    intros Hnew_fifo_contents Hnew_realign_contents Hpre H.
+    logical_simplify.
+    stepsimpl.
+    repeat (destruct_pair_let ; cbn [fst snd]).
+    cbn [denote_type absorb_any] in *.
+    ssplit.
+    {
+      apply step_fifo_invariant with (contents:=fifo_contents).
+      { apply Hfifo_nz. }
+      { now apply Hnew_fifo_contents. }
+      { cbv [fifo_pre].
+        destruct fifo_state as (?,(?,(?,count))).
+        destruct fifo_full.
+        { now boolsimpl. }
+        { boolsimpl.
+          cbv [fifo_invariant] in H.
+          logical_simplify.
+          rewrite H4.
+          match goal with
+          | |- if ?B then _ else _ => destruct B
+          end.
+          { apply H1. }
+          trivial.
+          }
+      }
+      apply H.
+    }
+    { eapply step_realign_invariant.
+      { now rewrite Hnew_realign_contents. }
+      { now rewrite Hnew_realign_contents. }
+      { now rewrite Hnew_realign_contents. }
+      { cbv [realign_fifo_pre] in Hpre. cbn in input, fifo_state.
+        destruct_products.
+        now cbn.
+      }
+      { apply H0. }
+    }
+    all:
+      cbn [fst snd];
+      erewrite (step_fifo (BitVec 32) fifo_size) with (new_contents := new_fifo_contents);
+      [ | trivial | now rewrite Hnew_fifo_contents |
+        cbn in input; destruct_products; cbn [fifo_pre fst snd];
+        destruct fifo_full; boolsimpl; try trivial;
+          boolsimpl;
+          cbv [fifo_invariant] in H;
+          logical_simplify;
+          rewrite H4;
+          match goal with
+          | |- if ?B then _ else _ => destruct B
+          end; try trivial
+      |  apply H ].
+    {
+      cbv [fifo_spec]; cbn [fst snd].
+      cbn [denote_type absorb_any] in *.
+      destr (length new_fifo_contents =? fifo_size).
+      { now rewrite E. }
+      { eapply step_fifo_invariant with (new_contents:=new_fifo_contents) in H.
+        { cbv [fifo_invariant] in H.
+          destruct (fst (step (fifo fifo_size) _ _)) as (?, (?, (?, ?))).
+          logical_simplify.
+          cbn [denote_type absorb_any] in *.
+          rewrite <- H4 in E.
+          rewrite <- H4.
+          lia.
+        }
+        { lia. }
+        { rewrite Hnew_fifo_contents. reflexivity. }
+        { cbn [fifo_pre fst snd].
+          destruct_products.
+          cbn in H.
+          destruct fifo_full.
+          { now boolsimpl. }
+          { boolsimpl.
+            cbv [fifo_invariant] in H.
+            logical_simplify.
+            rewrite H4.
+            match goal with
+            | |- if ?B then _ else _ => destruct B
+            end.
+            { apply H1. }
+            trivial.
+          }
+        }
+      }
+    }
+    {
+      cbv [fifo_spec]; cbn [fst snd].
+      cbn [denote_type absorb_any] in *.
+      destr (length new_fifo_contents =? 0).
+      { now rewrite E. }
+      { eapply step_fifo_invariant with (new_contents:=new_fifo_contents) in H.
+        { cbv [fifo_invariant] in H.
+          destruct (fst (step (fifo fifo_size) _ _)) as (?, (?, (?, ?))).
+          logical_simplify.
+          cbn [denote_type absorb_any] in *.
+          rewrite <- H4 in E.
+          rewrite <- H4.
+          lia.
+        }
+        { lia. }
+        { rewrite Hnew_fifo_contents. reflexivity. }
+        { cbn [fifo_pre fst snd].
+          destruct_products.
+          cbn in H.
+          destruct fifo_full.
+          { now boolsimpl. }
+          { boolsimpl.
+            cbv [fifo_invariant] in H.
+            logical_simplify.
+            rewrite H4.
+            match goal with
+            | |- if ?B then _ else _ => destruct B
+            end.
+            { apply H1. }
+            trivial.
+          }
+        }
+      }
+    }
+  Qed.
+
+  Lemma step_realign_fifo
+      fifo_contents
+      realign_contents
+      (input : denote_type (input_of (realign_fifo fifo_size)))
+      (state : denote_type (state_of (realign_fifo fifo_size))):
+
+    realign_fifo_pre input state ->
+    realign_fifo_invariant fifo_contents realign_contents state ->
+    snd (step (realign_fifo fifo_size) state input) = realign_fifo_spec fifo_contents realign_contents input.
+  Proof.
+    intros.
+    destruct state as (top_state, (realign_state, fifo_state)) eqn:?.
+    (* destruct realign_state as (x0,(x1,(x2,(x3,x4)))). *)
+    destruct top_state as (is_last, (out_valid, (out_data, (out_length, (fifo_empty, fifo_full))))).
+    cbn in input, state.
+    cbv [realign_fifo realign_fifo_pre realign_fifo_invariant K] in *.
+    intros. logical_simplify. cbn [fst snd] in *.
+    stepsimpl.
+    repeat (destruct_pair_let; cbn [fst snd]).
+
+    match goal with
+    | |- context [snd (step (fifo (T:=BitVec 32) fifo_size) ?X ?Y) ] =>
+      remember (snd (step (fifo (T:=BitVec 32) fifo_size) X Y)) as stepped_fifo
+    end.
+    match goal with
+    | |- context [ snd (step realign ?X ?Y) ] =>
+      remember (snd (step realign X Y)) as stepped_realigner
+    end.
+
+    assert (length fifo_contents =? fifo_size = fifo_full).
+    { destruct fifo_full.
+      { rewrite H2. apply Nat.eqb_refl. }
+      { apply Nat.eqb_neq. lia. }
+    }
+    assert (length fifo_contents =? 0 = fifo_empty).
+    { destruct fifo_empty.
+      { rewrite H3. apply Nat.eqb_refl. }
+      { apply Nat.eqb_neq. lia. }
+    }
+
+    cbn [denote_type absorb_any] in *.
+    rewrite <- Heqstepped_realigner in *.
+    rewrite <- Heqstepped_fifo.
+
+    rewrite step_fifo with
+      (T:=BitVec 32) (fifo_size:=fifo_size)
+      (contents:=fifo_contents)
+      (new_contents:=realign_fifo_update_fifo_contents fifo_contents input state)
+      in Heqstepped_fifo; cycle 1.
+    { trivial. }
+    { subst; reflexivity. }
+    { clear Heqstepped_fifo Heqstepped_realigner.
+      (* clear stepped_fifo stepped_realigner. *)
+      cbv [fifo_pre].
+      destruct_products.
+      destruct fifo_full; boolsimpl.
+      { trivial. }
+      {
+        match goal with
+        | |- if ?B then _ else _ => destruct B
+        end; try trivial.
+        cbn in H0.
+        logical_simplify.
+        now rewrite H6.
+      }
+    }
+    { trivial. }
+    cbv [realign_fifo_update_fifo_contents] in *.
+
+    rewrite step_realign with
+      (latched_valid:=fst (fst realign_contents))
+      (latched_bytes:=snd (fst realign_contents))
+      (state_data:=snd realign_contents)
+      in Heqstepped_realigner, Heqstepped_fifo; cycle 1.
+    { cbn [realign_pre]; destruct_products; cbn; trivial. }
+    { subst; cbn [fst snd ]. trivial. }
+    { cbn [realign_pre]; destruct_products; cbn; trivial. }
+    { subst; cbn [fst snd ]. trivial. }
+
+    cbv [realign_fifo_spec].
+    destruct input as (data_valid, (data, (data_mask, (drain, (consumer_ready, u))))).
+    repeat (destruct_pair_let; cbn [fst snd]).
+    destruct u.
+    cbn [denote_type absorb_any] in *.
+    cbv [realign_fifo_update_fifo_contents] in *.
+    cbn [fst snd] in *.
+    rewrite Heqd in Heqstepped_fifo; cbn [fst snd] in Heqstepped_fifo.
+    rewrite H4 in *.
+    rewrite H5 in *.
+    rewrite <- Heqstepped_realigner in *.
+    rewrite <- Heqstepped_fifo.
+    clear Heqstepped_realigner Heqstepped_fifo.
+    reflexivity.
+  Qed.
+End RealignFifo.

--- a/cava2/Components/RealignerProperties.v
+++ b/cava2/Components/RealignerProperties.v
@@ -33,373 +33,13 @@ Require Import Cava.Expr.
 Require Import Cava.ExprProperties.
 Require Import Cava.Primitives.
 Require Import Cava.Semantics.
-Require Import Cava.Fifo.
+Require Import Cava.Components.Realigner.
 
 Import ListNotations.
 
 Local Open Scope bool.
 Local Open Scope nat.
 Local Open Scope list.
-
-Lemma nz_s_1_a_1: forall x:nat, (x <> 0 -> x - 1 + 1 = x)%nat.
-Proof. lia. Qed.
-
-Lemma lt_nat_log2_simpl: forall x y,
-  (y < 2 ^ (Nat.log2_up x ))%nat ->
-  (N.of_nat y < 2 ^ N.of_nat (Nat.log2_up x))%N.
-Proof.
-  intros.
-  change 2%N with (N.of_nat (S (S 0))).
-  rewrite Nat2N.inj_pow.
-  lia.
-Qed.
-
-Lemma inj_le: forall x, (1 <=? x)%N = negb (N.to_nat x =? 0)%nat.
-Proof.
-  intros.
-  rewrite <- (N2Nat.id x).
-  rewrite (Nat2N.id (N.to_nat x)).
-  destruct (N.to_nat x); cbn.
-  { reflexivity. }
-  rewrite N.leb_le.
-  lia.
-Qed.
-
-Lemma eqb_inj: forall x y, ( N.of_nat x =? N.of_nat y )%N = ( x =? y ).
-Proof. intros.
-  destruct (Nat.eqb_spec x y ).
-  { rewrite e. rewrite N.eqb_refl. reflexivity. }
-  { rewrite N.eqb_neq. lia. }
-Qed.
-
-Section FifoSpec.
-  Context (T: type).
-  Context (fifo_size: nat).
-  Context (Hfifo_nz: (1 < fifo_size)%nat).
-
-  Definition fifo_bits_size := Nat.log2_up (fifo_size + 1).
-
-  Definition fifo_pre
-    (contents: list (denote_type T))
-    (input : denote_type (input_of (fifo (T:=T) fifo_size)))
-    (state: denote_type (state_of (fifo (T:=T) fifo_size)))
-    :=
-    let '(valid, (data, (accepted_output,_))) := input in
-    let '(_, (_, (fifo, count))) := state in
-    (* if count is fifo_size we are full and we shouldn't be receiving  *)
-    (if valid then N.to_nat count < fifo_size else True).
-
-  Definition fifo_invariant
-    (contents: list (denote_type T))
-    (state: denote_type (state_of (fifo (T:=T) fifo_size)))
-    :=
-    let '(_, (_, (fifo, count))) := state in
-    fifo_size = length fifo
-    /\ N.to_nat count <= fifo_size
-    /\ N.to_nat count = length contents
-    /\ contents = rev (firstn (length contents) fifo)
-  .
-
-  Definition fifo_contents_update (empty full: bool) contents
-      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
-      :=
-    let '(valid, (data, (accepted_output,_))) := input in
-    let contents' := if accepted_output && negb empty then tl contents else contents in
-    contents' ++ if valid && negb full then [data] else [].
-
-  Ltac N2nat_lt_2lg_solve x :=
-    apply lt_nat_log2_simpl;
-    apply (Nat.lt_le_trans _ (length x + 1)); [lia|];
-    apply Nat.log2_up_spec; lia.
-
-  (* Reduces the mod equations that arise here that aren't solved by e.g.
-     Z.to_euclidean_division_equations, likely due to the non-constants modulus *)
-  Local Ltac reduce_mod_eqs fifo contents :=
-      match goal with
-      | |- context [ N.modulo ?X ?Y ] =>
-        let H := fresh in
-        assert (X mod Y = X)%N as H;
-        [ apply N.mod_small;
-          N2nat_lt_2lg_solve fifo
-        |]; rewrite H; clear H
-      | |- context [ N.modulo ( ?X + ?Y - 1 ) ?Y ] =>
-        let H := fresh in
-        assert (( X + Y - 1 ) mod Y = X - 1)%N as H;
-        let H1 := fresh in
-        assert (forall x, 0 < x -> x <> 0)%N as H1 by lia;
-        let H2 := fresh in
-        assert (2 ^ N.of_nat (Nat.log2_up (Datatypes.length fifo + 1)) <> 0)%N as H2 by
-          (
-            apply H1;
-            change 0%N with (N.of_nat 0)%nat;
-            N2nat_lt_2lg_solve fifo
-          );
-
-        rewrite N.add_sub_swap by lia;
-        rewrite <- N.add_mod_idemp_r by apply H2;
-
-        rewrite N.mod_same by apply H2;
-        rewrite N.add_0_r;
-
-        rewrite N.mod_small;
-
-        replace (N.of_nat (length contents) - 1)%N with (N.of_nat (length contents - 1))%N
-          by apply Nat2N.inj_sub;
-
-        [| N2nat_lt_2lg_solve fifo]
-
-      | |- context [ N.modulo ( ?X + 1 ) ?Y ] =>
-        let H := fresh in
-        assert ( (X + 1)  mod Y = (X + 1) )%N as H;
-        [ replace (N.of_nat( length contents ) + 1)%N with (N.of_nat (length contents  + 1)) by lia;
-          apply N.mod_small;
-          N2nat_lt_2lg_solve fifo
-        |] ; rewrite H; clear H
-      end.
-
-  Lemma step_fifo_invariant
-      contents new_contents
-      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
-      (state : denote_type (state_of (fifo (T:=T) fifo_size))) :
-    new_contents = fifo_contents_update (length contents =? 0) (length contents =? fifo_size) contents input ->
-    fifo_pre contents input state ->
-    fifo_invariant contents state ->
-    fifo_invariant new_contents (fst (step (fifo fifo_size) state input)).
-  Proof.
-    destruct input as (input_valid, (input_data, (accepted_output, []))).
-    destruct state as (s_valid, (s_data, (fifo, count))).
-    intros Hcontents Hpre Hinv.
-    destruct Hinv as [Hfifo_len [Hcount_bound [Hcontents_len Hcontents_rev_fifo ]]].
-    cbv [fifo_pre fifo_invariant fifo_contents_update] in *.
-    cbn in fifo.
-
-    split.
-    { destruct input_valid; stepsimpl; try rewrite length_removelast_cons; apply Hfifo_len. }
-
-    (* *)
-    assert (fifo <> []) as Hfifon_empty by
-      (apply length_pos_nonnil; setoid_rewrite <- Hfifo_len; lia).
-
-    stepsimpl.
-
-    fold denote_type in *. (* denote_type is previously unfolded in some implicits *)
-
-    rewrite inj_le.
-    rewrite Hcontents_len.
-    rewrite <- Nat2N.id in Hcontents_len.
-    apply N2Nat.inj in Hcontents_len.
-    subst.
-
-    destruct (Nat.eqb_spec (@Datatypes.length (denote_type T) contents) 0)
-      as [Hcontents_len_z | Hcontents_len_nz];
-      destruct input_valid, accepted_output;
-      stepsimpl;
-      boolsimpl.
-
-    (* Clean up terms *)
-    all:
-      try rewrite app_nil_r;
-      try rewrite Hcontents_len_z;
-      try change (N.of_nat 0 + 1)%N with (N.of_nat 1)%N;
-      try replace (N.of_nat (length contents) + 1)%N with (N.of_nat (length contents + 1))%N by
-        apply Nat2N.inj_add;
-      try rewrite Nat2N.id.
-
-    (* Simplify mod equations *)
-    all: try reduce_mod_eqs fifo contents.
-
-    all:
-      try apply length_zero_iff_nil in Hcontents_len_z;
-      try rewrite Nat2N.id in *;
-      repeat ssplit.
-    all: try (tauto || lia).
-
-    all: subst; try rewrite app_nil_l.
-
-    all: try (destruct fifo; tauto).
-
-    5: {
-      rewrite tl_length.
-      lia.
-    }
-    5: {
-      rewrite Hcontents_rev_fifo at 1.
-      rewrite tl_rev.
-      replace (length contents) with (S (length contents - 1)) by lia.
-      rewrite removelast_firstn by lia.
-      rewrite tl_length.
-      reflexivity.
-    }
-
-    all:
-      assert (Datatypes.length (contents) <> Datatypes.length fifo) by lia;
-      destruct (Nat.eqb_spec (Datatypes.length (contents)) (Datatypes.length fifo)); try tauto;
-      try rewrite app_length;
-      try rewrite tl_length;
-      try now (cbn; lia).
-
-    all:
-      rewrite Hcontents_rev_fifo at 1;
-      try rewrite tl_rev;
-      try (
-        replace (length contents) with (S (length contents - 1)) by lia;
-        rewrite removelast_firstn by lia);
-      boolsimpl.
-
-    {
-      rewrite removelast_cons1 by tauto.
-      cbn [length].
-      rewrite nz_s_1_a_1 by lia.
-      rewrite firstn_cons.
-      cbn.
-      rewrite firstn_removelast by lia.
-      reflexivity.
-    }
-
-    {
-      rewrite removelast_cons1 by tauto.
-      cbn [length].
-      rewrite Nat.add_1_r.
-      rewrite firstn_cons.
-      cbn.
-      rewrite firstn_removelast by lia.
-      reflexivity.
-    }
-  Qed.
-
-  Definition fifo_spec
-      (contents: list (denote_type T))
-      (new_contents: list (denote_type T))
-      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
-      (state : denote_type (state_of (fifo (T:=T) fifo_size)))
-      : denote_type (Bit ** T ** Bit ** Bit) :=
-    (negb (0 =? length contents)
-    , (if 0 =? length contents then default else hd default contents
-    , (length new_contents =? 0
-    , length new_contents =? fifo_size)))%nat.
-
-  Lemma step_fifo
-      contents new_contents
-      (input : denote_type (input_of (fifo (T:=T) fifo_size)))
-      (state : denote_type (state_of (fifo (T:=T) fifo_size))) :
-    new_contents = fifo_contents_update (length contents =? 0) (length contents =? fifo_size) contents input ->
-    fifo_pre contents input state ->
-    fifo_invariant contents state ->
-    snd (step (fifo fifo_size) state input) = fifo_spec contents new_contents input state.
-  Proof.
-    destruct input as (input_valid, (input_data, (accepted_output, []))).
-    destruct state as (s_valid, (s_data, (fifo, count))).
-    intros Hcontents Hpre Hinv.
-    destruct Hinv as [Hfifo_len [Hcount_bound [Hcontents_len Hcontents_rev_fifo]]].
-    cbv [Fifo.fifo fifo_spec fifo_pre fifo_invariant fifo_contents_update K] in *.
-    cbn in fifo.
-
-    (* *)
-    assert (fifo <> []) as Hfifon_empty by
-      (apply length_pos_nonnil; setoid_rewrite <- Hfifo_len; lia).
-
-    stepsimpl.
-    repeat (destruct_pair_let; cbn [fst snd]).
-
-    fold denote_type in *. (* denote_type is previously unfolded in some implicits *)
-
-    logical_simplify.
-
-    fold denote_type in *.
-
-    rewrite inj_le.
-    rewrite Hcontents_len.
-    rewrite <- Nat2N.id in Hcontents_len.
-    apply N2Nat.inj in Hcontents_len.
-    rewrite (Nat.eqb_sym 0 (length contents)).
-    subst.
-
-    f_equal.
-    f_equal.
-
-    {
-      destruct (Nat.eqb_spec (@Datatypes.length (denote_type T) contents) 0)
-        as [Hcontents_len_z | Hcontents_len_nz];
-        stepsimpl;
-        boolsimpl.
-        { reflexivity. }
-        { try reduce_mod_eqs fifo contents.
-          { reflexivity. }
-          rewrite Nat2N.id.
-          rewrite resize_noop by reflexivity.
-          rewrite Hcontents_rev_fifo.
-          rewrite rev_length.
-          rewrite firstn_length.
-          rewrite hd_rev.
-          replace (Init.Nat.min (length contents) (length fifo))
-            with (length contents) by (rewrite Nat.min_l; lia).
-          rewrite <- (firstn_skipn (length contents) fifo) at 1.
-          rewrite app_nth1 .
-          2:{ cbn.
-            rewrite firstn_length.
-            replace (Init.Nat.min (length contents) (length fifo))
-            with (length contents).
-            2:{ rewrite Nat.min_l. {lia. }
-              rewrite Nat2N.id in Hcount_bound.
-              lia.
-            }
-            lia.
-          }
-        rewrite nth_last.
-        { reflexivity. }
-        rewrite firstn_length.
-        replace (Init.Nat.min (length contents) (length fifo))
-          with (length contents) by (rewrite Nat.min_l; lia).
-        reflexivity.
-        }
-    }
-
-    destruct (Nat.eqb_spec (@Datatypes.length (denote_type T) contents) 0)
-      as [Hcontents_len_z | Hcontents_len_nz];
-    destruct input_valid, accepted_output;
-      stepsimpl;
-      boolsimpl;
-      fold denote_type in *;
-      try reduce_mod_eqs fifo contents;
-      try rewrite app_nil_r;
-      try reflexivity;
-      try rewrite app_length; cbn.
-
-    all: destr (length contents =? length fifo); try lia; cbn.
-    all: repeat match goal with
-         | |- context [ ?X ] =>
-            lazymatch X with
-            | ( N.of_nat ?Y =? N.of_nat ?Z )%N => fail
-            | ( N.of_nat ?Y + ?Z =? _ )%N =>
-              replace ( N.of_nat Y + Z )%N
-              with ( N.of_nat (Y + (N.to_nat Z) ) )%N by now (rewrite Nat2N.inj_add; rewrite N2Nat.id)
-            | ( N.of_nat ?Y =? ?Z )%N =>
-              replace ( N.of_nat Y =? Z )%N
-                with ( N.of_nat Y =? N.of_nat (N.to_nat Z) )%N by now rewrite N2Nat.id
-            end
-         end.
-    all: repeat rewrite eqb_inj.
-    all: repeat match goal with
-         | |- context [ ?X ] =>
-            match X with
-            | _ =? _  => destr X; try lia
-            end
-         end.
-    all: try reflexivity.
-    all: repeat match goal with
-                | H: length (tl ?X) + 1 = _ |- _ =>
-                  rewrite tl_length in H; try rewrite nz_s_1_a_1 in H by lia
-                | H: length (tl ?X) + 1 <> _ |- _ =>
-                  rewrite tl_length in H; try rewrite nz_s_1_a_1 in H by lia
-                | H: length (tl ?X) = _ |- _ =>
-                  rewrite tl_length in H
-                | H: length (tl ?X) <> _ |- _ =>
-                  rewrite tl_length in H
-                end.
-    all: lia.
-  Qed.
-
-End FifoSpec.
 
 Section RealignerSpec.
   Local Open Scope N.
@@ -622,23 +262,23 @@ Section RealignerSpec.
     BigEndianBytes.N_to_bytes 4 (BigEndianBytes.concat_bytes (List.resize Byte.x00 4 xs)) = xs.
   Admitted.
 
-  Lemma concat_bytes_4_bound xs: 
+  Lemma concat_bytes_4_bound xs:
     BigEndianBytes.concat_bytes (List.resize Byte.x00 4 xs) < 2 ^ 32.
   Admitted.
 
-  Lemma concat_bytes_8_bound xs: 
+  Lemma concat_bytes_8_bound xs:
     BigEndianBytes.concat_bytes (List.resize Byte.x00 8 xs) < 2 ^ 64.
   Admitted.
 
   Lemma concat_bytes_skip_4_of_8_spec xs n:
-      (length xs < 8)%nat -> 
+      (length xs < 8)%nat ->
       n < 32 ->
         N.testbit
           (BigEndianBytes.concat_bytes (List.resize Byte.x00 8 (skipn 4 xs))) n = false.
   Admitted.
 
   Lemma concat_bytes_lower_8_zero xs n:
-      (length xs < 4)%nat -> 
+      (length xs < 4)%nat ->
       n < 32 ->
         N.testbit
           (BigEndianBytes.concat_bytes (List.resize Byte.x00 8 xs)) n = false.
@@ -654,7 +294,7 @@ Section RealignerSpec.
   Admitted.
 
   Lemma concat_bytes_8_is_64bit xs n:
-        64 <= n -> 
+        64 <= n ->
         N.testbit
           (BigEndianBytes.concat_bytes (List.resize Byte.x00 8 xs))
           n = false.
@@ -663,7 +303,7 @@ Section RealignerSpec.
   Lemma concat_bytes_truncation x:
     (N.shiftr
       (BigEndianBytes.concat_bytes (List.resize Byte.x00 8 x))
-      (N.of_nat 32) mod 2 ^ N.of_nat 32)%N 
+      (N.of_nat 32) mod 2 ^ N.of_nat 32)%N
       = BigEndianBytes.concat_bytes (List.resize Byte.x00 4 x).
   Admitted.
 
@@ -876,13 +516,10 @@ Section RealignerSpec.
     let '(out_valid, (out_data, (out_len, (buff, buff_len)))) := state in
 
     buff_len = N.of_nat (length ghost_state)
-    (* buff_len = N.of_nat (length (firstn 4 ghost_state)) *)
     /\ out_valid = latched_valid
     /\ out_data = BigEndianBytes.concat_bytes (List.resize Byte.x00 4 latched_bytes)
     /\ N.to_nat out_len = length latched_bytes
-    (* /\ True *)
     /\ buff = BigEndianBytes.concat_bytes (List.resize Byte.x00 8 ghost_state)
-    (* /\ N.shiftr buff (N.of_nat 32) = BigEndianBytes.concat_bytes (firstn 4 ghost_state) *)
     /\ (buff < 2 ^ 64)%N
     /\ (buff_len < 8)%N
     .
@@ -904,7 +541,6 @@ Section RealignerSpec.
     destruct state as (out_valid, (out_data, (out_length, (q, q_len)))).
     intros Hst Hlatch Hlatchvalid Hpre Hinv.
     destruct Hinv as [Hbuff_len [Hlatch_valid [Hlatch_bytes [Hlatch_bytes_len [Hfirst_bytes [Hbuf_bound Hbuf_len_bound]]]]]].
-(* bvresize bvconcat bvmin bvslice *)
     cbv [realign realign_spec realign_pre realign_invariant realign_update_state realign_update_latched_bytes realign_update_latched_valid K] in *;
     stepsimpl.
 
@@ -935,7 +571,6 @@ Section RealignerSpec.
           { apply (N.lt_le_trans _ (8 - 4)%N); lia. }
           lia.
         }
-        Search (_ <=? _ = false)%N.
         apply N.leb_gt in Heqb.
         destruct flush; try lia.
       }
@@ -1206,7 +841,6 @@ Section RealignerSpec.
       2:{ cbn; lia. }
       apply N.mul_lt_mono_pos_r.
       { lia. }
-      Search (N.land).
       rewrite N.land_ones.
       apply N.mod_upper_bound.
       lia.
@@ -1356,4 +990,3 @@ Section RealignerSpec.
   Qed.
 
 End RealignerSpec.
-

--- a/silveroak-opentitan/hmac/hw/Hmac.v
+++ b/silveroak-opentitan/hmac/hw/Hmac.v
@@ -21,7 +21,7 @@ Require Import Cava.Types.
 Require Import Cava.Expr.
 Require Import Cava.Primitives.
 Require Import Cava.TLUL.
-Require Import Cava.Fifo.
+Require Import Cava.Components.RealignFifo.
 
 Require Import HmacHardware.Sha256.
 Import ExprNotations.

--- a/silveroak-opentitan/hmac/hw/Sha256.v
+++ b/silveroak-opentitan/hmac/hw/Sha256.v
@@ -23,8 +23,6 @@ Require Import Cava.Types.
 Require Import Cava.Expr.
 Require Import Cava.Primitives.
 
-Require Import Cava.Fifo.
-
 Import ListNotations.
 Import PrimitiveNotations.
 


### PR DESCRIPTION
This splits `fifo` `realign` and `realign_fifo` into separate files for easier manipulation (as some of the proof terms are slow), and also adds a spec and proof for `realign_fifo` in terms of the `fifo` and `realign` specs. 