### PR TITLE
Partial version of sha256 proof

### DIFF
--- a/silveroak-opentitan/hmac/Spec/SHA256Properties.v
+++ b/silveroak-opentitan/hmac/Spec/SHA256Properties.v
@@ -356,6 +356,18 @@ Proof.
   rewrite sha256_W_alt_truncate by lia. reflexivity.
 Qed.
 
+(* alternate phrasing of sha256_step_alt_truncate *)
+Lemma sha256_step_alt_firstn msg i H n :
+  (S i * 16 <= n)%nat ->
+  SHA256Alt.sha256_step (firstn n msg) H i
+  = SHA256Alt.sha256_step msg H i.
+Proof.
+  intros. destr (length msg <? n)%nat; [ push_firstn; reflexivity | ].
+  erewrite <-(sha256_step_alt_truncate (firstn n msg) (skipn n msg))
+    by length_hammer.
+  rewrite firstn_skipn; reflexivity.
+Qed.
+
 Lemma slice0_W_alt msg block i :
   (i * 16 = length msg)%nat -> length block = 16%nat ->
   List.slice 0%N (SHA256Alt.W (msg ++ block) i) 0 16 = block.

--- a/silveroak-opentitan/hmac/hw/Sha256.v
+++ b/silveroak-opentitan/hmac/hw/Sha256.v
@@ -68,7 +68,7 @@ Section Var.
       else
 
       let next_state :=
-        if is_final && state == `padder_waiting` then
+        if data_valid && is_final && state == `padder_waiting` then
           (* From our receiving state we can transition to: *)
           (* - Emitting 0x80.. state if final word was a full word *)
           if final_length == `K 4` then `padder_emit_bit`
@@ -98,7 +98,7 @@ Section Var.
         in
 
       let next_length :=
-        if state == `padder_waiting` && is_final then length + `bvresize 61` final_length
+        if state == `padder_waiting` && is_final && data_valid then length + `bvresize 61` final_length
         else if state == `padder_waiting` && data_valid then length + `K 4`
         (* We are done here so set the next length to 0 *)
         else if state == `padder_writing_length` && current_offset == `K 15`
@@ -109,7 +109,7 @@ Section Var.
       let next_out :=
         (* If we have final word and its not a full word, we can emit 0x80 byte
          * immediately *)
-        if state == `padder_waiting` && is_final then
+        if state == `padder_waiting` && is_final && data_valid then
           if final_length == `K 0`
           then `Constant (BitVec 32) 0x80000000`
           else if final_length == `K 1`
@@ -132,7 +132,7 @@ Section Var.
       in
 
       let out_valid :=
-        !(state == `padder_waiting` && (!data_valid) && (!is_final) ) in
+        !(state == `padder_waiting` && (!data_valid) ) in
 
       let next_offset :=
         if !out_valid then current_offset

--- a/silveroak-opentitan/hmac/hw/Sha256Properties.v
+++ b/silveroak-opentitan/hmac/hw/Sha256Properties.v
@@ -1671,14 +1671,8 @@ Proof.
   intros (((((msg, msg_complete), padder_byte_index), inner_byte_index), t), cleared).
   intros; logical_simplify; subst.
 
-  (* This might be a faster way to simplify, but breaks some parts of the proof *)
-  (*
   rewrite step_sha256_simplified_eq. cbv [step_sha256_simplified]. cbn [fst snd].
   rewrite <-!tup_if. cbn [fst snd].
-   *)
-  cbv [sha256]; stepsimpl.
-  repeat (destruct_inner_pair_let; cbn [fst snd]).
-  autorewrite with tuple_if; cbn [fst snd].
 
   (* A whole bunch of assertions about the properties of padded_message_size
      related to all 3 possible next messages *)

--- a/silveroak-opentitan/hmac/hw/Sha256Properties.v
+++ b/silveroak-opentitan/hmac/hw/Sha256Properties.v
@@ -1214,7 +1214,9 @@ Instance sha256_invariant
     (* the padder resets to an empty message after producing the last word *)
     let padder_repr :=
         if padder_done
-        then ([], false, true, 0)
+        then if t =? 64
+             then ([], false, true, 0)
+             else (msg, msg_complete, padder_done, byte_index)
         else (msg, msg_complete, padder_done, byte_index) in
     (* the byte index according to sha256_padder is the same as for sha256,
        except that it resets to [] after producing the last word *)
@@ -1457,9 +1459,8 @@ Proof.
                    | lazymatch goal with
                      | |- context [Nat.eqb ?x ?y] => destr (Nat.eqb x y)
                      end ].
-      { (* here we have n mod 64 = count * 4, count <= 15, and n + 4 = padded_message_size *)
-        (* i.e. last word produced by padder *)
-        (* padder thinks it does not reset here, sha256 spec thinks it does *)
+      { (* t = 64, index =message size *)
+        (* padder stays in same state till inner done -- padder is not resetting because consumer_ready is false! *)
     }
 
     apply invariant_preser


### PR DESCRIPTION
This is my work on the sha256 proof so far, to be updated a little more before I unmark as draft.

What's done right now:
- Invariant and specification are written
- Invariant-holds-at-reset is proved
- Certain subclauses of the invariant preservation proof (I tried to do the hardest bits first):
  - proofs that the subcircuits' preconditions are satisfied (this required some tweaks to subcircuit specifications and proofs)
  - proofs that the subcircuits' invariants are always satisfied (this also required some tweaks to subcircuit specifications and proofs)
  - All invariant clauses for the case where `count=0`; there are three other cases (`0 < count <= 15`, `count=16`, and `count=17`) but most of the clauses are similar, so the `count=0` case should hopefully provide a helpful example for each clause

Still to be done:
- Remaining clauses of invariant for the other cases of `count`
- Proof that invariant implies postcondition