### PR TITLE
Add HMAC registers to circuit needed by software:

### DIFF
--- a/cava2/Expr.v
+++ b/cava2/Expr.v
@@ -351,7 +351,7 @@ Definition bvmax {var n}: Circuit (var:=var) [] [BitVec n; BitVec n] (BitVec n) 
 Definition bvmin {var n}: Circuit (var:=var) [] [BitVec n; BitVec n] (BitVec n) :=
   {{ fun x y => `BinaryOp BinBitVecMin x y` }}.
 
-Definition endian_swap32 : Circuit [] [BitVec 32] (BitVec 32) := {{
+Definition endian_swap32 {var} : Circuit (var:=var) [] [BitVec 32] (BitVec 32) := {{
   fun x =>
   let a := `bvslice 0 8` x in
   let b := `bvslice 8 8` x in
@@ -361,5 +361,4 @@ Definition endian_swap32 : Circuit [] [BitVec 32] (BitVec 32) := {{
   `bvconcat` (`bvconcat` (`bvconcat` a b) c) d
 
 }}.
-
 

--- a/cava2/Expr.v
+++ b/cava2/Expr.v
@@ -350,3 +350,16 @@ Definition bvmax {var n}: Circuit (var:=var) [] [BitVec n; BitVec n] (BitVec n) 
   {{ fun x y => `BinaryOp BinBitVecMax x y` }}.
 Definition bvmin {var n}: Circuit (var:=var) [] [BitVec n; BitVec n] (BitVec n) :=
   {{ fun x y => `BinaryOp BinBitVecMin x y` }}.
+
+Definition endian_swap32 : Circuit [] [BitVec 32] (BitVec 32) := {{
+  fun x =>
+  let a := `bvslice 0 8` x in
+  let b := `bvslice 8 8` x in
+  let c := `bvslice 16 8` x in
+  let d := `bvslice 24 8` x in
+
+  `bvconcat` (`bvconcat` (`bvconcat` a b) c) d
+
+}}.
+
+

--- a/cava2/ExprProperties.v
+++ b/cava2/ExprProperties.v
@@ -143,3 +143,28 @@ Proof.
   push_list_fold. reflexivity.
 Qed.
 Hint Rewrite @step_foldl2 using solve [eauto] : stepsimpl.
+
+Lemma step_endian_swap32 (x : denote_type (BitVec 32)) :
+  step endian_swap32 tt (x, tt)
+  = (tt, N.lor
+          (N.land (N.shiftr x 24) (N.ones 8))
+        (N.lor
+          (N.land (N.shiftl x 8) (N.shiftl (N.ones 8) 16))
+        (N.lor
+          (N.land (N.shiftr x 8) (N.shiftl (N.ones 8) 8))
+          (N.land (N.shiftl x 24) (N.shiftl (N.ones 8) 24))))).
+Proof.
+  cbv [endian_swap32]. stepsimpl. f_equal.
+  apply N.bits_inj; intro i. push_Ntestbit.
+  cbn [Nat.add].
+
+  destr (i <? N.of_nat 8)%N;
+  [|destr (i <? N.of_nat 16)%N;
+  [|destr (i <? N.of_nat 24)%N;
+  [|destr (i <? N.of_nat 32)%N]
+  ]]; push_Ntestbit; boolsimpl.
+
+  all: try reflexivity; f_equal; prove_by_zify.
+Qed.
+
+Hint Rewrite @step_endian_swap32 using solve [eauto] : stepsimpl.

--- a/silveroak-opentitan/hmac/hw/Hmac.v
+++ b/silveroak-opentitan/hmac/hw/Hmac.v
@@ -356,7 +356,7 @@ Section SanityCheck.
     : denote_type (Vec (BitVec 32) hmac_register_count) .
     cbv [state_of hmac absorb_any] in v.
     destruct v.
-    destruct d as (_, regs).
+    destruct d as (_, (_, regs)).
     exact regs.
   Defined.
 


### PR DESCRIPTION
- Sets the STATUS bit 1 to the value of `fifo_full`
- Uses CFG bit 2 (`endian_swap`) to switch input endianness